### PR TITLE
fix(auth): handle OAuth callback errors for Microsoft login

### DIFF
--- a/src/pages/api/auth/callback.ts
+++ b/src/pages/api/auth/callback.ts
@@ -9,8 +9,19 @@ export default async function handler(
 
   if (typeof code === 'string') {
     const supabase = createPagesServerClient({ req, res });
-    await supabase.auth.exchangeCodeForSession(code);
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.error('OAuth callback error:', error.message);
+      const msg = encodeURIComponent(error.message);
+      res.redirect(`/login?error=${msg}`);
+      return;
+    }
+  } else {
+    res.redirect('/login?error=missing_code');
+    return;
   }
 
-  res.redirect('/dashboard');
+  res.redirect('/suameca');
 }

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from 'react';
 import { NextPage } from 'next';
+import { useRouter } from 'next/router';
 import { Image } from 'react-bootstrap';
+import Alert from '@components/UI/Alert';
 import LoginForm from './_LoginForm';
 import SignUpForm from './_SignUpForm';
 import SocialAuth from './_SocialAuth';
@@ -22,12 +24,17 @@ const LOGO_SETTINGS = {
 type AuthTab = 'login' | 'signup';
 
 const LoginPage: NextPage = () => {
+  const router = useRouter();
+  const oauthError = router.query.error as string | undefined;
   const [activeTab, setActiveTab] = useState<AuthTab>('login');
 
   return (
     <LoginContainer>
       <aside className="form-wrapper">
         <div className="container">
+          {oauthError && (
+            <Alert>Error de autenticación: {decodeURIComponent(oauthError)}</Alert>
+          )}
           <Image
             src={LOGO_SETTINGS.url}
             fluid


### PR DESCRIPTION
## Summary
- Fix silent OAuth failure: `exchangeCodeForSession` errors now redirect to `/login?error=<message>` instead of `/dashboard` without a session (which causes the "enters for a second then kicks out" behavior)
- Login page shows the OAuth error message so users know what went wrong
- Redirect to `/suameca` instead of `/dashboard` after successful OAuth

Closes #218

## Test plan
- [ ] Login with Microsoft — if it fails, error message shows on login page
- [ ] Login with Google — should still work normally
- [ ] Login with email/password — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)