### PR TITLE
feat(risk): migrate Commodities from Fly.io to frontend calculations

### DIFF
--- a/src/lib/risk/exposureCalculator.ts
+++ b/src/lib/risk/exposureCalculator.ts
@@ -1,0 +1,197 @@
+/* eslint-disable no-restricted-syntax, object-shorthand, prefer-template, no-continue */
+/**
+ * Exposure calculator — TypeScript port of gestion_de_riesgos/exposure.py
+ *
+ * Calculates USD exposure by commodity for Super de Alimentos.
+ */
+
+import type { ExposureParams } from 'src/types/risk';
+
+// ── Constants ──
+
+const LIBRAS_CONTRATO = 112_000; // lbs per sugar contract
+const LBS_PER_TON = 2204.62;
+const CONV_BU_TON = 0.3936825; // bushels to tons conversion
+const CREDITO_PCT = 0.26; // corn byproduct credit percentage
+const COCOA_TON_CONTRATO = 10; // tons per cocoa contract
+
+export interface CommodityExposure {
+  nombre: string;
+  proyeccion_tons: number;
+  tons_reales: number;
+  num_contratos: number;
+  precio_unitario: number;
+  exposicion_usd: number;
+  detalle: Record<string, number>;
+}
+
+export interface ExposureResult {
+  commodities: CommodityExposure[];
+  total_commodities_usd: number;
+  exposicion_real_usd: number;
+  ventas_intl_usd: number;
+  ventas_co_usd: number;
+  ventas_pe_usd: number;
+  market_prices: Record<string, { value: number; date: string; source: string; contract?: string }>;
+}
+
+// ── Sugar (Azúcar ICE SB) ──
+
+function calcularAzucar(params: ExposureParams): CommodityExposure {
+  const tonTotal = (params.proyeccion_azucar ?? []).reduce((a: number, b: number) => a + b, 0);
+  const tonContrato = LIBRAS_CONTRATO / LBS_PER_TON; // ~50.82 tons
+  const tonReales = tonTotal * (params.factor_crudo_refinado ?? 1.05);
+  const numContratos = tonReales / tonContrato;
+  const precioLibra = (params.precio_azucar_cent_lb ?? 0) / 100;
+  const precioContrato = precioLibra * LIBRAS_CONTRATO;
+  const exposicionUsd = precioContrato * numContratos;
+
+  return {
+    nombre: 'AZUCAR',
+    proyeccion_tons: tonTotal,
+    tons_reales: tonReales,
+    num_contratos: numContratos,
+    precio_unitario: precioLibra,
+    exposicion_usd: exposicionUsd,
+    detalle: {
+      ton_contrato: tonContrato,
+      precio_contrato: precioContrato,
+      factor_crudo_refinado: params.factor_crudo_refinado ?? 1.05,
+    },
+  };
+}
+
+// ── Corn/Glucose (Maíz CME ZC) ──
+
+function calcularMaiz(params: ExposureParams): CommodityExposure {
+  const tonTotal = (params.proyeccion_glucosa ?? []).reduce((a: number, b: number) => a + b, 0);
+  const precioCentBu = (params.precio_maiz_cent_bu ?? 0) + (params.base_maiz_cent_bu ?? 0);
+  const precioCentTon = precioCentBu * CONV_BU_TON;
+  const precioUsdTon = precioCentTon / 100;
+  const precioNet = (params.flete_usd_ton ?? 0) + precioUsdTon;
+  const creditoSubproductos = precioNet * CREDITO_PCT;
+  const precioNeto = precioUsdTon + creditoSubproductos;
+  const glucosaMateria = (params.factor_maiz_glucosa ?? 1.495) * precioNeto;
+  const procFeeUsdTon = ((params.proc_fee_cop_kg ?? 0) / (params.trm ?? 1)) * 1000;
+  const precioGlucosa = procFeeUsdTon + (params.processing_fee_usd ?? 0) + glucosaMateria;
+  const exposicionUsd = tonTotal * precioGlucosa;
+
+  return {
+    nombre: 'MAIZ',
+    proyeccion_tons: tonTotal,
+    tons_reales: tonTotal,
+    num_contratos: tonTotal * CONV_BU_TON,
+    precio_unitario: precioGlucosa,
+    exposicion_usd: exposicionUsd,
+    detalle: {
+      precio_cent_bu: precioCentBu,
+      precio_usd_ton: precioUsdTon,
+      flete_usd_ton: params.flete_usd_ton ?? 0,
+      credito_subproductos: creditoSubproductos,
+      glucosa_materia: glucosaMateria,
+      proc_fee_usd_ton: procFeeUsdTon,
+      processing_fee_usd: params.processing_fee_usd ?? 0,
+    },
+  };
+}
+
+// ── Cocoa derivatives (ICE CC) ──
+
+interface CocoaProduct {
+  nombre: string;
+  proyeccion: number[];
+  factor: number;
+}
+
+function calcularCocoaDerivado(
+  product: CocoaProduct,
+  precioFuturo: number,
+): CommodityExposure {
+  const tonTotal = product.proyeccion.reduce((a, b) => a + b, 0);
+  const kgReales = tonTotal * 1000 * product.factor;
+  const tonReales = kgReales / 1000;
+  const numContratos = tonReales / COCOA_TON_CONTRATO;
+  const precioContrato = COCOA_TON_CONTRATO * precioFuturo;
+  const exposicionUsd = numContratos * precioContrato;
+
+  return {
+    nombre: product.nombre,
+    proyeccion_tons: tonTotal,
+    tons_reales: tonReales,
+    num_contratos: numContratos,
+    precio_unitario: precioFuturo,
+    exposicion_usd: exposicionUsd,
+    detalle: {
+      factor_conversion: product.factor,
+      kg_reales: kgReales,
+      precio_contrato: precioContrato,
+    },
+  };
+}
+
+// ── Packaging (Empaque) ──
+
+function calcularEmpaque(params: ExposureParams): CommodityExposure {
+  const tonBolsa = (params.proyeccion_bolsa ?? []).reduce((a: number, b: number) => a + b, 0);
+  const tonEnvoltura = (params.proyeccion_envoltura ?? []).reduce((a: number, b: number) => a + b, 0);
+  const tonTotal = tonBolsa + tonEnvoltura;
+  const precioFijo = params.precio_empaque_fijo ?? 0;
+  const trm = params.trm ?? 1;
+  const exposicionUsd = (precioFijo * tonTotal) / trm;
+
+  return {
+    nombre: 'EMPAQUE',
+    proyeccion_tons: tonTotal,
+    tons_reales: tonTotal,
+    num_contratos: 0,
+    precio_unitario: precioFijo / trm,
+    exposicion_usd: exposicionUsd,
+    detalle: {
+      ton_bolsa: tonBolsa,
+      ton_envoltura: tonEnvoltura,
+      precio_fijo_cop: precioFijo,
+      trm: trm,
+    },
+  };
+}
+
+// ── Total Exposure ──
+
+export function calcularExposicionTotal(params: ExposureParams): ExposureResult {
+  const precioCocoa = params.precio_cocoa_usd_ton ?? 0;
+
+  const azucar = calcularAzucar(params);
+  const maiz = calcularMaiz(params);
+
+  const cocoaPolvo = calcularCocoaDerivado(
+    { nombre: 'COCOA_POLVO', proyeccion: params.proyeccion_cocoa_polvo ?? [], factor: params.factor_cocoa_polvo ?? 1.22 },
+    precioCocoa,
+  );
+  const manteca = calcularCocoaDerivado(
+    { nombre: 'MANTECA_CACAO', proyeccion: params.proyeccion_manteca ?? [], factor: params.factor_manteca ?? 1.95 },
+    precioCocoa,
+  );
+  const licor = calcularCocoaDerivado(
+    { nombre: 'LICOR_CACAO', proyeccion: params.proyeccion_licor ?? [], factor: params.factor_licor ?? 1.53 },
+    precioCocoa,
+  );
+
+  const empaque = calcularEmpaque(params);
+
+  const commodities = [azucar, maiz, cocoaPolvo, manteca, licor, empaque];
+  const totalCommoditiesUsd = commodities.reduce((s, c) => s + c.exposicion_usd, 0);
+
+  const ventasIntl = params.ventas_intl_usd ?? 0;
+  const ventasCo = params.ventas_co_usd ?? 0;
+  const ventasPe = params.ventas_pe_usd ?? 0;
+
+  return {
+    commodities,
+    total_commodities_usd: totalCommoditiesUsd,
+    exposicion_real_usd: ventasIntl - totalCommoditiesUsd,
+    ventas_intl_usd: ventasIntl,
+    ventas_co_usd: ventasCo,
+    ventas_pe_usd: ventasPe,
+    market_prices: {}, // populated by caller with DB prices
+  };
+}

