### PR TITLE
feat(chile): add Chile (BCCh) tab to MarketDashboard

### DIFF
--- a/src/components/marketDashboard/MarketDashboard.tsx
+++ b/src/components/marketDashboard/MarketDashboard.tsx
@@ -42,6 +42,7 @@ const DASHBOARD_TABS = [
   { label: 'Monedas', path: '/monedas-dashboard' },
   { label: 'FIC', path: '/fic' },
   { label: 'Peru', path: '/peru' },
+  { label: 'Chile', path: '/chile' },
   { label: 'Par de Monedas', path: '/par-monedas' },
 ];
 

--- a/src/pages/chile/index.tsx
+++ b/src/pages/chile/index.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { CoreLayout } from '@layout';
+import { faGlobeAmericas } from '@fortawesome/free-solid-svg-icons';
+import MarketDashboard from '@components/marketDashboard/MarketDashboard';
+import { DashboardConfig } from 'src/types/watchlist';
+
+const CHILE_CONFIG: DashboardConfig = {
+  title: 'Chile - BCCh',
+  icon: faGlobeAmericas,
+  filters: {
+    fuentes: ['BCCh'],
+  },
+  groupByField: 'sub_group',
+  defaultPeriod: '1Y',
+  showNormalize: true,
+};
+
+export default function ChilePage() {
+  return (
+    <CoreLayout>
+      <MarketDashboard config={CHILE_CONFIG} />
+    </CoreLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a new "Chile" tab to the MarketDashboard navigation, filtering series by source `BCCh` (Banco Central de Chile)
- Creates `src/pages/chile/index.tsx` following the same pattern as the Peru page
- Adds tab entry in `DASHBOARD_TABS` array in `MarketDashboard.tsx`

Backend (already deployed): collector in xerenity-dm, tables `bcch_series_catalog` + `bcch_series_value`, and `search_mv` updated with BCCh series.

Closes #232

## Test plan
- [ ] Navigate to /chile and verify the page loads with BCCh series grouped by sub_group
- [ ] Verify the "Chile" tab appears in the dashboard navigation between Peru and Par de Monedas
- [ ] Verify chart and normalize toggle work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)