### PR TITLE
fix: guard onboarding sub-components against SSR prerender

### DIFF
--- a/src/pages/onboarding/_AccountTypeStep/index.tsx
+++ b/src/pages/onboarding/_AccountTypeStep/index.tsx
@@ -65,7 +65,7 @@ const TypeCard = styled.button`
   }
 `;
 
-function AccountTypeStep({ onSelect, loading }: AccountTypeStepProps) {
+function AccountTypeStep({ onSelect = () => {}, loading = false }: Partial<AccountTypeStepProps>) {
   return (
     <CardGrid>
       <TypeCard

--- a/src/pages/onboarding/_CompanyStep/index.tsx
+++ b/src/pages/onboarding/_CompanyStep/index.tsx
@@ -117,17 +117,17 @@ const Container = styled.div`
 `;
 
 function CompanyStep({
-  domain,
-  domainCompanies,
-  loading,
-  onJoin,
-  onCreate,
-  onBack,
-}: CompanyStepProps) {
+  domain = '',
+  domainCompanies = [],
+  loading = false,
+  onJoin = () => {},
+  onCreate = () => {},
+  onBack = () => {},
+}: Partial<CompanyStepProps>) {
   const [companyName, setCompanyName] = useState('');
   const [companyNit, setCompanyNit] = useState('');
   const [error, setError] = useState('');
-  const isFreemail = isFreemailDomain(domain);
+  const isFreemail = domain ? isFreemailDomain(domain) : false;
 
   const handleCreate = () => {
     if (!companyName.trim()) {


### PR DESCRIPTION
Next.js prerenders _CompanyStep as a page, causing undefined.toLowerCase() crash. Added default props.