--- a/src/lib/risk/futuresCalculator.ts
+++ b/src/lib/risk/futuresCalculator.ts
@@ -1,0 +1,216 @@
+/* eslint-disable no-plusplus, no-continue, no-restricted-syntax, prefer-template */
+/**
+ * Futures portfolio calculator — TypeScript port of gestion_de_riesgos/futures_portfolio.py
+ *
+ * Calculates P&L per position (inception and monthly) with contract multipliers.
+ */
+
+import type { FuturesPosition } from 'src/types/risk';
+import type { FuturesPositionRow } from './supabaseRisk';
+
+// ── Constants ──
+
+const CONTRACT_MULTIPLIERS: Record<string, number> = {
+  MAIZ: 5_000,     // bushels
+  AZUCAR: 112_000, // libras
+  CACAO: 10,        // toneladas metricas
+};
+
+const DIRECTION_SIGN: Record<string, number> = {
+  LONG: 1,
+  SHORT: -1,
+};
+
+const PRICE_UNITS: Record<string, string> = {
+  MAIZ: 'cents/bu',
+  AZUCAR: 'cents/lb',
+  CACAO: 'USD/ton',
+};
+
+// ── Helpers ──
+
+/**
+ * Last business day of the previous month (skip weekends).
+ */
+export function lastBusinessDayOfPrevMonth(refDate: Date): Date {
+  const firstOfMonth = new Date(refDate.getFullYear(), refDate.getMonth(), 1);
+  const lastCalDay = new Date(firstOfMonth.getTime() - 86400000); // day before = last of prev month
+  const wd = lastCalDay.getDay(); // 0=Sun, 6=Sat
+  if (wd === 0) lastCalDay.setDate(lastCalDay.getDate() - 2); // Sun → Fri
+  else if (wd === 6) lastCalDay.setDate(lastCalDay.getDate() - 1); // Sat → Fri
+  return lastCalDay;
+}
+
+function toDateStr(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Find the last available price for an asset on or before targetDate.
+ */
+function findPrice(
+  dates: string[],
+  assetPrices: (number | null)[],
+  targetDate: string,
+): { price: number | null; date: string | null } {
+  for (let i = dates.length - 1; i >= 0; i--) {
+    if (dates[i] <= targetDate && assetPrices[i] != null) {
+      return { price: assetPrices[i], date: dates[i] };
+    }
+  }
+  return { price: null, date: null };
+}
+
+// ── Main Calculator ──
+
+export function calculateFuturesPortfolio(
+  positions: FuturesPositionRow[],
+  dates: string[],
+  prices: Record<string, (number | null)[]>,
+  filterDate: string,
+): FuturesPosition[] {
+  const refDate = new Date(filterDate + 'T12:00:00');
+  const prevMonthLastBD = lastBusinessDayOfPrevMonth(refDate);
+  const prevMonthStr = toDateStr(prevMonthLastBD);
+
+  const result: FuturesPosition[] = [];
+
+  let totalValorT = 0;
+  let totalValorT1 = 0;
+  let totalPnlMonth = 0;
+  let totalPnlInception = 0;
+
+  for (const pos of positions) {
+    const multiplier = CONTRACT_MULTIPLIERS[pos.asset] ?? 1;
+    const dirSign = DIRECTION_SIGN[pos.direction] ?? 1;
+    const assetPrices = prices[pos.asset];
+
+    if (!assetPrices) continue;
+
+    // Current price: last available on or before filterDate
+    const current = findPrice(dates, assetPrices, filterDate);
+
+    // Precio previo logic:
+    // If position opened in the current month → use entry_price
+    // If older → use last business day of previous month's price
+    const entryMonth = pos.entry_date.slice(0, 7); // "YYYY-MM"
+    const filterMonth = filterDate.slice(0, 7);
+
+    let precioPrevio: number | null;
+    let precioPrevioDate: string | null;
+
+    if (entryMonth === filterMonth) {
+      // Opened this month — previo = entry price
+      precioPrevio = pos.entry_price;
+      precioPrevioDate = pos.entry_date;
+    } else {
+      // Older position — previo = last BD of prev month
+      const prev = findPrice(dates, assetPrices, prevMonthStr);
+      precioPrevio = prev.price;
+      precioPrevioDate = prev.date;
+    }
+
+    const currentPrice = current.price;
+    const entryPrice = pos.entry_price;
+
+    // Calculations
+    const valorT = currentPrice != null ? pos.nominal * multiplier * currentPrice : null;
+    const valorT1 = precioPrevio != null ? pos.nominal * multiplier * precioPrevio : null;
+
+    const pnlInception =
+      currentPrice != null
+        ? (currentPrice - entryPrice) * pos.nominal * multiplier * dirSign
+        : null;
+
+    const pnlMonth =
+      currentPrice != null && precioPrevio != null
+        ? (currentPrice - precioPrevio) * pos.nominal * multiplier * dirSign
+        : null;
+
+    if (valorT != null) totalValorT += valorT;
+    if (valorT1 != null) totalValorT1 += valorT1;
+    if (pnlMonth != null) totalPnlMonth += pnlMonth;
+    if (pnlInception != null) totalPnlInception += pnlInception;
+
+    result.push({
+      id: pos.id,
+      asset: pos.asset,
+      contract: pos.contract,
+      direction: pos.direction,
+      nominal: pos.nominal,
+      multiplier,
+      entry_price: entryPrice,
+      entry_date: pos.entry_date,
+      current_price: currentPrice,
+      current_price_date: current.date,
+      precio_previo: precioPrevio,
+      precio_previo_date: precioPrevioDate,
+      valor_t: valorT != null ? Math.round(valorT) : null,
+      valor_t1: valorT1 != null ? Math.round(valorT1) : null,
+      pnl_inception: pnlInception != null ? Math.round(pnlInception) : null,
+      pnl_month: pnlMonth != null ? Math.round(pnlMonth) : null,
+      price_unit: PRICE_UNITS[pos.asset] ?? '',
+      active: pos.active,
+      closed_date: pos.closed_date,
+      closed_price: pos.closed_price,
+      rolled_to: pos.rolled_to,
+    });
+  }
+
+  // Totals row
+  result.push({
+    id: '',
+    asset: 'Total',
+    contract: '',
+    direction: '' as 'LONG',
+    nominal: 0,
+    multiplier: 0,
+    entry_price: 0,
+    entry_date: '',
+    current_price: null,
+    current_price_date: null,
+    precio_previo: null,
+    precio_previo_date: null,
+    valor_t: Math.round(totalValorT),
+    valor_t1: Math.round(totalValorT1),
+    pnl_inception: Math.round(totalPnlInception),
+    pnl_month: Math.round(totalPnlMonth),
+    price_unit: '',
+    active: true,
+    closed_date: null,
+    closed_price: null,
+    rolled_to: null,
+  });
+
+  return result;
+}
+
+/**
+ * Execute a roll: returns close update + new position record.
+ */
+export function executeRoll(
+  oldPosition: FuturesPositionRow,
+  newContract: string,
+  rollPrice: number,
+  rollDate: string,
+  newEntryPrice?: number,
+): { closeUpdate: Record<string, unknown>; newPosition: Partial<FuturesPositionRow> } {
+  return {
+    closeUpdate: {
+      active: false,
+      closed_date: rollDate,
+      closed_price: rollPrice,
+      rolled_to: newContract,
+    },
+    newPosition: {
+      asset: oldPosition.asset,
+      contract: newContract,
+      direction: oldPosition.direction,
+      nominal: oldPosition.nominal,
+      entry_price: newEntryPrice ?? rollPrice,
+      entry_date: rollDate,
+      active: true,
+      company_id: oldPosition.company_id,
+    },
+  };
+}

--- a/src/lib/risk/supabaseRisk.ts
+++ b/src/lib/risk/supabaseRisk.ts
@@ -1,0 +1,228 @@
+/* eslint-disable no-restricted-syntax, no-plusplus, no-continue */
+/**
+ * Direct Supabase queries for risk management data.
+ * Replaces Django backend calls — reads from xerenity schema tables.
+ */
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+
+const supabase = createClientComponentClient();
+const SCHEMA = 'xerenity';
+
+// ── Risk Prices (global market data) ──
+
+export interface RiskPriceRow {
+  date: string;
+  asset: string;
+  price: number;
+  contract: string | null;
+}
+
+export async function fetchRiskPrices(
+  startDate: string,
+  endDate: string,
+): Promise<RiskPriceRow[]> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_prices')
+    .select('date, asset, price, contract')
+    .gte('date', startDate)
+    .lte('date', endDate)
+    .order('date', { ascending: true });
+
+  if (error) throw new Error(`Failed to fetch risk_prices: ${error.message}`);
+  return (data ?? []) as RiskPriceRow[];
+}
+
+/**
+ * Pivot raw price rows into a date-indexed structure.
+ * Returns { dates: string[], prices: { MAIZ: number[], AZUCAR: number[], ... } }
+ */
+export function pivotPrices(rows: RiskPriceRow[]): {
+  dates: string[];
+  prices: Record<string, (number | null)[]>;
+  contracts: Record<string, string>;
+} {
+  const dateSet = new Set<string>();
+  const assetSet = new Set<string>();
+  const priceMap = new Map<string, Map<string, number>>();
+  const contractMap = new Map<string, string>();
+
+  for (const row of rows) {
+    dateSet.add(row.date);
+    assetSet.add(row.asset);
+
+    if (!priceMap.has(row.date)) priceMap.set(row.date, new Map());
+    priceMap.get(row.date)!.set(row.asset, row.price);
+
+    if (row.contract) contractMap.set(row.asset, row.contract);
+  }
+
+  const dates = Array.from(dateSet).sort();
+  const assets = Array.from(assetSet).sort();
+
+  const prices: Record<string, (number | null)[]> = {};
+  for (const asset of assets) {
+    prices[asset] = dates.map((d) => priceMap.get(d)?.get(asset) ?? null);
+  }
+
+  const contracts: Record<string, string> = {};
+  contractMap.forEach((contract, asset) => {
+    contracts[asset] = contract;
+  });
+
+  return { dates, prices, contracts };
+}
+
+// ── Risk Positions (per-company) ──
+
+export interface RiskPositionRow {
+  asset: string;
+  position: number;
+  position_type: 'benchmark' | 'gr';
+  weight: number;
+  company_id: string | null;
+  portfolio_id: string | null;
+}
+
+export async function fetchRiskPositions(
+  companyId?: string,
+): Promise<RiskPositionRow[]> {
+  let query = supabase
+    .schema(SCHEMA)
+    .from('risk_positions')
+    .select('*')
+    .order('asset', { ascending: true });
+
+  if (companyId) query = query.eq('company_id', companyId);
+
+  const { data, error } = await query;
+  if (error) throw new Error(`Failed to fetch risk_positions: ${error.message}`);
+  return (data ?? []) as RiskPositionRow[];
+}
+
+// ── Portfolio Config (per-company) ──
+
+export interface PortfolioConfigRow {
+  id: string;
+  price_date_start: string | null;
+  price_date_end: string | null;
+  rolling_window: number | null;
+  confidence_level: number | null;
+  company_id: string | null;
+}
+
+export async function fetchPortfolioConfig(
+  companyId?: string,
+): Promise<PortfolioConfigRow | null> {
+  let query = supabase
+    .schema(SCHEMA)
+    .from('risk_portfolio_config')
+    .select('*')
+    .limit(1);
+
+  if (companyId) query = query.eq('company_id', companyId);
+
+  const { data, error } = await query;
+  if (error) throw new Error(`Failed to fetch risk_portfolio_config: ${error.message}`);
+  return data?.[0] ?? null;
+}
+
+// ── Futures Portfolio (per-company) ──
+
+export interface FuturesPositionRow {
+  id: string;
+  asset: string;
+  contract: string;
+  direction: 'LONG' | 'SHORT';
+  nominal: number;
+  entry_price: number;
+  entry_date: string;
+  active: boolean;
+  closed_date: string | null;
+  closed_price: number | null;
+  rolled_to: string | null;
+  company_id: string | null;
+  portfolio_id: string | null;
+}
+
+export async function fetchFuturesPositionsFromDB(
+  companyId?: string,
+  activeOnly = true,
+): Promise<FuturesPositionRow[]> {
+  let query = supabase
+    .schema(SCHEMA)
+    .from('risk_futures_portfolio')
+    .select('*')
+    .order('entry_date', { ascending: false });
+
+  if (activeOnly) query = query.eq('active', true);
+  if (companyId) query = query.eq('company_id', companyId);
+
+  const { data, error } = await query;
+  if (error) throw new Error(`Failed to fetch risk_futures_portfolio: ${error.message}`);
+  return (data ?? []) as FuturesPositionRow[];
+}
+
+// ── CRUD for Futures Positions ──
+
+export async function upsertFuturesPositionsDB(
+  records: Partial<FuturesPositionRow>[],
+): Promise<void> {
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_futures_portfolio')
+    .upsert(records, { onConflict: 'company_id,asset,contract,entry_date,direction' });
+
+  if (error) throw new Error(`Failed to upsert futures positions: ${error.message}`);
+}
+
+export async function closeFuturesPositionDB(
+  positionId: string,
+  closedDate: string,
+  closedPrice: number,
+  rolledTo?: string,
+): Promise<void> {
+  const payload: Record<string, unknown> = {
+    active: false,
+    closed_date: closedDate,
+    closed_price: closedPrice,
+  };
+  if (rolledTo) payload.rolled_to = rolledTo;
+
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_futures_portfolio')
+    .update(payload)
+    .eq('id', positionId);
+
+  if (error) throw new Error(`Failed to close futures position: ${error.message}`);
+}
+
+export async function deleteFuturesPositionDB(positionId: string): Promise<void> {
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_futures_portfolio')
+    .delete()
+    .eq('id', positionId);
+
+  if (error) throw new Error(`Failed to delete futures position: ${error.message}`);
+}
+
+export async function editFuturesPositionDB(
+  positionId: string,
+  updates: Record<string, unknown>,
+): Promise<void> {
+  const allowed = ['asset', 'contract', 'direction', 'nominal', 'entry_price', 'entry_date'];
+  const payload: Record<string, unknown> = {};
+  for (const key of allowed) {
+    if (key in updates) payload[key] = updates[key];
+  }
+
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_futures_portfolio')
+    .update(payload)
+    .eq('id', positionId);
+
+  if (error) throw new Error(`Failed to edit futures position: ${error.message}`);
+}

