### PR TITLE
fix(risk): fix auth session not being sent to backend

### DIFF
--- a/src/models/risk/riskApi.ts
+++ b/src/models/risk/riskApi.ts
@@ -11,9 +11,9 @@ import type {
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 
 const BASE_URL = process.env.NEXT_PUBLIC_PYSDK_URL || 'https://pysdk.fly.dev';
+const supabase = createClientComponentClient();
 
 async function postJson<T>(url: string, body: Record<string, unknown>): Promise<T> {
-  const supabase = createClientComponentClient();
   const { data: { session } } = await supabase.auth.getSession();
 
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };


### PR DESCRIPTION
## Summary

Moves `createClientComponentClient()` to module scope in `riskApi.ts`, matching the pattern used by all other model files (loans, trading, series, etc.).

The session was returning null because the client was being instantiated inside each `postJson()` call instead of at module level.
#243
## Test plan
- [ ] Vercel preview build passes
- [ ] Risk endpoints receive Authorization header
- [ ] Commodities page loads data in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)