### PR TITLE
fix(auth): client-side OAuth callback for Microsoft login

### DIFF
--- a/src/pages/auth/callback.tsx
+++ b/src/pages/auth/callback.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+
+/**
+ * Client-side OAuth callback page.
+ * Supabase implicit flow sends tokens as URL hash fragments (#access_token=...)
+ * which are only visible to the browser, not the server.
+ * This page detects the session client-side and redirects.
+ */
+export default function AuthCallback() {
+  const router = useRouter();
+  const supabase = createClientComponentClient();
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) {
+        router.replace('/suameca');
+      } else {
+        router.replace('/login?error=oauth_session_failed');
+      }
+    });
+  }, [supabase, router]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '100vh',
+        color: '#666',
+      }}
+    >
+      Autenticando...
+    </div>
+  );
+}

--- a/src/pages/login/_SignUpForm/index.tsx
+++ b/src/pages/login/_SignUpForm/index.tsx
@@ -57,7 +57,7 @@ function SingUpForm() {
       email: preparedValues.email,
       password: preparedValues.password,
       options: {
-        emailRedirectTo: 'https://xerenity.vercel.app/api/auth/callback',
+        emailRedirectTo: 'https://xerenity.vercel.app/auth/callback',
         data: {
           full_name: preparedValues.name,
           country: preparedValues.country,

--- a/src/pages/login/_SocialAuth/index.tsx
+++ b/src/pages/login/_SocialAuth/index.tsx
@@ -60,7 +60,7 @@ function SocialAuth() {
     await supabase.auth.signInWithOAuth({
       provider,
       options: {
-        redirectTo: `${window.location.origin}/api/auth/callback`,
+        redirectTo: `${window.location.origin}/auth/callback`,
       },
     });
   };


### PR DESCRIPTION
## Summary
- Root cause: Supabase uses implicit flow, sending tokens as URL hash fragments (`#access_token=...`) which the server-side API route cannot read — resulting in `missing_code` error
- New `/auth/callback` client-side page that detects the session from hash fragments and redirects to `/suameca`
- Updated SocialAuth and SignUpForm to use the new client-side callback

## Test plan
- [ ] Login with Microsoft — should now complete successfully
- [ ] Login with Google — should work
- [ ] Login with GitHub — should work
- [ ] Sign up email confirmation redirect works

🤖 Generated with [Claude Code](https://claude.com/claude-code)