--- a/src/lib/risk/varCalculator.ts
+++ b/src/lib/risk/varCalculator.ts
@@ -1,0 +1,214 @@
+/* eslint-disable no-plusplus, no-continue, no-restricted-syntax, no-restricted-globals, @typescript-eslint/no-use-before-define */
+/**
+ * VaR (Value at Risk) calculator — TypeScript port of var_engine/var_calculator.py
+ *
+ * Parametric VaR using variance-covariance method:
+ *   - Log returns
+ *   - Rolling volatility (180-day window, min 30 observations)
+ *   - Z-score lookup (no external library needed)
+ */
+
+// Z-scores for common confidence levels (from scipy.stats.norm.ppf)
+const Z_SCORES: Record<number, number> = {
+  0.90: 1.2816,
+  0.95: 1.6449,
+  0.99: 2.3263,
+};
+
+export function getZScore(confidence: number): number {
+  return Z_SCORES[confidence] ?? 2.3263; // default 99%
+}
+
+/**
+ * Calculate log returns: ln(price[t] / price[t-1])
+ * Skips nulls — returns null where price or previous price is missing.
+ */
+export function calculateLogReturns(prices: (number | null)[]): (number | null)[] {
+  const returns: (number | null)[] = [null]; // first element has no return
+  for (let i = 1; i < prices.length; i++) {
+    const prev = prices[i - 1];
+    const curr = prices[i];
+    if (prev != null && curr != null && prev > 0 && curr > 0) {
+      returns.push(Math.log(curr / prev));
+    } else {
+      returns.push(null);
+    }
+  }
+  return returns;
+}
+
+/**
+ * Calculate standard deviation of non-null values.
+ * Returns null if fewer than minPeriods non-null values.
+ */
+function stdDev(values: (number | null)[], minPeriods = 30): number | null {
+  const valid = values.filter((v): v is number => v != null);
+  if (valid.length < minPeriods) return null;
+
+  const n = valid.length;
+  const mean = valid.reduce((a, b) => a + b, 0) / n;
+  const variance = valid.reduce((sum, v) => sum + (v - mean) ** 2, 0) / (n - 1);
+  return Math.sqrt(variance);
+}
+
+/**
+ * Calculate rolling standard deviation over a window.
+ * Each output[i] = std(returns[i-window+1 ... i]) with at least minPeriods non-null values.
+ */
+export function calculateRollingStd(
+  returns: (number | null)[],
+  window = 180,
+  minPeriods = 30,
+): (number | null)[] {
+  const result: (number | null)[] = [];
+  for (let i = 0; i < returns.length; i++) {
+    if (i < minPeriods - 1) {
+      result.push(null);
+      continue;
+    }
+    const start = Math.max(0, i - window + 1);
+    const windowSlice = returns.slice(start, i + 1);
+    result.push(stdDev(windowSlice, minPeriods));
+  }
+  return result;
+}
+
+/**
+ * Calculate VaR factors for multiple assets.
+ * Returns rolling VaR factor (z_score × volatility) per date per asset.
+ */
+export function calculateVarSeries(
+  prices: Record<string, (number | null)[]>,
+  window = 180,
+  confidence = 0.99,
+): {
+  varFactors: Record<string, (number | null)[]>;
+  returns: Record<string, (number | null)[]>;
+} {
+  const z = getZScore(confidence);
+  const varFactors: Record<string, (number | null)[]> = {};
+  const allReturns: Record<string, (number | null)[]> = {};
+
+  for (const [asset, assetPrices] of Object.entries(prices)) {
+    const rets = calculateLogReturns(assetPrices);
+    allReturns[asset] = rets;
+    const rollingVol = calculateRollingStd(rets, window);
+    varFactors[asset] = rollingVol.map((vol) => (vol != null ? vol * z : null));
+  }
+
+  return { varFactors, returns: allReturns };
+}
+
+/**
+ * Get the latest (last non-null) VaR factor per asset as a percentage.
+ */
+export function getLatestVarFactors(
+  varFactors: Record<string, (number | null)[]>,
+): Record<string, number | null> {
+  const result: Record<string, number | null> = {};
+  for (const [asset, factors] of Object.entries(varFactors)) {
+    let last: number | null = null;
+    for (let i = factors.length - 1; i >= 0; i--) {
+      if (factors[i] != null) {
+        last = factors[i]! * 100; // as percentage
+        break;
+      }
+    }
+    result[asset] = last;
+  }
+  return result;
+}
+
+/**
+ * Calculate covariance matrix from returns (pairwise, last `window` observations).
+ * Returns { covariance: Record<asset, Record<asset, number>>, correlation: same }
+ */
+export function calculateMatrices(
+  returns: Record<string, (number | null)[]>,
+  window = 180,
+  minPeriods = 20,
+): {
+  covariance: Record<string, Record<string, number | null>>;
+  correlation: Record<string, Record<string, number | null>>;
+  observations: Record<string, number>;
+} {
+  const assets = Object.keys(returns);
+  const len = returns[assets[0]]?.length ?? 0;
+  const startIdx = Math.max(0, len - window);
+
+  // Get windowed returns
+  const windowed: Record<string, (number | null)[]> = {};
+  for (const asset of assets) {
+    windowed[asset] = returns[asset].slice(startIdx);
+  }
+
+  // Count observations per asset
+  const observations: Record<string, number> = {};
+  for (const asset of assets) {
+    observations[asset] = windowed[asset].filter((v) => v != null).length;
+  }
+
+  // Pairwise covariance
+  const covariance: Record<string, Record<string, number | null>> = {};
+  const correlation: Record<string, Record<string, number | null>> = {};
+
+  for (const a of assets) {
+    covariance[a] = {};
+    correlation[a] = {};
+    for (const b of assets) {
+      const pairs: { ra: number; rb: number }[] = [];
+      for (let i = 0; i < windowed[a].length; i++) {
+        const va = windowed[a][i];
+        const vb = windowed[b][i];
+        if (va != null && vb != null) {
+          pairs.push({ ra: va, rb: vb });
+        }
+      }
+
+      if (pairs.length < minPeriods) {
+        covariance[a][b] = null;
+        correlation[a][b] = null;
+        continue;
+      }
+
+      const n = pairs.length;
+      const meanA = pairs.reduce((s, p) => s + p.ra, 0) / n;
+      const meanB = pairs.reduce((s, p) => s + p.rb, 0) / n;
+      const cov = pairs.reduce((s, p) => s + (p.ra - meanA) * (p.rb - meanB), 0) / (n - 1);
+      covariance[a][b] = safeRound(cov, 10);
+
+      // Correlation
+      const stdA = Math.sqrt(pairs.reduce((s, p) => s + (p.ra - meanA) ** 2, 0) / (n - 1));
+      const stdB = Math.sqrt(pairs.reduce((s, p) => s + (p.rb - meanB) ** 2, 0) / (n - 1));
+      if (stdA > 0 && stdB > 0) {
+        correlation[a][b] = safeRound(cov / (stdA * stdB), 4);
+      } else {
+        correlation[a][b] = null;
+      }
+    }
+  }
+
+  return { covariance, correlation, observations };
+}
+
+/**
+ * Find the last non-null price on or before a target date.
+ */
+export function findPrice(
+  dates: string[],
+  prices: (number | null)[],
+  targetDate: string,
+): { price: number | null; date: string | null } {
+  for (let i = dates.length - 1; i >= 0; i--) {
+    if (dates[i] <= targetDate && prices[i] != null) {
+      return { price: prices[i], date: dates[i] };
+    }
+  }
+  return { price: null, date: null };
+}
+
+function safeRound(value: number | null, decimals = 3): number | null {
+  if (value == null || isNaN(value)) return null;
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}

