### PR TITLE
fix(auth): wait for auth state change in OAuth callback

### DIFF
--- a/src/pages/auth/callback.tsx
+++ b/src/pages/auth/callback.tsx
@@ -6,20 +6,37 @@ import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
  * Client-side OAuth callback page.
  * Supabase implicit flow sends tokens as URL hash fragments (#access_token=...)
  * which are only visible to the browser, not the server.
- * This page detects the session client-side and redirects.
+ * We listen for onAuthStateChange to wait for Supabase to process the hash.
  */
 export default function AuthCallback() {
   const router = useRouter();
   const supabase = createClientComponentClient();
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session) {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        subscription.unsubscribe();
         router.replace('/suameca');
-      } else {
-        router.replace('/login?error=oauth_session_failed');
       }
     });
+
+    // Fallback: if no auth event fires within 5s, check session directly
+    const timeout = setTimeout(async () => {
+      const { data } = await supabase.auth.getSession();
+      if (data.session) {
+        router.replace('/suameca');
+      } else {
+        router.replace('/login?error=oauth_timeout');
+      }
+      subscription.unsubscribe();
+    }, 5000);
+
+    return () => {
+      clearTimeout(timeout);
+      subscription.unsubscribe();
+    };
   }, [supabase, router]);
 
   return (


### PR DESCRIPTION
## Summary
- `getSession()` was racing against Supabase's hash fragment processing, returning null immediately
- Now uses `onAuthStateChange` to wait for `SIGNED_IN` event before redirecting
- 5-second fallback timeout prevents infinite loading

## Test plan
- [ ] Login with Microsoft — should see "Autenticando..." then redirect to /suameca
- [ ] Login with Google/GitHub — same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)