### PR TITLE
feat(loans): rediseño página de créditos con TanStack Table

### DIFF
--- a/src/components/loans/LoansBlotterTable.tsx
+++ b/src/components/loans/LoansBlotterTable.tsx
@@ -1,0 +1,524 @@
+/* eslint-disable no-nested-ternary, jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/control-has-associated-label */
+'use client';
+
+import React, { useState, useMemo, useRef, useEffect, CSSProperties } from 'react';
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getFilteredRowModel,
+  flexRender,
+  createColumnHelper,
+  type SortingState,
+  type VisibilityState,
+  type ColumnSizingState,
+} from '@tanstack/react-table';
+import type { Loan } from 'src/types/loans';
+import currencyFormat from 'src/utils/currencyFormat';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type LoansBlotterProps = {
+  loans: Loan[];
+  typeFilter: string;
+  globalFilter: string;
+  onGlobalFilterChange: (v: string) => void;
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string) => void;
+  onToggleSelectAll: () => void;
+  onDelete: (loan: Loan) => void;
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const TYPE_COLORS: Record<string, { bg: string; fg: string }> = {
+  ibr:  { bg: '#fff3cd', fg: '#856404' },
+  uvr:  { bg: '#e8d5f5', fg: '#6f42c1' },
+  fija: { bg: '#cce5ff', fg: '#004085' },
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  ibr: 'IBR',
+  uvr: 'UVR',
+  fija: 'Tasa Fija',
+};
+
+const DAYS_COUNT_LABELS: Record<string, string> = {
+  por_dias_360: '30/360',
+  por_dias_365: 'Act/365',
+  por_periodo: 'Por Periodo',
+};
+
+const fmtMM = (v: number | null | undefined) => {
+  if (v == null) return '—';
+  const abs = Math.abs(v);
+  if (abs >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${(v / 1e3).toFixed(1)}K`;
+  return v.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+};
+
+// ─── Column definitions ─────────────────────────────────────────────────────
+
+const columnHelper = createColumnHelper<Loan>();
+
+const COLUMN_LABELS: Record<string, string> = {
+  select: '',
+  bank: 'Banco',
+  loan_identifier: 'Identificador',
+  type: 'Tipo',
+  original_balance: 'Monto',
+  interest_rate: 'Tasa Nominal',
+  spread: 'Spread',
+  periodicity: 'Periodicidad',
+  number_of_payments: 'Periodos',
+  start_date: 'F. Inicio',
+  days_count: 'Conteo Días',
+  grace: 'Gracia',
+  min_period_rate: 'Tasa Mín.',
+  actions: 'Acciones',
+};
+
+const DEFAULT_VISIBILITY: VisibilityState = {
+  select: true,
+  bank: true,
+  loan_identifier: true,
+  type: true,
+  original_balance: true,
+  interest_rate: true,
+  spread: true,
+  periodicity: true,
+  number_of_payments: true,
+  start_date: true,
+  days_count: false,
+  grace: false,
+  min_period_rate: false,
+  actions: true,
+};
+
+const buildColumns = (
+  onDelete: (loan: Loan) => void,
+  selectedIds: Set<string>,
+  onToggleSelect: (id: string) => void,
+  onToggleSelectAll: () => void,
+  allSelected: boolean,
+) => [
+  columnHelper.display({
+    id: 'select',
+    size: 36,
+    enableHiding: false,
+    enableSorting: false,
+    enableResizing: false,
+    header: () => (
+      <input type="checkbox" checked={allSelected} onChange={onToggleSelectAll} />
+    ),
+    cell: (info) => (
+      <input
+        type="checkbox"
+        checked={selectedIds.has(info.row.original.id)}
+        onChange={() => onToggleSelect(info.row.original.id)}
+      />
+    ),
+  }),
+  columnHelper.accessor('bank', {
+    id: 'bank',
+    header: 'Banco',
+    size: 120,
+    cell: (info) => <span style={{ fontSize: 11 }}>{info.getValue() || '—'}</span>,
+  }),
+  columnHelper.accessor('loan_identifier', {
+    id: 'loan_identifier',
+    header: 'Identificador',
+    size: 120,
+    cell: (info) => <span style={{ fontSize: 11 }}>{info.getValue() || '—'}</span>,
+  }),
+  columnHelper.accessor('type', {
+    id: 'type',
+    header: 'Tipo',
+    size: 80,
+    cell: (info) => {
+      const v = info.getValue();
+      const tc = TYPE_COLORS[v] ?? { bg: '#e2e3e5', fg: '#383d41' };
+      return (
+        <span style={{ padding: '2px 6px', borderRadius: 4, fontSize: 10, fontWeight: 700, background: tc.bg, color: tc.fg }}>
+          {TYPE_LABELS[v] ?? v}
+        </span>
+      );
+    },
+  }),
+  columnHelper.accessor('original_balance', {
+    id: 'original_balance',
+    header: 'Monto',
+    size: 120,
+    cell: (info) => (
+      <span style={{ fontFamily: 'monospace', fontSize: 11 }}>
+        {currencyFormat(info.getValue(), 0)}
+      </span>
+    ),
+  }),
+  columnHelper.accessor('interest_rate', {
+    id: 'interest_rate',
+    header: 'Tasa Nominal',
+    size: 100,
+    cell: (info) => {
+      const r = info.row.original;
+      const label = r.type === 'fija'
+        ? `${info.getValue()}%`
+        : `${TYPE_LABELS[r.type] ?? r.type}`;
+      return <span style={{ fontFamily: 'monospace', fontSize: 11 }}>{label}</span>;
+    },
+  }),
+  columnHelper.display({
+    id: 'spread',
+    header: 'Spread',
+    size: 80,
+    cell: (info) => {
+      const r = info.row.original;
+      const label = r.type === 'fija' ? '—' : `${r.interest_rate}%`;
+      return <span style={{ fontFamily: 'monospace', fontSize: 11 }}>{label}</span>;
+    },
+  }),
+  columnHelper.accessor('periodicity', {
+    id: 'periodicity',
+    header: 'Periodicidad',
+    size: 100,
+    cell: (info) => <span style={{ fontSize: 11 }}>{info.getValue() || '—'}</span>,
+  }),
+  columnHelper.accessor('number_of_payments', {
+    id: 'number_of_payments',
+    header: 'Periodos',
+    size: 70,
+    cell: (info) => <span style={{ fontFamily: 'monospace', fontSize: 11 }}>{info.getValue()}</span>,
+  }),
+  columnHelper.accessor('start_date', {
+    id: 'start_date',
+    header: 'F. Inicio',
+    size: 100,
+    cell: (info) => <span style={{ fontSize: 11 }}>{info.getValue() || '—'}</span>,
+  }),
+  // ── Hidden by default ──
+  columnHelper.accessor('days_count', {
+    id: 'days_count',
+    header: 'Conteo Días',
+    size: 90,
+    cell: (info) => <span style={{ fontSize: 11 }}>{DAYS_COUNT_LABELS[info.getValue()] ?? info.getValue()}</span>,
+  }),
+  columnHelper.display({
+    id: 'grace',
+    header: 'Gracia',
+    size: 100,
+    cell: (info) => {
+      const r = info.row.original;
+      if (!r.grace_type || !r.grace_period) return <span>—</span>;
+      return <span style={{ fontSize: 11 }}>{r.grace_type} ({r.grace_period})</span>;
+    },
+  }),
+  columnHelper.accessor('min_period_rate', {
+    id: 'min_period_rate',
+    header: 'Tasa Mín.',
+    size: 80,
+    cell: (info) => {
+      const v = info.getValue();
+      return v ? <span style={{ fontFamily: 'monospace', fontSize: 11 }}>{v}%</span> : <span>—</span>;
+    },
+  }),
+  // ── Actions ──
+  columnHelper.display({
+    id: 'actions',
+    header: '',
+    size: 40,
+    enableHiding: false,
+    enableSorting: false,
+    enableResizing: false,
+    cell: (info) => (
+      <button
+        type="button"
+        title="Eliminar"
+        onClick={() => onDelete(info.row.original)}
+        style={{ background: 'none', border: 'none', color: '#dc3545', cursor: 'pointer', fontSize: 12, padding: 2 }}
+      >
+        ✕
+      </button>
+    ),
+  }),
+];
+
+// ─── Sortable Header ────────────────────────────────────────────────────────
+
+function SortableHeader({
+  header,
+  children,
+}: {
+  header: {
+    id: string;
+    getSize: () => number;
+    column: {
+      getCanSort: () => boolean;
+      getToggleSortingHandler: () => ((e: unknown) => void) | undefined;
+      getIsSorted: () => false | 'asc' | 'desc';
+      getCanResize: () => boolean;
+    };
+    getResizeHandler: () => (e: React.MouseEvent | React.TouchEvent) => void;
+  };
+  children: React.ReactNode;
+}) {
+  const sorted = header.column.getIsSorted();
+
+  const style: CSSProperties = {
+    width: header.getSize(),
+    padding: '8px 6px',
+    fontWeight: 600,
+    whiteSpace: 'nowrap',
+    userSelect: 'none',
+    cursor: header.column.getCanSort() ? 'pointer' : 'default',
+    position: 'relative',
+  };
+
+  return (
+    <th style={style}>
+      <div
+        style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+        onClick={header.column.getToggleSortingHandler()}
+      >
+        {children}
+        {sorted === 'asc' && <span style={{ fontSize: 10, color: '#0d6efd' }}>▲</span>}
+        {sorted === 'desc' && <span style={{ fontSize: 10, color: '#0d6efd' }}>▼</span>}
+        {!sorted && header.column.getCanSort() && <span style={{ fontSize: 10, color: '#dee2e6' }}>⇅</span>}
+      </div>
+      {header.column.getCanResize() && (
+        <div
+          onMouseDown={header.getResizeHandler()}
+          onTouchStart={header.getResizeHandler()}
+          style={{
+            position: 'absolute', right: 0, top: 0, height: '100%',
+            width: 5, cursor: 'col-resize', zIndex: 1,
+            background: 'transparent',
+          }}
+          onClick={(e) => e.stopPropagation()}
+        />
+      )}
+    </th>
+  );
+}
+
+// ─── Column Visibility Dropdown ─────────────────────────────────────────────
+
+function ColumnVisibilityDropdown({
+  visibility,
+  onToggle,
+  onReset,
+}: {
+  visibility: VisibilityState;
+  onToggle: (id: string) => void;
+  onReset: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const toggleableColumns = Object.keys(COLUMN_LABELS).filter((id) => id !== 'actions' && id !== 'select');
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          padding: '4px 10px', fontSize: 11, fontWeight: 600, borderRadius: 6,
+          border: '1px solid #dee2e6', background: open ? '#e9ecef' : '#fff',
+          cursor: 'pointer', color: '#495057', display: 'flex', alignItems: 'center', gap: 4,
+        }}
+      >
+        ⚙ Columnas
+      </button>
+      {open && (
+        <div style={{
+          position: 'absolute', top: '100%', right: 0, zIndex: 1000, background: '#fff',
+          border: '1px solid #dee2e6', borderRadius: 8, boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+          padding: 12, minWidth: 200, maxHeight: 360, overflowY: 'auto',
+        }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: '#6c757d', marginBottom: 8, textTransform: 'uppercase' }}>Columnas visibles</div>
+          {toggleableColumns.map((colId) => (
+            <label key={colId} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, cursor: 'pointer', padding: '3px 0' }}>
+              <input
+                type="checkbox"
+                checked={visibility[colId] !== false}
+                onChange={() => onToggle(colId)}
+              />
+              {COLUMN_LABELS[colId] ?? colId}
+            </label>
+          ))}
+          <div style={{ borderTop: '1px solid #dee2e6', marginTop: 10, paddingTop: 8 }}>
+            <button
+              type="button"
+              onClick={onReset}
+              style={{ fontSize: 11, color: '#dc3545', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+            >
+              ↺ Resetear columnas
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── LoansBlotterTable ──────────────────────────────────────────────────────
+
+export default function LoansBlotterTable({
+  loans,
+  typeFilter,
+  globalFilter,
+  onGlobalFilterChange,
+  selectedIds,
+  onToggleSelect,
+  onToggleSelectAll,
+  onDelete,
+}: LoansBlotterProps) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(DEFAULT_VISIBILITY);
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
+
+  // Filter by type
+  const filteredByType = useMemo(
+    () => typeFilter === 'Todos' ? loans : loans.filter((l) => l.type === typeFilter),
+    [loans, typeFilter],
+  );
+
+  const allSelected = filteredByType.length > 0 && filteredByType.every((l) => selectedIds.has(l.id));
+
+  const columns = useMemo(
+    () => buildColumns(onDelete, selectedIds, onToggleSelect, onToggleSelectAll, allSelected),
+    [onDelete, selectedIds, onToggleSelect, onToggleSelectAll, allSelected],
+  );
+
+  const table = useReactTable({
+    data: filteredByType,
+    columns,
+    state: { sorting, columnVisibility, columnSizing, globalFilter },
+    onSortingChange: setSorting,
+    onColumnVisibilityChange: setColumnVisibility,
+    onColumnSizingChange: setColumnSizing,
+    onGlobalFilterChange: onGlobalFilterChange,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    columnResizeMode: 'onChange',
+    enableColumnResizing: true,
+  });
+
+  // Totals
+  const totals = useMemo(() => {
+    const total = filteredByType.reduce((acc, l) => acc + l.original_balance, 0);
+    const ibrLoans = filteredByType.filter((l) => l.type === 'ibr');
+    const uvrLoans = filteredByType.filter((l) => l.type === 'uvr');
+    const fijaLoans = filteredByType.filter((l) => l.type === 'fija');
+    return {
+      count: filteredByType.length,
+      total_balance: total,
+      ibr_count: ibrLoans.length,
+      uvr_count: uvrLoans.length,
+      fija_count: fijaLoans.length,
+    };
+  }, [filteredByType]);
+
+  if (loans.length === 0) {
+    return (
+      <div style={{ padding: 40, textAlign: 'center', color: '#6c757d', border: '2px dashed #dee2e6', borderRadius: 8 }}>
+        No hay créditos. Agrega uno desde el botón &quot;Nuevo Crédito&quot;.
+      </div>
+    );
+  }
+
+  const visibleColumnIds = table.getVisibleLeafColumns().map((c) => c.id);
+
+  return (
+    <div>
+      {/* Toolbar: search + column visibility */}
+      <div style={{ display: 'flex', gap: 8, marginBottom: 10, alignItems: 'center', justifyContent: 'flex-end' }}>
+        <input
+          type="text"
+          placeholder="Buscar…"
+          value={globalFilter}
+          onChange={(e) => onGlobalFilterChange(e.target.value)}
+          style={{
+            padding: '4px 10px', fontSize: 11, borderRadius: 6, border: '1px solid #ced4da',
+            width: 160, outline: 'none',
+          }}
+        />
+        <ColumnVisibilityDropdown
+          visibility={columnVisibility}
+          onToggle={(id) => table.getColumn(id)?.toggleVisibility()}
+          onReset={() => setColumnVisibility(DEFAULT_VISIBILITY)}
+        />
+      </div>
+
+      {/* Table */}
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', fontSize: 12, borderCollapse: 'collapse', tableLayout: 'fixed' }}>
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id} style={{ background: '#f8f9fa', borderBottom: '2px solid #dee2e6' }}>
+                {headerGroup.headers.map((header) => (
+                  <SortableHeader key={header.id} header={header}>
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </SortableHeader>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <tr key={row.id} style={{ borderBottom: '1px solid #eee' }}>
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id} style={{ padding: '6px', overflow: 'hidden', textOverflow: 'ellipsis', width: cell.column.getSize() }}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr style={{ borderTop: '2px solid #343a40', background: '#f1f3f5' }}>
+              {visibleColumnIds.map((colId, idx) => {
+                const tStyle: CSSProperties = { padding: '8px 6px', fontFamily: 'monospace', fontSize: 11, fontWeight: 700 };
+                if (idx === 0) {
+                  return (
+                    <td key={colId} style={tStyle}>
+                      TOTAL ({totals.count})
+                    </td>
+                  );
+                }
+                if (colId === 'original_balance') {
+                  return (
+                    <td key={colId} style={tStyle}>
+                      {fmtMM(totals.total_balance)}
+                    </td>
+                  );
+                }
+                if (colId === 'type') {
+                  return (
+                    <td key={colId} style={{ ...tStyle, fontSize: 10 }}>
+                      {totals.ibr_count > 0 && <span style={{ color: '#856404' }}>IBR:{totals.ibr_count} </span>}
+                      {totals.uvr_count > 0 && <span style={{ color: '#6f42c1' }}>UVR:{totals.uvr_count} </span>}
+                      {totals.fija_count > 0 && <span style={{ color: '#004085' }}>Fija:{totals.fija_count}</span>}
+                    </td>
+                  );
+                }
+                return <td key={colId} />;
+              })}
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/loans/index.tsx
+++ b/src/pages/loans/index.tsx
@@ -1,36 +1,29 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 'use client';
 
-import React, { useEffect } from 'react';
-import { Container, Row, Col, Form, InputGroup } from 'react-bootstrap';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { CoreLayout } from '@layout';
 import { ExportToCsv, downloadBlob } from 'src/utils/downloadCSV';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import {
-  faCalendar,
-  faDollar,
   faFileCsv,
   faPlus,
   faLandmark,
   faTrash,
+  faTable,
+  faChartBar,
 } from '@fortawesome/free-solid-svg-icons';
-import Toolbar from '@components/UI/Toolbar';
 import tokens from 'design-tokens/tokens.json';
 import Chart from '@components/chart/Chart';
-import Button from '@components/UI/Button';
 import PageTitle from '@components/PageTitle';
 import { MultiValue } from 'react-select';
-import LoansTable from 'src/pages/loans/_LoansTable';
 import MultipleSelect from '@components/UI/MultipleSelect';
 import ConfirmationModal from '@components/UI/ConfirmationModal';
 import useAppStore from '@store';
-import Panel from '@components/Panel';
 import { Loan } from 'src/types/loans';
-import { SelectableRows } from 'src/types/selectableRows';
-import { GenericCard, TableValue } from '@components/InforCard/InfoCard';
-import DataTableBase from '@components/Table/BaseDataTable';
-import LoanDebtListColumns from '@components/Table/columnDefinition/loans/loanDebt/columns';
+import LoansBlotterTable from 'src/components/loans/LoansBlotterTable';
 import NewCreditModal from './_NewCreditModal';
 import CashFlowOverlay from './_cashFlowOverLay/cashFlowOverlay';
 
@@ -56,6 +49,35 @@ const CSV_FILE = {
   format: 'text/csv;charset=utf-8;',
 };
 
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const fmtMM = (v: number | null | undefined) => {
+  if (v == null) return '—';
+  const abs = Math.abs(v);
+  if (abs >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${(v / 1e3).toFixed(1)}K`;
+  return v.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+};
+
+const TYPE_PILL_COLORS: Record<string, { bg: string; color: string }> = {
+  ibr:  { bg: '#fff3cd', color: '#856404' },
+  uvr:  { bg: '#e8d5f5', color: '#6f42c1' },
+  fija: { bg: '#cce5ff', color: '#004085' },
+};
+
+type ViewMode = 'table' | 'chart';
+type TypeFilter = 'Todos' | 'ibr' | 'uvr' | 'fija';
+
+const TYPE_OPTIONS: { key: TypeFilter; label: string }[] = [
+  { key: 'Todos', label: 'Todos' },
+  { key: 'ibr', label: 'IBR' },
+  { key: 'uvr', label: 'UVR' },
+  { key: 'fija', label: 'Tasa Fija' },
+];
+
+// ─── Page ───────────────────────────────────────────────────────────────────
+
 export default function LoansPage() {
   const {
     banks,
@@ -77,17 +99,22 @@ export default function LoansPage() {
     onShowCashFlowTable,
     resetStore,
     setFilterDate,
-    loanDebtData,
     fullLoan,
     wakeServer,
     selectedLoans,
     deleteMultipleLoans,
     loading,
+    setCurrentSelection,
   } = useAppStore();
+
+  const [viewMode, setViewMode] = useState<ViewMode>('table');
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('Todos');
+  const [globalFilter, setGlobalFilter] = useState('');
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   const cashflowsEmpty = mergedCashFlows.length === 0;
 
-  // Split chart data into interest (total payment) and principal for stacked bars
+  // Chart data
   const paymentChartData = mergedCashFlows.map((flow) => ({
     time: flow.date.split(' ')[0],
     value: flow.payment,
@@ -96,62 +123,98 @@ export default function LoansPage() {
     time: flow.date.split(' ')[0],
     value: flow.principal,
   }));
-  // Implied rate line (rate_tot = forward rate + spread, as percentage)
   const rateChartData = mergedCashFlows.map((flow) => ({
     time: flow.date.split(' ')[0],
     value: flow.rate_tot,
   }));
 
+  // Type counts for pills
+  const typeCounts = useMemo(() => {
+    const counts = { ibr: 0, uvr: 0, fija: 0 };
+    loans.forEach((l) => {
+      if (l.type in counts) counts[l.type as keyof typeof counts] += 1;
+    });
+    return counts;
+  }, [loans]);
+
+  // Selection handlers
+  const onToggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const filteredLoans = useMemo(
+    () => typeFilter === 'Todos' ? loans : loans.filter((l) => l.type === typeFilter),
+    [loans, typeFilter],
+  );
+
+  const onToggleSelectAll = useCallback(() => {
+    setSelectedIds((prev) => {
+      const allSelected = filteredLoans.every((l) => prev.has(l.id));
+      if (allSelected) return new Set();
+      return new Set(filteredLoans.map((l) => l.id));
+    });
+  }, [filteredLoans]);
+
+  const onDeleteFromTable = useCallback((loan: Loan) => {
+    setCurrentSelection(loan);
+    onShowDeleteConfirm(true);
+  }, [setCurrentSelection, onShowDeleteConfirm]);
+
+  // Keep store selectedLoans in sync
+  useEffect(() => {
+    const ids = Array.from(selectedIds);
+    const selectedRows = loans.filter((l) => selectedIds.has(l.id));
+    setSelectedLoans({
+      selectedCount: ids.length,
+      selectedRows,
+      filterDate,
+    });
+  }, [selectedIds, loans, filterDate, setSelectedLoans]);
+
   const onDownloadSeries = () => {
     const { name, columns, format } = CSV_FILE;
-    const allValues: string[][] = [];
-
-    allValues.push(columns);
-
-    if (mergedCashFlows) {
-      mergedCashFlows.forEach(
-        ({
+    const allValues: string[][] = [columns];
+    mergedCashFlows.forEach(
+      ({ date, beginning_balance, ending_balance, interest, payment, principal }) => {
+        allValues.push([
           date,
-          beginning_balance,
-          ending_balance,
-          interest,
-          payment,
-          principal,
-        }) => {
-          allValues.push([
-            date,
-            beginning_balance.toString(),
-            ending_balance.toString(),
-            interest.toString(),
-            payment.toString(),
-            principal.toString(),
-          ]);
-        }
-      );
-    }
-
+          beginning_balance.toString(),
+          ending_balance.toString(),
+          interest.toString(),
+          payment.toString(),
+          principal.toString(),
+        ]);
+      }
+    );
     const csv = ExportToCsv(allValues);
     downloadBlob(csv, name, format);
   };
 
-  const onBankFilter = (
-    selections: MultiValue<{ value: string; label: string }>
-  ) => {
-    const selectionValues = selections?.map(({ value }) => ({
-      bank_name: value,
-    }));
+  const onBankFilter = (selections: MultiValue<{ value: string; label: string }>) => {
+    const selectionValues = selections?.map(({ value }) => ({ bank_name: value }));
     setSelectedBanks(selectionValues);
   };
 
   const onDeleteConfirmed = () => {
-    if (currentSelection) {
-      deleteLoanItem(currentSelection.id);
+    if (currentSelection) deleteLoanItem(currentSelection.id);
+  };
+
+  const onDeleteSelected = () => {
+    const ids = Array.from(selectedIds);
+    if (ids.length > 0) {
+      deleteMultipleLoans(ids);
+      setSelectedIds(new Set());
     }
   };
 
   useEffect(() => {
     getLoanData();
-    return () => resetStore(); // Reset when component unmount
+    return () => resetStore();
   }, [getLoanData, resetStore]);
 
   useEffect(() => {
@@ -160,17 +223,12 @@ export default function LoansPage() {
 
   useEffect(() => {
     if (errorMessage) {
-      toast.error(errorMessage, {
-        position: toast.POSITION.BOTTOM_RIGHT,
-      });
+      toast.error(errorMessage, { position: toast.POSITION.BOTTOM_RIGHT });
     } else if (successMessage) {
-      toast.success(successMessage, {
-        position: toast.POSITION.BOTTOM_RIGHT,
-      });
+      toast.success(successMessage, { position: toast.POSITION.BOTTOM_RIGHT });
     }
   }, [errorMessage, successMessage]);
 
-  // Prep Bank data for select component
   const bankSelectItems = banks.map((bck) => ({
     value: bck.bank_name,
     label: bck.bank_name,
@@ -178,211 +236,217 @@ export default function LoansPage() {
 
   return (
     <CoreLayout>
-      <Container fluid className="px-4 pb-3">
-        <Row>
-          <div className="d-flex align-items-center gap-2 py-1">
-            <PageTitle>
-              <Icon icon={faLandmark} size="1x" />
-              <h4>{PAGE_TITLE}</h4>
-            </PageTitle>
+      <div style={{ padding: '0 16px 16px' }}>
+        {/* ─── Header ─── */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 0', marginBottom: 8 }}>
+          <PageTitle>
+            <Icon icon={faLandmark} size="1x" />
+            <h4>{PAGE_TITLE}</h4>
+          </PageTitle>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <button
+              type="button"
+              disabled={cashflowsEmpty}
+              onClick={() => onShowCashFlowTable(true)}
+              style={{
+                padding: '4px 12px', fontSize: 11, fontWeight: 600, borderRadius: 6,
+                border: '1px solid #dee2e6', background: '#fff', cursor: cashflowsEmpty ? 'not-allowed' : 'pointer',
+                color: cashflowsEmpty ? '#adb5bd' : '#495057', opacity: cashflowsEmpty ? 0.6 : 1,
+              }}
+            >
+              Ver Flujos
+            </button>
+            <button
+              type="button"
+              disabled={cashflowsEmpty}
+              onClick={onDownloadSeries}
+              style={{
+                padding: '4px 12px', fontSize: 11, fontWeight: 600, borderRadius: 6,
+                border: '1px solid #dee2e6', background: '#fff', cursor: cashflowsEmpty ? 'not-allowed' : 'pointer',
+                color: cashflowsEmpty ? '#adb5bd' : '#495057', opacity: cashflowsEmpty ? 0.6 : 1,
+              }}
+            >
+              <Icon icon={faFileCsv} style={{ marginRight: 4 }} />
+              CSV
+            </button>
+            <button
+              type="button"
+              onClick={() => onShowNewLoanModal(true)}
+              style={{
+                padding: '4px 12px', fontSize: 11, fontWeight: 600, borderRadius: 6,
+                border: 'none', background: '#0d6efd', color: '#fff', cursor: 'pointer',
+              }}
+            >
+              <Icon icon={faPlus} style={{ marginRight: 4 }} />
+              Nuevo Crédito
+            </button>
           </div>
-        </Row>
-        <Row>
-          <div className="d-flex justify-content-end pb-3">
-            <Toolbar>
-              <Button
-                variant="outline-primary"
-                disabled={cashflowsEmpty}
-                onClick={onDownloadSeries}
-              >
-                <Icon icon={faFileCsv} className="mr-4" />
-                Descargar
-              </Button>
-              <Button
-                variant={cashflowsEmpty ? 'outline-primary' : 'primary'}
-                disabled={cashflowsEmpty}
-                onClick={() => onShowCashFlowTable(true)}
-              >
-                <Icon icon={faDollar} className="mr-4" />
-                Ver Flujos
-              </Button>
-              <Button
-                variant="primary"
-                onClick={() => onShowNewLoanModal(true)}
-              >
-                <Icon icon={faPlus} className="mr-4" />
-                Nuevo Crédito
-              </Button>
-            </Toolbar>
+        </div>
+
+        {/* ─── Summary Bar ─── */}
+        {fullLoan && (
+          <div style={{
+            display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'center',
+            padding: '12px 16px', background: '#f8f9fa', border: '1px solid #dee2e6',
+            borderRadius: 8, marginBottom: 12,
+          }}>
+            <SummaryItem label="# Créditos" value={fullLoan.loan_count?.toString() ?? '0'} />
+            <SummaryItem label="Deuda Total" value={fmtMM(fullLoan.total_value)} />
+            <SummaryItem label="CPD" value={`${((fullLoan.average_irr ?? 0) * 100).toFixed(2)}%`} />
+            <SummaryItem label="Tenor (Años)" value={(fullLoan.average_tenor ?? 0).toFixed(1)} />
+            <SummaryItem label="Duración (Años)" value={(fullLoan.average_duration ?? 0).toFixed(2)} />
+            {(fullLoan.total_value_ibr ?? 0) > 0 && (
+              <SummaryItem label="IBR" value={fmtMM(fullLoan.total_value_ibr)} color="#856404" />
+            )}
+            {(fullLoan.total_value_uvr ?? 0) > 0 && (
+              <SummaryItem label="UVR" value={fmtMM(fullLoan.total_value_uvr)} color="#6f42c1" />
+            )}
+            {(fullLoan.total_value_fija ?? 0) > 0 && (
+              <SummaryItem label="Tasa Fija" value={fmtMM(fullLoan.total_value_fija)} color="#004085" />
+            )}
           </div>
-        </Row>
-        <Row className="mb-3">
-          <Col sm={3}>
-            <GenericCard
-              value={fullLoan?.average_irr}
-              multi={100}
-              name="WACC (IRR)"
-              text="%"
+        )}
+
+        {/* ─── Filters + Toggle ─── */}
+        <div style={{ display: 'flex', gap: 8, marginBottom: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+          {/* Type pills */}
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+            <span style={{ fontSize: 11, color: '#6c757d', fontWeight: 600 }}>Tipo:</span>
+            {TYPE_OPTIONS.map(({ key, label }) => {
+              const count = key === 'Todos' ? loans.length : typeCounts[key as keyof typeof typeCounts] ?? 0;
+              const active = typeFilter === key;
+              const s = key !== 'Todos' ? TYPE_PILL_COLORS[key] : null;
+              return (
+                <button
+                  type="button"
+                  key={key}
+                  onClick={() => setTypeFilter(key)}
+                  style={{
+                    padding: '2px 10px', borderRadius: 12, fontSize: 11, fontWeight: 600, cursor: 'pointer',
+                    border: active ? '2px solid #495057' : '1px solid #dee2e6',
+                    background: active && s ? s.bg : active ? '#495057' : '#f8f9fa',
+                    color: active && s ? s.color : active ? '#fff' : '#6c757d',
+                  }}
+                >
+                  {label} {count > 0 && <span style={{ opacity: 0.7 }}>({count})</span>}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Bank filter */}
+          <div style={{ width: 200 }}>
+            <MultipleSelect
+              data={bankSelectItems}
+              onChange={onBankFilter}
+              placeholder="Filtrar por banco"
             />
-          </Col>
-          <Col sm={3}>
-            <GenericCard value={fullLoan?.average_tenor} name="Tenor (Años)" />
-          </Col>
-          <Col sm={3}>
-            <GenericCard
-              value={fullLoan?.average_duration}
-              name="Duración (Años)"
-              fixed={2}
+          </div>
+
+          {/* Date filter */}
+          <input
+            type="date"
+            value={filterDate}
+            onChange={(e) => setFilterDate(e.target.value)}
+            style={{
+              padding: '3px 8px', fontSize: 11, borderRadius: 6, border: '1px solid #ced4da',
+              fontFamily: 'monospace', outline: 'none',
+            }}
+          />
+
+          {/* Delete selected */}
+          {selectedIds.size > 0 && (
+            <button
+              type="button"
+              onClick={onDeleteSelected}
+              style={{
+                padding: '4px 10px', fontSize: 11, fontWeight: 600, borderRadius: 6,
+                border: '1px solid #dc3545', background: '#fff', color: '#dc3545', cursor: 'pointer',
+              }}
+            >
+              <Icon icon={faTrash} style={{ marginRight: 4 }} />
+              Borrar ({selectedIds.size})
+            </button>
+          )}
+
+          {/* View toggle */}
+          <div style={{ marginLeft: 'auto', display: 'flex', gap: 4 }}>
+            <button
+              type="button"
+              onClick={() => setViewMode('table')}
+              style={{
+                padding: '4px 10px', fontSize: 11, fontWeight: 600, borderRadius: '6px 0 0 6px',
+                border: '1px solid #dee2e6', cursor: 'pointer',
+                background: viewMode === 'table' ? '#495057' : '#fff',
+                color: viewMode === 'table' ? '#fff' : '#6c757d',
+              }}
+            >
+              <Icon icon={faTable} style={{ marginRight: 4 }} />
+              Tabla
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewMode('chart')}
+              style={{
+                padding: '4px 10px', fontSize: 11, fontWeight: 600, borderRadius: '0 6px 6px 0',
+                border: '1px solid #dee2e6', borderLeft: 'none', cursor: 'pointer',
+                background: viewMode === 'chart' ? '#495057' : '#fff',
+                color: viewMode === 'chart' ? '#fff' : '#6c757d',
+              }}
+            >
+              <Icon icon={faChartBar} style={{ marginRight: 4 }} />
+              Gráfico
+            </button>
+          </div>
+        </div>
+
+        {/* ─── Content ─── */}
+        <div style={{ background: '#fff', border: '1px solid #dee2e6', borderRadius: 8, padding: 16 }}>
+          {viewMode === 'table' ? (
+            <LoansBlotterTable
+              loans={loans}
+              typeFilter={typeFilter}
+              globalFilter={globalFilter}
+              onGlobalFilterChange={setGlobalFilter}
+              selectedIds={selectedIds}
+              onToggleSelect={onToggleSelect}
+              onToggleSelectAll={onToggleSelectAll}
+              onDelete={onDeleteFromTable}
             />
-          </Col>
-          <Col sm={3}>
-            <GenericCard
-              value={fullLoan?.loan_count}
-              name="# Total de creditos"
-              fixed={0}
-            />
-          </Col>
-        </Row>
-        <Row className="mb-3">
-          <Col sm={8}>
-            <Chart showToolbar loading={loading}>
-              <Chart.Bar
-                data={paymentChartData}
-                color={INTEREST_COLOR}
-                scaleId="right"
-                title="Interés"
-              />
-              <Chart.Bar
-                data={principalChartData}
-                color={PRINCIPAL_COLOR}
-                scaleId="right"
-                title="Capital"
-              />
-              <Chart.Line
-                data={rateChartData}
-                color={designSystem['green-400'].value}
-                scaleId="left"
-                title="Tasa % (Izq)"
-              />
-            </Chart>
-          </Col>
-          <Col sm={4}>
-            <table className="table">
-              <thead>
-                <tr>
-                  <th scope="col">Calculo</th>
-                  <th scope="col">IBR</th>
-                  <th scope="col">UVR</th>
-                  <th scope="col">Tasa Fija</th>
-                  <th scope="col">Total</th>
-                </tr>
-              </thead>
-              {fullLoan && (
-                <tbody>
-                  <tr>
-                    <th scope="row">Valor deuda</th>
-                    <TableValue value={fullLoan.total_value_ibr} fixed={0} />
-                    <TableValue value={fullLoan.total_value_uvr} fixed={0} />
-                    <TableValue value={fullLoan?.total_value_fija} fixed={0} />
-                    <TableValue value={fullLoan?.total_value} fixed={0} />
-                  </tr>
-                  <tr>
-                    <th scope="row">WACC %</th>
-                    <TableValue value={fullLoan?.average_irr_ibr} multi={100} />
-                    <TableValue value={fullLoan.average_irr_uvr} multi={100} />
-                    <TableValue
-                      value={fullLoan?.average_irr_fija}
-                      multi={100}
-                    />
-                    <TableValue value={fullLoan?.average_irr} multi={100} />
-                  </tr>
-                  <tr>
-                    <th scope="row">Tenor (Años)</th>
-                    <TableValue value={fullLoan?.average_tenor} />
-                    <TableValue value={fullLoan.average_tenor} />
-                    <TableValue value={fullLoan?.average_tenor} />
-                    <TableValue value={fullLoan?.average_tenor} />
-                  </tr>
-                  <tr>
-                    <th scope="row">Duracion (Años)</th>
-                    <TableValue value={fullLoan?.average_duration} />
-                    <TableValue value={fullLoan.average_duration} />
-                    <TableValue value={fullLoan?.average_duration} />
-                    <TableValue value={fullLoan?.average_duration} />
-                  </tr>
-                </tbody>
-              )}
-            </table>
-          </Col>
-        </Row>
-        <Row>
-          <Col sm={8}>
-            <Panel>
-              <Row>
-                <Col sm={12} md={3}>
-                  <MultipleSelect
-                    data={bankSelectItems}
-                    onChange={onBankFilter}
-                    placeholder="Filtra tabla por banco"
+          ) : (
+            <div>
+              {cashflowsEmpty ? (
+                <div style={{ padding: 40, textAlign: 'center', color: '#6c757d', border: '2px dashed #dee2e6', borderRadius: 8 }}>
+                  Selecciona créditos en la tabla para ver el gráfico de flujos.
+                </div>
+              ) : (
+                <Chart showToolbar loading={loading}>
+                  <Chart.Bar
+                    data={paymentChartData}
+                    color={INTEREST_COLOR}
+                    scaleId="right"
+                    title="Interés"
                   />
-                </Col>
-                <Col sm={12} md={3}>
-                  <InputGroup>
-                    <InputGroup.Text className="bg-white border-right-none">
-                      <Icon
-                        className="text-primary"
-                        icon={faCalendar}
-                        fixedWidth
-                      />
-                    </InputGroup.Text>
-                    <Form.Control
-                      type="date"
-                      value={filterDate}
-                      onChange={(a) => {
-                        setFilterDate(a.target.value);
-                      }}
-                    />
-                  </InputGroup>
-                </Col>
-                <Col sm={12} md={2} className="position-absolute end-0">
-                  <Button
-                    onClick={() => {
-                      deleteMultipleLoans(selectedLoans);
-                    }}
-                    disabled={selectedLoans.length === 0}
-                  >
-                    <Icon icon={faTrash} />
-                    Borrar creditos
-                  </Button>
-                </Col>
-              </Row>
-              <LoansTable
-                list={loans}
-                onSelect={({
-                  selectedCount,
-                  selectedRows,
-                }: SelectableRows<Loan>) => {
-                  setSelectedLoans({
-                    selectedCount,
-                    selectedRows,
-                    filterDate,
-                  });
-                }}
-              />
-            </Panel>
-          </Col>
-          <Col sm={4}>
-            <Panel>
-              <DataTableBase
-                columns={LoanDebtListColumns}
-                data={loanDebtData}
-                fixedHeader
-                selectableRowsNoSelectAll
-              />
-            </Panel>
-          </Col>
-        </Row>
-      </Container>
+                  <Chart.Bar
+                    data={principalChartData}
+                    color={PRINCIPAL_COLOR}
+                    scaleId="right"
+                    title="Capital"
+                  />
+                  <Chart.Line
+                    data={rateChartData}
+                    color={designSystem['green-400'].value}
+                    scaleId="left"
+                    title="Tasa % (Izq)"
+                  />
+                </Chart>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ─── Modals ─── */}
       <ConfirmationModal
         onCancel={() => onShowDeleteConfirm(false)}
         show={showDeleteConfirm}
@@ -402,5 +466,16 @@ export default function LoansPage() {
       />
       <ToastContainer />
     </CoreLayout>
+  );
+}
+
+// ─── Summary Item ───────────────────────────────────────────────────────────
+
+function SummaryItem({ label, value, color }: { label: string; value: string; color?: string }) {
+  return (
+    <div style={{ minWidth: 100 }}>
+      <div style={{ fontSize: 10, color: '#6c757d', textTransform: 'uppercase', marginBottom: 2 }}>{label}</div>
+      <div style={{ fontSize: 16, fontWeight: 700, fontFamily: 'monospace', color: color ?? '#212529' }}>{value}</div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Migra la tabla de créditos de `react-data-table-component` a **TanStack React Table** con sortable headers, column resizing y column visibility dropdown
- Reemplaza las 4 GenericCards por una **summary bar inline** (CPD, Deuda Total, Tenor, Duración, desglose IBR/UVR/Fija)
- Agrega **filtros pill por tipo de tasa** (Todos/IBR/UVR/Tasa Fija) con counts dinámicos
- Integra totales en el **footer de la tabla** (reemplaza tabla lateral derecha)
- Agrega **toggle Tabla/Gráfico** para alternar entre vista blotter y chart de cashflows
- Layout **full-width** (elimina split col-8/col-4)
- Renombra WACC → **CPD** (Costo Promedio de Deuda)

## Test plan
- [ ] Verificar que la summary bar muestra métricas correctas
- [ ] Verificar que los pills filtran por tipo de tasa
- [ ] Verificar sort, resize y visibility toggle en la tabla
- [ ] Verificar footer con totales
- [ ] Verificar toggle tabla/gráfico
- [ ] Verificar crear crédito sigue funcionando
- [ ] Verificar borrar créditos (individual y batch)
- [ ] Verificar CSV export y cashflow overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)