--- a/src/models/risk/riskApi.ts
+++ b/src/models/risk/riskApi.ts
@@ -1,114 +1,276 @@
+/* eslint-disable no-restricted-syntax, prefer-template */
 /**
- * Risk Management API client — calls the pysdk Django server.
- * Sends Supabase JWT in Authorization header for multi-tenant isolation.
- * Super admins can pass companyId to view other companies' portfolios.
+ * Risk Management API — frontend-only calculations.
+ * Reads data directly from Supabase and computes VaR, exposure, and P&L locally.
+ * No dependency on Fly.io/Django backend for the Commodities module.
  */
 import type {
-  RiskManagementResponse, RollingVarResponse, BenchmarkFactorsResponse,
+  RollingVarResponse, BenchmarkFactorsResponse,
   ExposureResponse, ExposureParams,
   FuturesPortfolioResponse, NewFuturesPosition, FuturesRollParams, FuturesCloseParams, FuturesEditParams,
 } from 'src/types/risk';
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import {
+  fetchRiskPrices, pivotPrices,
+  fetchFuturesPositionsFromDB, upsertFuturesPositionsDB,
+  closeFuturesPositionDB, deleteFuturesPositionDB, editFuturesPositionDB,
+} from 'src/lib/risk/supabaseRisk';
+import {
+  calculateVarSeries, getLatestVarFactors, calculateMatrices,
+  findPrice, getZScore,
+} from 'src/lib/risk/varCalculator';
+import { calcularExposicionTotal } from 'src/lib/risk/exposureCalculator';
+import { calculateFuturesPortfolio, executeRoll } from 'src/lib/risk/futuresCalculator';
 
