### PR TITLE
feat(fic): filtro Abierto/Cerrado usando tipo_fondo (#162)

### DIFF
--- a/src/components/marketDashboard/MarketDashboard.tsx
+++ b/src/components/marketDashboard/MarketDashboard.tsx
@@ -85,6 +85,7 @@ export default function MarketDashboard({ config }: MarketDashboardProps) {
   const searchText = useAppStore((s) => s.searchText);
   const entidadFilter = useAppStore((s) => s.entidadFilter);
   const activoFilter = useAppStore((s) => s.activoFilter);
+  const tipoFondoFilter = useAppStore((s) => s.tipoFondoFilter);
   const [panelsVisible, setPanelsVisible] = useState(true);
 
   const tourSteps: Step[] = useMemo(
@@ -131,6 +132,15 @@ export default function MarketDashboard({ config }: MarketDashboardProps) {
     return Array.from(set).sort();
   }, [watchlistEntries]);
 
+  // Unique tipos de fondo for the filter dropdown (FIC only)
+  const uniqueTiposFondo = useMemo(() => {
+    const set = new Set<string>();
+    watchlistEntries.forEach((e) => {
+      if (e.tipo_fondo) set.add(e.tipo_fondo);
+    });
+    return Array.from(set).sort();
+  }, [watchlistEntries]);
+
   // Filter + group from raw entries (reactive to all filters)
   const filteredGroups = useMemo(() => {
     let entries = watchlistEntries;
@@ -147,9 +157,12 @@ export default function MarketDashboard({ config }: MarketDashboardProps) {
     if (activoFilter) {
       entries = entries.filter((e) => e.activo !== false);
     }
+    if (tipoFondoFilter) {
+      entries = entries.filter((e) => e.tipo_fondo === tipoFondoFilter);
+    }
 
     return groupEntries(entries, config.groupByField);
-  }, [watchlistEntries, searchText, entidadFilter, activoFilter, config.groupByField]);
+  }, [watchlistEntries, searchText, entidadFilter, activoFilter, tipoFondoFilter, config.groupByField]);
 
   const { left, right } = useMemo(
     () =>
@@ -239,6 +252,7 @@ export default function MarketDashboard({ config }: MarketDashboardProps) {
             panelsVisible={panelsVisible}
             onTogglePanels={() => setPanelsVisible((v) => !v)}
             uniqueEntidades={uniqueEntidades}
+            uniqueTiposFondo={uniqueTiposFondo}
           />
         </Col>
       </Row>

--- a/src/components/marketDashboard/MarketDashboardToolbar.tsx
+++ b/src/components/marketDashboard/MarketDashboardToolbar.tsx
@@ -13,6 +13,7 @@ type MarketDashboardToolbarProps = {
   panelsVisible: boolean;
   onTogglePanels: () => void;
   uniqueEntidades?: string[];
+  uniqueTiposFondo?: string[];
 };
 
 export default function MarketDashboardToolbar({
@@ -20,6 +21,7 @@ export default function MarketDashboardToolbar({
   panelsVisible,
   onTogglePanels,
   uniqueEntidades,
+  uniqueTiposFondo,
 }: MarketDashboardToolbarProps) {
   const chartPeriod = useAppStore((s) => s.chartPeriod);
   const setChartPeriod = useAppStore((s) => s.setChartPeriod);
@@ -33,6 +35,8 @@ export default function MarketDashboardToolbar({
   const setEntidadFilter = useAppStore((s) => s.setEntidadFilter);
   const activoFilter = useAppStore((s) => s.activoFilter);
   const setActivoFilter = useAppStore((s) => s.setActivoFilter);
+  const tipoFondoFilter = useAppStore((s) => s.tipoFondoFilter);
+  const setTipoFondoFilter = useAppStore((s) => s.setTipoFondoFilter);
 
   const [showCurrencyModal, setShowCurrencyModal] = useState(false);
 
@@ -100,6 +104,24 @@ export default function MarketDashboardToolbar({
             {uniqueEntidades.map((ent) => (
               <option key={ent} value={ent}>
                 {ent}
+              </option>
+            ))}
+          </Form.Select>
+        )}
+        {config.showTipoFondoFilter && uniqueTiposFondo && uniqueTiposFondo.length > 0 && (
+          <Form.Select
+            size="sm"
+            aria-label="Filtrar por tipo de fondo"
+            value={tipoFondoFilter || ''}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+              setTipoFondoFilter(e.target.value || undefined)
+            }
+            style={{ maxWidth: 180, fontSize: 12 }}
+          >
+            <option value="">Abierto y Cerrado</option>
+            {uniqueTiposFondo.map((tipo) => (
+              <option key={tipo} value={tipo}>
+                {tipo}
               </option>
             ))}
           </Form.Select>

--- a/src/models/series/fetchWatchlistSnapshot.ts
+++ b/src/models/series/fetchWatchlistSnapshot.ts
@@ -51,6 +51,7 @@ export const fetchWatchlistMetadata = async (
       fuente: s.fuente,
       entidad: s.entidad,
       activo: s.activo,
+      tipo_fondo: s.tipo_fondo ?? null,
       latest_value: null,
       latest_date: null,
       change: null,

--- a/src/pages/fic/index.tsx
+++ b/src/pages/fic/index.tsx
@@ -16,6 +16,7 @@ const FIC_CONFIG: DashboardConfig = {
   showNormalize: true,
   showEntidadFilter: true,
   showActivoFilter: true,
+  showTipoFondoFilter: true,
   infoPath: '/fic/info',
   ficHierarchical: true,
 };

--- a/src/store/marketDashboard/index.ts
+++ b/src/store/marketDashboard/index.ts
@@ -65,6 +65,7 @@ export interface MarketDashboardSlice {
   searchText: string;
   entidadFilter: string | undefined;
   activoFilter: boolean;
+  tipoFondoFilter: string | undefined;
 
   fetchWatchlistSnapshot: (config: DashboardConfig) => Promise<void>;
   addToChart: (entry: WatchlistEntry) => Promise<void>;
@@ -78,6 +79,7 @@ export interface MarketDashboardSlice {
   setMarketSearchText: (text: string) => void;
   setEntidadFilter: (entidad: string | undefined) => void;
   setActivoFilter: (activo: boolean) => void;
+  setTipoFondoFilter: (tipoFondo: string | undefined) => void;
   resetWatchlistOnly: () => void;
   resetMarketDashboard: () => void;
 }
@@ -110,7 +112,8 @@ function filterEntries(
   entries: WatchlistEntry[],
   searchText: string,
   entidadFilter: string | undefined,
-  activoFilter: boolean
+  activoFilter: boolean,
+  tipoFondoFilter: string | undefined
 ): WatchlistEntry[] {
   let result = entries;
 
@@ -125,6 +128,9 @@ function filterEntries(
   }
   if (activoFilter) {
     result = result.filter((e) => e.activo !== false);
+  }
+  if (tipoFondoFilter) {
+    result = result.filter((e) => e.tipo_fondo === tipoFondoFilter);
   }
 
   return result;
@@ -143,6 +149,7 @@ const initialMarketState = {
   searchText: '',
   entidadFilter: undefined as string | undefined,
   activoFilter: true,
+  tipoFondoFilter: undefined as string | undefined,
 };
 
 function getPeriodCutoff(period: TimePeriod): string | null {
@@ -232,7 +239,8 @@ const createMarketDashboardSlice: StateCreator<MarketDashboardSlice> = (
         updated,
         state.searchText,
         state.entidadFilter,
-        state.activoFilter
+        state.activoFilter,
+        state.tipoFondoFilter
       );
 
       return {
@@ -382,6 +390,10 @@ const createMarketDashboardSlice: StateCreator<MarketDashboardSlice> = (
     set({ activoFilter: activo });
   },
 
+  setTipoFondoFilter: (tipoFondo: string | undefined) => {
+    set({ tipoFondoFilter: tipoFondo });
+  },
+
   resetWatchlistOnly: () =>
     set({
       watchlistEntries: [],
@@ -390,6 +402,7 @@ const createMarketDashboardSlice: StateCreator<MarketDashboardSlice> = (
       valuesLoading: false,
       searchText: '',
       entidadFilter: undefined,
+      tipoFondoFilter: undefined,
     }),
 
   resetMarketDashboard: () => set(initialMarketState),

--- a/src/types/lightserie.ts
+++ b/src/types/lightserie.ts
@@ -19,6 +19,7 @@ export interface LightSerieEntry {
   ticker: string;
   entidad: string | null;
   activo: boolean | null;
+  tipo_fondo?: string | null;
 }
 
 export interface PriceFormat {

--- a/src/types/watchlist.ts
+++ b/src/types/watchlist.ts
@@ -10,6 +10,7 @@ export interface WatchlistEntry {
   fuente: string;
   entidad: string | null;
   activo: boolean | null;
+  tipo_fondo: string | null;
   latest_value: number | null;
   latest_date: string | null;
   change: number | null;
@@ -71,6 +72,7 @@ export interface DashboardConfig {
   showNormalize?: boolean;
   showEntidadFilter?: boolean;
   showActivoFilter?: boolean;
+  showTipoFondoFilter?: boolean;
   showCurrencyPairSelector?: boolean;
   infoPath?: string;
   ficHierarchical?: boolean;


### PR DESCRIPTION
## Summary

Adds a **Tipo de Fondo** filter dropdown to the FIC dashboard, allowing users to filter between **Abierto** and **Cerrado** funds.

- Adds `tipo_fondo` field to `WatchlistEntry` and `LightSerieEntry` types
- Maps `tipo_fondo` from `search_mv` response in `fetchWatchlistSnapshot`
- Adds `tipoFondoFilter` state + `setTipoFondoFilter` action to the market dashboard store
- `MarketDashboardToolbar`: new dropdown (shown when `showTipoFondoFilter=true`, options populated dynamically)
- `MarketDashboard`: computes `uniqueTiposFondo`, applies filter in `filteredGroups` memo
- FIC page config: `showTipoFondoFilter: true`

## Dependencies

- DB migration: **avelezX/xerenity-db#60** must be applied first (adds `tipo_fondo TEXT` to `search_mv`)
- Builds on top of PR #189 (FIC hierarchical view)

## Test plan

- [ ] Apply xerenity-db#60 migration in Supabase SQL Editor
- [ ] Open `/fic` — dropdown shows "Abierto y Cerrado" / "FIC Abierto" / "FIC Cerrado" (after migration)
- [ ] Select "FIC Abierto" → only open-ended funds shown
- [ ] Select "FIC Cerrado" → only closed-end funds shown
- [ ] Select "Abierto y Cerrado" → all funds shown (default)
- [ ] Other filters (entidad, activo, search) continue to work alongside tipo_fondo filter
- [ ] Non-FIC dashboards unaffected (tipo_fondo is null for all other series)

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)