### PR TITLE
fix(auth): use localStorage for OAuth PKCE flow

### DIFF
--- a/src/pages/auth/callback.tsx
+++ b/src/pages/auth/callback.tsx
@@ -1,18 +1,17 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { createOAuthClient } from '../../utils/supabase-oauth';
 
 /**
  * OAuth callback page.
  *
- * Supabase v2 uses PKCE flow by default: tokens arrive as ?code=... query
- * param. The code_verifier needed for exchange is stored client-side in
- * cookies by createClientComponentClient, so the exchange MUST happen here
- * (not on a server-side API route which loses access to the code_verifier).
+ * Uses a dedicated OAuth client (localStorage-based) for the PKCE code
+ * exchange, then syncs the session to the cookie-based client that the
+ * rest of the app uses.
  */
 export default function AuthCallback() {
   const router = useRouter();
-  const supabase = createClientComponentClient();
 
   useEffect(() => {
     const queryParams = new URLSearchParams(window.location.search);
@@ -32,23 +31,34 @@ export default function AuthCallback() {
       return undefined;
     }
 
-    // PKCE flow: exchange code client-side (code_verifier is in cookies)
+    // PKCE flow: exchange code using the OAuth client (localStorage has the code_verifier)
     const code = queryParams.get('code');
 
     if (code) {
-      supabase.auth.exchangeCodeForSession(code).then(({ error: exchErr }) => {
-        if (exchErr) {
-          router.replace(
-            `/login?error=${encodeURIComponent(exchErr.message)}`,
-          );
-        } else {
-          router.replace('/suameca');
+      const oauthClient = createOAuthClient();
+      oauthClient.auth.exchangeCodeForSession(code).then(({ data, error: exchErr }) => {
+        if (exchErr || !data.session) {
+          const msg = exchErr?.message || 'no_session';
+          router.replace(`/login?error=${encodeURIComponent(msg)}`);
+          return;
         }
+
+        // Sync session to the cookie-based client used by the rest of the app
+        const supabase = createClientComponentClient();
+        supabase.auth
+          .setSession({
+            access_token: data.session.access_token,
+            refresh_token: data.session.refresh_token,
+          })
+          .then(() => {
+            router.replace('/suameca');
+          });
       });
       return undefined;
     }
 
     // Implicit flow fallback: tokens in hash fragment
+    const supabase = createClientComponentClient();
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event, session) => {
@@ -73,7 +83,7 @@ export default function AuthCallback() {
       clearTimeout(timeout);
       subscription.unsubscribe();
     };
-  }, [supabase, router]);
+  }, [router]);
 
   return (
     <div

--- a/src/pages/login/_SocialAuth/index.tsx
+++ b/src/pages/login/_SocialAuth/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import type { Provider } from '@supabase/supabase-js';
+import { createOAuthClient } from '../../../utils/supabase-oauth';
 import SocialAuthContainer from './SocialAuth.styled';
 
 const PROVIDERS: { name: string; provider: Provider; icon: JSX.Element }[] = [
@@ -52,12 +52,12 @@ const PROVIDERS: { name: string; provider: Provider; icon: JSX.Element }[] = [
 ];
 
 function SocialAuth() {
-  const supabase = createClientComponentClient();
   const [loading, setLoading] = useState<string | null>(null);
 
   const handleSocialLogin = async (provider: Provider) => {
     setLoading(provider);
-    await supabase.auth.signInWithOAuth({
+    const oauthClient = createOAuthClient();
+    await oauthClient.auth.signInWithOAuth({
       provider,
       options: {
         redirectTo: `${window.location.origin}/auth/callback`,

--- a/src/utils/supabase-oauth.ts
+++ b/src/utils/supabase-oauth.ts
@@ -1,0 +1,24 @@
+import { createClient } from '@supabase/supabase-js';
+
+/**
+ * Supabase client for OAuth flows only.
+ *
+ * Uses localStorage (default) instead of the auth-helpers' cookie storage.
+ * This ensures the PKCE code_verifier persists reliably across the OAuth
+ * redirect chain (login → provider → callback).
+ *
+ * After successful code exchange, the session must be synced to the
+ * cookie-based client (createClientComponentClient) for the rest of the app.
+ */
+export function createOAuthClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        flowType: 'pkce',
+        detectSessionInUrl: false,
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Root cause: `@supabase/auth-helpers-nextjs` uses cookie-based storage for PKCE `code_verifier`, but the cookie gets lost during OAuth redirect chain (login → provider → callback)
- Fix: Created `createOAuthClient()` that uses localStorage (default Supabase storage) for the OAuth flow. localStorage reliably persists across redirects
- After successful PKCE code exchange, the session is synced to the cookie-based client (`createClientComponentClient`) so the rest of the app works as before
- Also includes Azure `email profile openid` scopes from PR #223

## Changes
- `src/utils/supabase-oauth.ts` — new OAuth-specific Supabase client
- `src/pages/login/_SocialAuth/index.tsx` — uses OAuth client for `signInWithOAuth`
- `src/pages/auth/callback.tsx` — exchanges code via OAuth client, syncs session to cookies

## Test plan
- [ ] Login with Google
- [ ] Login with Microsoft
- [ ] Login with GitHub
- [ ] Login with email/password (unaffected)
- [ ] Session persists after OAuth login (navigate between pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)