-const BASE_URL = process.env.NEXT_PUBLIC_PYSDK_URL || 'https://pysdk.fly.dev';
-const supabase = createClientComponentClient();
-
-async function postJson<T>(url: string, body: Record<string, unknown>): Promise<T> {
-  const { data: { session } } = await supabase.auth.getSession();
-
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (session?.access_token) {
-    headers.Authorization = `Bearer ${session.access_token}`;
-  }
-
-  const res = await fetch(url, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(text || `Request failed: ${res.status}`);
-  }
-  const json = await res.json();
-  return json.body ?? json;
-}
-
-/** Helper: add company_id to body if provided (super_admin company selector) */
-function withCompany(base: Record<string, unknown>, companyId?: string): Record<string, unknown> {
-  if (companyId) return { ...base, company_id: companyId };
-  return base;
-}
-
-export const fetchRiskManagement = (
-  filterDate: string,
-  portfolioId?: string,
-  companyId?: string,
-): Promise<RiskManagementResponse> => {
-  const body: Record<string, unknown> = { filter_date: filterDate };
-  if (portfolioId) body.portfolio_id = portfolioId;
-  return postJson(`${BASE_URL}/risk_management`, withCompany(body, companyId));
+const UNITS: Record<string, string> = {
+  MAIZ: 'TONS', AZUCAR: 'TONS', CACAO: 'TONS', USD: 'USD/COP',
 };
 
-export const fetchRollingVar = (
-  filterDate: string,
-  confidenceLevel = 0.99
-): Promise<RollingVarResponse> =>
-  postJson(`${BASE_URL}/risk_rolling_var`, { filter_date: filterDate, confidence_level: confidenceLevel });
+// ── Helper: get date range for price history ──
 
-export const fetchBenchmarkFactors = (
-  filterDate: string,
-  confidenceLevel = 0.99
-): Promise<BenchmarkFactorsResponse> =>
-  postJson(`${BASE_URL}/risk_benchmark_factors`, { filter_date: filterDate, confidence_level: confidenceLevel });
+function getStartDate(filterDate: string, daysBack: number): string {
+  const d = new Date(filterDate + 'T12:00:00');
+  d.setDate(d.getDate() - daysBack);
+  return d.toISOString().slice(0, 10);
+}
 
-export const fetchExposure = (
+function lastBusinessDayOfPrevMonth(filterDate: string): string {
+  const d = new Date(filterDate + 'T12:00:00');
+  const first = new Date(d.getFullYear(), d.getMonth(), 1);
+  const last = new Date(first.getTime() - 86400000);
+  const wd = last.getDay();
+  if (wd === 0) last.setDate(last.getDate() - 2);
+  else if (wd === 6) last.setDate(last.getDate() - 1);
+  return last.toISOString().slice(0, 10);
+}
+
+// ── Benchmark Factors ──
+
+export async function fetchBenchmarkFactors(
+  filterDate: string,
+  confidenceLevel = 0.99,
+): Promise<BenchmarkFactorsResponse> {
+  const startDate = getStartDate(filterDate, 400); // ~13 months for 180d rolling + prices
+  const rows = await fetchRiskPrices(startDate, filterDate);
+  const { dates, prices, contracts } = pivotPrices(rows);
+  const assets = Object.keys(prices);
+
+  if (assets.length === 0) throw new Error('No hay precios disponibles');
+
+  const { varFactors, returns } = calculateVarSeries(prices, 180, confidenceLevel);
+  const latestFactors = getLatestVarFactors(varFactors);
+  const { covariance, correlation, observations } = calculateMatrices(returns, 180);
+
+  // Price start: last business day of previous month
+  const priceStartDate = lastBusinessDayOfPrevMonth(filterDate);
+
+  const factors: Record<string, {
+    factor_var_diario: number | null;
+    daily_variance: number | null;
+    price_start: number | null;
+    price_end: number | null;
+    factor_unit: string;
+    contract?: string;
+  }> = {};
+
+  const actualStartDates: string[] = [];
+  const actualEndDates: string[] = [];
+
+  for (const asset of assets) {
+    const pStart = findPrice(dates, prices[asset], priceStartDate);
+    const pEnd = findPrice(dates, prices[asset], filterDate);
+    if (pStart.date) actualStartDates.push(pStart.date);
+    if (pEnd.date) actualEndDates.push(pEnd.date);
+
+    const dailyVar = covariance[asset]?.[asset] ?? null;
+
+    factors[asset] = {
+      factor_var_diario: latestFactors[asset] ?? null,
+      daily_variance: dailyVar,
+      price_start: pStart.price != null ? Math.round(pStart.price * 10000) / 10000 : null,
+      price_end: pEnd.price != null ? Math.round(pEnd.price * 10000) / 10000 : null,
+      factor_unit: UNITS[asset] ?? '',
+      contract: contracts[asset],
+    };
+  }
+
+  const realStart = actualStartDates.length > 0 ? actualStartDates.sort().pop()! : priceStartDate;
+  const realEnd = actualEndDates.length > 0 ? actualEndDates.sort().pop()! : filterDate;
+
+  // Covariance period
+  const len = dates.length;
+  const covStart = len > 180 ? dates[len - 180] : dates[0];
+  const covEnd = dates[len - 1];
+
+  return {
+    factors,
+    covariance_matrix: covariance,
+    correlation_matrix: correlation,
+    assets,
+    contracts,
+    period: { start: realStart, end: realEnd },
+    covariance_period: { start: covStart, end: covEnd, observations },
+    confidence_level: confidenceLevel,
+    z_score: Math.round(getZScore(confidenceLevel) * 10000) / 10000,
+  };
+}
+
+// ── Rolling VaR ──
+
+export async function fetchRollingVar(
+  filterDate: string,
+  confidenceLevel = 0.99,
+): Promise<RollingVarResponse> {
+  const startDate = getStartDate(filterDate, 365);
+  const rows = await fetchRiskPrices(startDate, filterDate);
+  const { dates, prices, contracts } = pivotPrices(rows);
+
+  if (dates.length === 0) throw new Error('No hay precios disponibles');
+
+  const { varFactors } = calculateVarSeries(prices, 180, confidenceLevel);
+
+  // Rolling VaR in $ = var_factor × price
+  const rollingVar: Record<string, (number | null)[]> = {};
+  for (const [asset, factors] of Object.entries(varFactors)) {
+    const assetPrices = prices[asset];
+    rollingVar[asset] = factors.map((f, i) => {
+      const p = assetPrices[i];
+      if (f == null || p == null) return null;
+      return Math.round(f * p * 100) / 100;
+    });
+  }
+
+  return { dates, prices, rolling_var: rollingVar, contracts };
+}
+
+// ── Exposure ──
+
+export async function fetchExposure(
   filterDate: string,
   exposureParams: ExposureParams,
-  companyId?: string,
-): Promise<ExposureResponse> =>
-  postJson(`${BASE_URL}/risk_exposure`, withCompany({ filter_date: filterDate, exposure_params: exposureParams }, companyId));
+): Promise<ExposureResponse> {
+  // Fetch latest prices to override params
+  const startDate = getStartDate(filterDate, 60);
+  const rows = await fetchRiskPrices(startDate, filterDate);
+  const { dates, prices, contracts } = pivotPrices(rows);
+
+  const priceMap: Record<string, string> = {
+    AZUCAR: 'precio_azucar_cent_lb',
+    MAIZ: 'precio_maiz_cent_bu',
+    CACAO: 'precio_cocoa_usd_ton',
+    USD: 'trm',
+  };
+
+  const marketPrices: Record<string, { value: number; date: string; source: string; contract?: string }> = {};
+  const params = { ...exposureParams };
+
+  for (const [dbCol, paramKey] of Object.entries(priceMap)) {
+    if (prices[dbCol]) {
+      const found = findPrice(dates, prices[dbCol], filterDate);
+      if (found.price != null && found.date != null) {
+        marketPrices[paramKey] = {
+          value: Math.round(found.price * 10000) / 10000,
+          date: found.date,
+          source: dbCol,
+          contract: contracts[dbCol],
+        };
+        (params as Record<string, unknown>)[paramKey] = found.price;
+      }
+    }
+  }
+
+  const result = calcularExposicionTotal(params);
+  return {
+    ...result,
+    market_prices: marketPrices,
+    exposicion_ventas_intl: result.exposicion_real_usd,
+    exposicion_pen: 0,
+  } as unknown as ExposureResponse;
+}
 
 // ── Futures Portfolio ──
 
-export const fetchFuturesPortfolio = (
+export async function fetchFuturesPortfolio(
   filterDate: string,
   activeOnly = true,
   companyId?: string,
-): Promise<FuturesPortfolioResponse> =>
-  postJson(`${BASE_URL}/risk_futures_portfolio`, withCompany({ filter_date: filterDate, active_only: activeOnly }, companyId));
+): Promise<FuturesPortfolioResponse> {
+  const positions = await fetchFuturesPositionsFromDB(companyId, activeOnly);
 
-export const upsertFuturesPositions = (
-  filterDate: string,
+  if (positions.length === 0) return { portfolio: [] };
+
+  const startDate = getStartDate(filterDate, 90);
+  const rows = await fetchRiskPrices(startDate, filterDate);
+  const { dates, prices } = pivotPrices(rows);
+
+  const portfolio = calculateFuturesPortfolio(positions, dates, prices, filterDate);
+  return { portfolio };
+}
+
+// ── Futures CRUD ──
+
+export async function upsertFuturesPositions(
+  _filterDate: string,
   positions: NewFuturesPosition[],
   companyId?: string,
-): Promise<{ status: string; count: number }> =>
-  postJson(`${BASE_URL}/risk_futures_portfolio_upsert`, withCompany({ filter_date: filterDate, positions }, companyId));
+): Promise<{ status: string; count: number }> {
+  const records = positions.map((p) => ({
+    ...p,
+    active: true,
+    ...(companyId ? { company_id: companyId } : {}),
+  }));
+  await upsertFuturesPositionsDB(records);
+  return { status: 'ok', count: positions.length };
+}
 
-export const rollFuturesPosition = (
-  filterDate: string,
+export async function rollFuturesPosition(
+  _filterDate: string,
   params: FuturesRollParams,
-  companyId?: string,
-): Promise<{ status: string; closed_position_id: string; new_position: unknown }> =>
-  postJson(`${BASE_URL}/risk_futures_portfolio_roll`, withCompany({ filter_date: filterDate, ...params }, companyId));
+): Promise<{ status: string; closed_position_id: string; new_position: unknown }> {
+  const positions = await fetchFuturesPositionsFromDB();
+  const oldPos = positions.find((p) => p.id === params.position_id);
+  if (!oldPos) throw new Error(`Position ${params.position_id} not found`);
 
-export const closeFuturesPosition = (
-  filterDate: string,
+  const { closeUpdate, newPosition } = executeRoll(
+    oldPos, params.new_contract, params.roll_price,
+    params.roll_date ?? new Date().toISOString().slice(0, 10),
+    params.new_entry_price,
+  );
+
+  await closeFuturesPositionDB(
+    params.position_id,
+    closeUpdate.closed_date as string,
+    closeUpdate.closed_price as number,
+    closeUpdate.rolled_to as string,
+  );
+  await upsertFuturesPositionsDB([newPosition]);
+
+  return { status: 'rolled', closed_position_id: params.position_id, new_position: newPosition };
+}
+
+export async function closeFuturesPosition(
+  _filterDate: string,
   params: FuturesCloseParams,
-  companyId?: string,
-): Promise<{ status: string; position_id: string }> =>
-  postJson(`${BASE_URL}/risk_futures_portfolio_close`, withCompany({ filter_date: filterDate, ...params }, companyId));
+): Promise<{ status: string; position_id: string }> {
+  await closeFuturesPositionDB(
+    params.position_id,
+    params.closed_date ?? new Date().toISOString().slice(0, 10),
+    params.closed_price,
+  );
+  return { status: 'closed', position_id: params.position_id };
+}
 
-export const deleteFuturesPosition = (
-  filterDate: string,
+export async function deleteFuturesPosition(
+  _filterDate: string,
   positionId: string,
-  companyId?: string,
-): Promise<{ status: string; position_id: string }> =>
-  postJson(`${BASE_URL}/risk_futures_portfolio_delete`, withCompany({ filter_date: filterDate, position_id: positionId }, companyId));
+): Promise<{ status: string; position_id: string }> {
+  await deleteFuturesPositionDB(positionId);
+  return { status: 'deleted', position_id: positionId };
+}
 
-export const editFuturesPosition = (
-  filterDate: string,
+export async function editFuturesPosition(
+  _filterDate: string,
   params: FuturesEditParams,
-  companyId?: string,
-): Promise<{ status: string; position_id: string; updated_fields: string[] }> =>
-  postJson(`${BASE_URL}/risk_futures_portfolio_edit`, withCompany({ filter_date: filterDate, ...params }, companyId));
+): Promise<{ status: string; position_id: string; updated_fields: string[] }> {
+  await editFuturesPositionDB(params.position_id, params.updates);
+  return { status: 'updated', position_id: params.position_id, updated_fields: Object.keys(params.updates) };
+}

--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -31,8 +31,8 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
-import { fetchRiskManagement, fetchRollingVar, fetchBenchmarkFactors, fetchExposure, fetchFuturesPortfolio, upsertFuturesPositions, rollFuturesPosition, closeFuturesPosition, deleteFuturesPosition, editFuturesPosition } from 'src/models/risk/riskApi';
-import type { RiskRow, RiskConfig, RollingVarResponse, BenchmarkFactorsResponse, ExposureParams, ExposureResponse, MarketPrice, FuturesPosition, NewFuturesPosition } from 'src/types/risk';
+import { fetchRollingVar, fetchBenchmarkFactors, fetchExposure, fetchFuturesPortfolio, upsertFuturesPositions, rollFuturesPosition, closeFuturesPosition, deleteFuturesPosition, editFuturesPosition } from 'src/models/risk/riskApi';
+import type { RollingVarResponse, BenchmarkFactorsResponse, ExposureParams, ExposureResponse, MarketPrice, FuturesPosition, NewFuturesPosition } from 'src/types/risk';
 import useAppStore from 'src/store';
 import type { Company } from 'src/types/user';
 
@@ -604,10 +604,6 @@ function RiskManagement() {
   const [activeTab, setActiveTab] = useState('benchmark');
   const [pageTabs, setPageTabs] = useState<TabItemType[]>(TAB_ITEMS);
   const [filterDate, setFilterDate] = useState(defaultDate());
-  const [, setLoading] = useState(false);
-  const [, setRows] = useState<RiskRow[]>([]);
-  const [, setConfig] = useState<RiskConfig | null>(null);
-  const [, setError] = useState<string | null>(null);
 
   // Methodology modal
   const [methModal, setMethModal] = useState<string | null>(null);
@@ -697,22 +693,7 @@ function RiskManagement() {
     );
   };
 
-  const handleCalculate = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await fetchRiskManagement(filterDate, undefined, selectedCompanyId);
-      setRows(data.risk_table);
-      setConfig(data.config);
-      toast.success('Cálculo completado');
-    } catch (e: unknown) {
-      const msg = (e as Error)?.message || 'Error calculando riesgos';
-      setError(msg);
-      toast.error(msg);
-    } finally {
-      setLoading(false);
-    }
-  }, [filterDate]);
+  // handleCalculate removed — benchmark factors loaded via tab useEffect below
 
   const handleFetchRolling = useCallback(async () => {
     setRollingLoading(true);
@@ -806,7 +787,7 @@ function RiskManagement() {
   const handleFetchExposure = useCallback(async () => {
     setExposureLoading(true);
     try {
-      const data = await fetchExposure(filterDate, exposureParams, selectedCompanyId);
+      const data = await fetchExposure(filterDate, exposureParams);
       setExposureResult(data);
 
       // Update local params with DB prices
@@ -831,7 +812,7 @@ function RiskManagement() {
   }, [filterDate, exposureParams]);
 
   useEffect(() => {
-    handleCalculate();
+    handleFetchBenchmarkFactors();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -875,7 +856,7 @@ function RiskManagement() {
         roll_price: parseFloat(rollPrice),
         new_entry_price: rollEntryPrice ? parseFloat(rollEntryPrice) : undefined,
         roll_date: futuresFilterDate,
-      }, selectedCompanyId);
+      });
       toast.success(`Roll completado: ${rollModal.contract} → ${rollContract}`);
       setRollModal(null);
       setRollContract('');
@@ -894,7 +875,7 @@ function RiskManagement() {
         position_id: closeModal.id,
         closed_price: parseFloat(closePrice),
         closed_date: futuresFilterDate,
-      }, selectedCompanyId);
+      });
       toast.success('Posición cerrada');
       setCloseModal(null);
       setClosePrice('');
@@ -908,7 +889,7 @@ function RiskManagement() {
     if (!pos.id) return;
     if (!window.confirm(`Eliminar posición ${pos.asset} ${pos.contract} ${pos.direction} x${pos.nominal}?`)) return;
     try {
-      await deleteFuturesPosition(futuresFilterDate, pos.id, selectedCompanyId);
+      await deleteFuturesPosition(futuresFilterDate, pos.id);
       toast.success('Posición eliminada');
       handleFetchFutures();
     } catch (e: unknown) {
@@ -919,7 +900,7 @@ function RiskManagement() {
   const handleEdit = useCallback(async () => {
     if (!editModal?.id || Object.keys(editFields).length === 0) return;
     try {
-      await editFuturesPosition(futuresFilterDate, { position_id: editModal.id, updates: editFields }, selectedCompanyId);
+      await editFuturesPosition(futuresFilterDate, { position_id: editModal.id, updates: editFields });
       toast.success('Posición actualizada');
       setEditModal(null);
       setEditFields({});

--- a/src/types/risk.ts
+++ b/src/types/risk.ts
@@ -132,6 +132,10 @@ export interface FuturesPosition {
   pnl_inception: number | null;
   pnl_month: number | null;
   price_unit: string | null;
+  active?: boolean | null;
+  closed_date?: string | null;
+  closed_price?: number | null;
+  rolled_to?: string | null;
 }
 
 export interface FuturesPortfolioResponse {


### PR DESCRIPTION
## Summary
#244
Eliminates the dependency on Fly.io/Django for the entire Commodities risk module. The frontend now reads prices directly from Supabase and computes everything locally in TypeScript.

## Architecture change
#244
```
BEFORE: Frontend → Fly.io (Python) → Supabase
AFTER:  Frontend → Supabase (direct) → Frontend (calculates in TS)
```

## New calculation engine (src/lib/risk/)

| File | Purpose |
|------|---------|
| supabaseRisk.ts | Direct Supabase queries (risk_prices, risk_positions, risk_futures_portfolio) |
| varCalculator.ts | VaR engine: log returns, rolling std, z-scores, covariance/correlation matrices |
| exposureCalculator.ts | Commodity exposure: sugar, corn, cocoa derivatives, packaging |
| futuresCalculator.ts | Futures P&L: valor_t, valor_t1, pnl_month, pnl_inception |

## What still uses Fly.io

Pricing module (NDF, IBR Swap, XCCY Swap, COLTES) — these require QuantLib which only runs in Python.

## Test plan

- [ ] Benchmark tab: factors, prices, VaR calculations match previous values
- [ ] Rolling VaR tab: chart displays correctly
- [ ] Matrices tab: covariance and correlation matrices
- [ ] Exposure tab: commodity exposure calculations
- [ ] Portafolio GR tab: futures positions with P&L
- [ ] CRUD operations on futures positions work via Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)