### PR TITLE
feat(fic): agrupar por clase activo + tipo_fondo como checkbox

### DIFF
--- a/src/components/marketDashboard/MarketDashboard.tsx
+++ b/src/components/marketDashboard/MarketDashboard.tsx
@@ -135,15 +135,6 @@ export default function MarketDashboard({ config }: MarketDashboardProps) {
     return Array.from(set).sort();
   }, [watchlistEntries]);
 
-  // Unique tipos de fondo for the filter dropdown (FIC only)
-  const uniqueTiposFondo = useMemo(() => {
-    const set = new Set<string>();
-    watchlistEntries.forEach((e) => {
-      if (e.tipo_fondo) set.add(e.tipo_fondo);
-    });
-    return Array.from(set).sort();
-  }, [watchlistEntries]);
-
   // Unique clases de activo for the filter dropdown (FIC only)
   const uniqueClasesActivo = useMemo(() => {
     const set = new Set<string>();
@@ -293,7 +284,7 @@ export default function MarketDashboard({ config }: MarketDashboardProps) {
             panelsVisible={panelsVisible}
             onTogglePanels={() => setPanelsVisible((v) => !v)}
             uniqueEntidades={uniqueEntidades}
-            uniqueTiposFondo={uniqueTiposFondo}
+
             uniqueClasesActivo={uniqueClasesActivo}
             uniqueTamanosFondo={uniqueTamanosFondo}
             uniqueTamanosInversionistas={uniqueTamanosInversionistas}

--- a/src/components/marketDashboard/MarketDashboardToolbar.tsx
+++ b/src/components/marketDashboard/MarketDashboardToolbar.tsx
@@ -13,7 +13,6 @@ type MarketDashboardToolbarProps = {
   panelsVisible: boolean;
   onTogglePanels: () => void;
   uniqueEntidades?: string[];
-  uniqueTiposFondo?: string[];
   uniqueClasesActivo?: string[];
   uniqueTamanosFondo?: string[];
   uniqueTamanosInversionistas?: string[];
@@ -24,7 +23,6 @@ export default function MarketDashboardToolbar({
   panelsVisible,
   onTogglePanels,
   uniqueEntidades,
-  uniqueTiposFondo,
   uniqueClasesActivo,
   uniqueTamanosFondo,
   uniqueTamanosInversionistas,
@@ -122,23 +120,16 @@ export default function MarketDashboardToolbar({
             ))}
           </Form.Select>
         )}
-        {config.showTipoFondoFilter && uniqueTiposFondo && uniqueTiposFondo.length > 0 && (
-          <Form.Select
-            size="sm"
-            aria-label="Filtrar por tipo de fondo"
-            value={tipoFondoFilter || ''}
-            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-              setTipoFondoFilter(e.target.value || undefined)
-            }
-            style={{ maxWidth: 180, fontSize: 12 }}
-          >
-            <option value="">Abierto y Cerrado</option>
-            {uniqueTiposFondo.map((tipo) => (
-              <option key={tipo} value={tipo}>
-                {tipo}
-              </option>
-            ))}
-          </Form.Select>
+        {config.showTipoFondoFilter && (
+          <InputGroup style={{ width: 'auto' }}>
+            <InputGroup.Checkbox
+              checked={tipoFondoFilter === 'Cerrado'}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setTipoFondoFilter(e.target.checked ? 'Cerrado' : undefined)
+              }
+            />
+            <InputGroup.Text style={{ fontSize: 12 }}>Solo cerrado</InputGroup.Text>
+          </InputGroup>
         )}
         {config.showClaseActivoFilter && uniqueClasesActivo && uniqueClasesActivo.length > 0 && (
           <Form.Select
@@ -148,7 +139,7 @@ export default function MarketDashboardToolbar({
             onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
               setClaseActivoFilter(e.target.value || undefined)
             }
-            style={{ maxWidth: 200, fontSize: 12 }}
+            style={{ maxWidth: 160, fontSize: 12 }}
           >
             <option value="">Todas las clases</option>
             {uniqueClasesActivo.map((clase) => (
@@ -202,7 +193,7 @@ export default function MarketDashboardToolbar({
             onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
               setAperturaFilter(e.target.value || undefined)
             }
-            style={{ maxWidth: 200, fontSize: 12 }}
+            style={{ maxWidth: 160, fontSize: 12 }}
           >
             <option value="">Todos los fondos</option>
             <option value="Abierto">Abierto</option>

--- a/src/pages/fic/index.tsx
+++ b/src/pages/fic/index.tsx
@@ -11,7 +11,7 @@ const FIC_CONFIG: DashboardConfig = {
   filters: {
     grupos: ['FIC'],
   },
-  groupByField: 'sub_group',
+  groupByField: 'clase_activo',
   defaultPeriod: '1Y',
   showNormalize: true,
   showEntidadFilter: true,

--- a/src/types/watchlist.ts
+++ b/src/types/watchlist.ts
@@ -68,7 +68,7 @@ export interface DashboardConfig {
     fuentes?: string[];
     subGroups?: string[];
   };
-  groupByField: 'grupo' | 'sub_group' | 'fuente' | 'entidad';
+  groupByField: 'grupo' | 'sub_group' | 'fuente' | 'entidad' | 'clase_activo';
   leftPanelGroups?: string[];
   rightPanelGroups?: string[];
   defaultChartTickers?: string[];


### PR DESCRIPTION
## Cambios

- **Panel lateral** agrupa por `clase_activo` (Renta Fija, Renta Variable, Mercado Monetario, etc.) en lugar de `sub_group`
- **tipo_fondo** pasa de dropdown a checkbox compacto \"Solo cerrado\" — solo tiene 2 valores, el checkbox es más limpio
- Dropdowns más angostos (160px)
- Limpieza: elimina prop `uniqueTiposFondo` que ya no se usa

🤖 Generated with [Claude Code](https://claude.com/claude-code)