### PR TITLE
feat(sidebar): clickable user menu with role + popover

### DIFF
--- a/src/layout/CoreLayout/Sidebar/Sidebar.tsx
+++ b/src/layout/CoreLayout/Sidebar/Sidebar.tsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
-import { Image, Badge } from 'react-bootstrap';
+import { Image } from 'react-bootstrap';
 import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
-import { faShareFromSquare } from '@fortawesome/free-solid-svg-icons';
-import Button from '@components/UI/Button';
+import {
+  faShareFromSquare,
+  faChevronUp,
+  faUser,
+  faBuilding,
+  faShieldAlt,
+  faEnvelope,
+} from '@fortawesome/free-solid-svg-icons';
 import useAppStore from 'src/store';
 import SidebarNavList from './SidebarNavList';
 
@@ -23,14 +29,16 @@ const getInitials = (email: string, fullName?: string): string => {
   return email.substring(0, 2).toUpperCase();
 };
 
-const getRoleBadge = (role: string): { label: string; bg: string } | null => {
+const getRoleLabel = (role: string): { label: string; className: string } => {
   switch (role) {
     case 'super_admin':
-      return { label: 'Admin', bg: 'danger' };
+      return { label: 'Super Admin', className: 'role-super-admin' };
     case 'corp_admin':
-      return { label: 'Admin Corp', bg: 'warning' };
+      return { label: 'Admin Corp', className: 'role-corp-admin' };
+    case 'gestor':
+      return { label: 'Gestor', className: 'role-gestor' };
     default:
-      return null;
+      return { label: 'Lector', className: 'role-lector' };
   }
 };
 
@@ -38,6 +46,19 @@ const Sidebar = () => {
   const supabase = createClientComponentClient();
   const router = useRouter();
   const userProfile = useAppStore((s) => s.userProfile);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close menu when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    if (menuOpen) document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [menuOpen]);
 
   const logout = async () => {
     const { error } = await supabase.auth.signOut();
@@ -49,7 +70,7 @@ const Sidebar = () => {
   };
 
   const initials = userProfile ? getInitials(userProfile.email, userProfile.full_name) : '';
-  const roleBadge = userProfile ? getRoleBadge(userProfile.role) : null;
+  const roleInfo = userProfile ? getRoleLabel(userProfile.role) : null;
 
   return (
     <div className="layout-sidebar">
@@ -59,26 +80,80 @@ const Sidebar = () => {
         </figure>
         <SidebarNavList currentPath={router.pathname} />
       </section>
-      <section className="bottom-container">
-        {userProfile && (
-          <div className="sidebar-user-info">
-            <div className="sidebar-user-avatar">{initials}</div>
-            <div className="sidebar-user-details">
-              <span className="sidebar-user-email" title={userProfile.email}>
-                {userProfile.email}
-              </span>
-              {roleBadge && (
-                <Badge bg={roleBadge.bg} className="sidebar-role-badge">
-                  {roleBadge.label}
-                </Badge>
+      <section className="bottom-container" ref={menuRef}>
+        {/* Popover menu */}
+        {menuOpen && userProfile && (
+          <div className="sidebar-user-popover">
+            <div className="popover-header">
+              <div className="popover-avatar">{initials}</div>
+              <div className="popover-identity">
+                <span className="popover-name">
+                  {userProfile.full_name || userProfile.email.split('@')[0]}
+                </span>
+                {roleInfo && (
+                  <span className={`popover-role ${roleInfo.className}`}>
+                    {roleInfo.label}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className="popover-divider" />
+            <div className="popover-details">
+              <div className="popover-detail-row">
+                <Icon icon={faEnvelope} className="popover-icon" />
+                <span title={userProfile.email}>{userProfile.email}</span>
+              </div>
+              <div className="popover-detail-row">
+                <Icon icon={faShieldAlt} className="popover-icon" />
+                <span>Rol: {roleInfo?.label}</span>
+              </div>
+              <div className="popover-detail-row">
+                <Icon icon={faUser} className="popover-icon" />
+                <span>Cuenta: {userProfile.account_type === 'corporate' ? 'Corporativa' : 'Individual'}</span>
+              </div>
+              {userProfile.company_name && (
+                <div className="popover-detail-row">
+                  <Icon icon={faBuilding} className="popover-icon" />
+                  <span>{userProfile.company_name}</span>
+                </div>
               )}
             </div>
+            <div className="popover-divider" />
+            <button
+              type="button"
+              className="popover-logout"
+              onClick={logout}
+            >
+              <Icon icon={faShareFromSquare} />
+              Cerrar sesión
+            </button>
           </div>
         )}
-        <Button $fullwidth variant="outline-primary" onClick={() => logout()}>
-          <Icon icon={faShareFromSquare} />
-          Salir
-        </Button>
+
+        {/* User button (always visible) */}
+        {userProfile && (
+          <button
+            type="button"
+            className="sidebar-user-button"
+            onClick={() => setMenuOpen(!menuOpen)}
+          >
+            <div className="sidebar-user-avatar">{initials}</div>
+            <div className="sidebar-user-details">
+              <span className="sidebar-user-name">
+                {userProfile.full_name || userProfile.email.split('@')[0]}
+              </span>
+              {roleInfo && (
+                <span className={`sidebar-user-role ${roleInfo.className}`}>
+                  {roleInfo.label}
+                </span>
+              )}
+            </div>
+            <Icon
+              icon={faChevronUp}
+              className={`sidebar-chevron ${menuOpen ? 'open' : ''}`}
+            />
+          </button>
+        )}
       </section>
     </div>
   );

--- a/src/styles/layout/_sidebar.scss
+++ b/src/styles/layout/_sidebar.scss
@@ -52,29 +52,41 @@
   }
 
   .bottom-container {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    gap: 8px;
 
-    .sidebar-user-info {
+    // Clickable user button at the bottom
+    .sidebar-user-button {
       display: flex;
       align-items: center;
       gap: 10px;
       padding: 10px 8px;
+      border: none;
       border-top: solid 1px $gray-200;
+      background: none;
+      cursor: pointer;
+      width: 100%;
+      text-align: left;
+      border-radius: 0 0 $radius-md $radius-md;
+      transition: background-color 0.15s;
+
+      &:hover {
+        background-color: $purple-10;
+      }
 
       .sidebar-user-avatar {
         flex-shrink: 0;
-        width: 36px;
-        height: 36px;
+        width: 32px;
+        height: 32px;
         border-radius: 50%;
         background-color: $purple-200;
         color: $white-100;
         display: flex;
         align-items: center;
         justify-content: center;
-        font-size: 13px;
+        font-size: 12px;
         font-weight: 600;
         letter-spacing: 0.5px;
       }
@@ -82,22 +94,159 @@
       .sidebar-user-details {
         display: flex;
         flex-direction: column;
-        gap: 2px;
         min-width: 0;
+        flex: 1;
 
-        .sidebar-user-email {
-          font-size: 11px;
+        .sidebar-user-name {
+          font-size: 12px;
+          font-weight: 500;
           color: $purple-500;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
         }
 
-        .sidebar-role-badge {
+        .sidebar-user-role {
           font-size: 10px;
-          align-self: flex-start;
-          padding: 2px 6px;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.3px;
+
+          &.role-super-admin { color: #dc3545; }
+          &.role-corp-admin { color: #e67e22; }
+          &.role-gestor { color: #2980b9; }
+          &.role-lector { color: #7f8c8d; }
         }
+      }
+
+      .sidebar-chevron {
+        font-size: 10px;
+        color: $purple-500;
+        transition: transform 0.2s;
+        &.open { transform: rotate(180deg); }
+      }
+    }
+
+    // Popover menu that opens above the user button
+    .sidebar-user-popover {
+      position: absolute;
+      bottom: calc(100% + 6px);
+      left: 0;
+      right: 0;
+      background: $white-100;
+      border: 1px solid $gray-200;
+      border-radius: $radius-md;
+      box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.12);
+      z-index: 100;
+      animation: slideUp 0.15s ease-out;
+
+      .popover-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 14px 12px;
+
+        .popover-avatar {
+          flex-shrink: 0;
+          width: 40px;
+          height: 40px;
+          border-radius: 50%;
+          background-color: $purple-200;
+          color: $white-100;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 15px;
+          font-weight: 600;
+        }
+
+        .popover-identity {
+          display: flex;
+          flex-direction: column;
+          min-width: 0;
+
+          .popover-name {
+            font-size: 13px;
+            font-weight: 600;
+            color: $purple-500;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+
+          .popover-role {
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+
+            &.role-super-admin { color: #dc3545; }
+            &.role-corp-admin { color: #e67e22; }
+            &.role-gestor { color: #2980b9; }
+            &.role-lector { color: #7f8c8d; }
+          }
+        }
+      }
+
+      .popover-divider {
+        height: 1px;
+        background-color: $gray-200;
+        margin: 0 12px;
+      }
+
+      .popover-details {
+        padding: 10px 12px;
+
+        .popover-detail-row {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          padding: 4px 0;
+          font-size: 11px;
+          color: $purple-500;
+
+          .popover-icon {
+            width: 14px;
+            color: $purple-300;
+            flex-shrink: 0;
+          }
+
+          span {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+        }
+      }
+
+      .popover-logout {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        width: 100%;
+        padding: 10px 12px;
+        border: none;
+        background: none;
+        cursor: pointer;
+        font-size: 12px;
+        color: #dc3545;
+        border-radius: 0 0 $radius-md $radius-md;
+        transition: background-color 0.15s;
+
+        &:hover {
+          background-color: rgba(220, 53, 69, 0.06);
+        }
+      }
+    }
+
+    @keyframes slideUp {
+      from {
+        opacity: 0;
+        transform: translateY(4px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replace static user info + "Salir" button with interactive user panel
- Compact button at bottom shows initials, name, and colored role label (Super Admin / Admin Corp / Gestor / Lector)
- Click opens popover with full details: email, rol, tipo de cuenta, empresa
- "Cerrar sesión" in popover replaces old "Salir" button
- Popover closes on outside click with slide-up animation

## Test plan
- [ ] Login as super_admin → see red "Super Admin" label, click to open popover
- [ ] Login as lector → see gray "Lector" label
- [ ] Verify popover shows correct email, role, account type
- [ ] Click outside popover → closes
- [ ] "Cerrar sesión" logs out correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)