### PR TITLE
fix(lint): remove unused var in loans page

### DIFF
--- a/src/pages/loans/index.tsx
+++ b/src/pages/loans/index.tsx
@@ -482,8 +482,8 @@ export default function LoansPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {cashflowModalData.map((row, i) => (
-                    <tr key={`${row.date}-${i}`} style={{ borderBottom: '1px solid #eee' }}>
+                  {cashflowModalData.map((row) => (
+                    <tr key={`${row.date}-${row.beginning_balance}`} style={{ borderBottom: '1px solid #eee' }}>
                       <td style={tdStyle}>{row.date?.split(' ')[0]}</td>
                       <td style={tdStyle}>{((row.rate_tot ?? row.rate ?? 0) * 100).toFixed(2)}%</td>
                       <td style={tdStyle}>{currencyFormat(row.beginning_balance, 0)}</td>


### PR DESCRIPTION
## Summary
- Remove unused `i` index variable from cashflow modal map
- Use `row.date-row.beginning_balance` as key instead of array index

Fixes Vercel build failure from PR #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)