### PR TITLE
feat(risk): access control + company config + Exposición Natural

### DIFF
--- a/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
+++ b/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
@@ -117,6 +117,7 @@ const SidebarNavList = ({ currentPath }: SidebarNavProps) => {
             key={`${name}${path}`}
           />
         ))}
+      {(userRole === 'super_admin' || userRole === 'corp_admin') && (
       <SubNavItem
         name="Riesgos"
         icon={faScaleBalanced}
@@ -125,7 +126,7 @@ const SidebarNavList = ({ currentPath }: SidebarNavProps) => {
           currentPath.includes('/loans') ||
           currentPath.includes('/ndf-pricer') ||
           currentPath.includes('/ibr-swap') ||
-          currentPath.includes('/xccy-swap') ||
+          currentPath.includes('/xcxy-swap') ||
           currentPath.includes('/portfolio') ||
           currentPath.includes('/coltes-calculator') ||
           currentPath.includes('/tes-portfolio')
@@ -141,6 +142,7 @@ const SidebarNavList = ({ currentPath }: SidebarNavProps) => {
           />
         ))}
       </SubNavItem>
+      )}
       <SubNavItem
         name="Monedas"
         icon={faDollarSign}

--- a/src/lib/risk/companyConfig.ts
+++ b/src/lib/risk/companyConfig.ts
@@ -1,0 +1,153 @@
+/**
+ * Company-specific risk configuration.
+ * Reads from xerenity.risk_company_config to determine which commodities
+ * a company manages, their contract specs, and exposure parameters.
+ */
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+
+const supabase = createClientComponentClient();
+const SCHEMA = 'xerenity';
+
+export interface CommodityConfig {
+  asset: string;
+  unit: string;
+  price_unit: string;
+  contract_multiplier: number;
+  chart_color: string;
+  exchange: string;
+  symbol: string;
+}
+
+export interface RiskCompanyConfig {
+  id: string;
+  company_id: string;
+  commodities: CommodityConfig[];
+  currency_asset: string;
+  currency_unit: string;
+  exposure_defaults: Record<string, unknown>;
+  rolling_window: number;
+  confidence_level: number;
+}
+
+/**
+ * Fetch risk configuration for a specific company.
+ * Returns null if the company has no risk config (not onboarded for risk).
+ */
+export async function fetchCompanyRiskConfig(
+  companyId: string,
+): Promise<RiskCompanyConfig | null> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_company_config')
+    .select('*')
+    .eq('company_id', companyId)
+    .limit(1);
+
+  if (error) throw new Error(`Failed to fetch risk_company_config: ${error.message}`);
+  if (!data || data.length === 0) return null;
+
+  const row = data[0];
+  return {
+    id: row.id,
+    company_id: row.company_id,
+    commodities: (row.commodities ?? []) as CommodityConfig[],
+    currency_asset: row.currency_asset ?? 'USD',
+    currency_unit: row.currency_unit ?? 'USD/COP',
+    exposure_defaults: (row.exposure_defaults ?? {}) as Record<string, unknown>,
+    rolling_window: row.rolling_window ?? 180,
+    confidence_level: row.confidence_level != null ? Number(row.confidence_level) : 0.99,
+  };
+}
+
+function parseConfigRow(row: Record<string, unknown>): RiskCompanyConfig {
+  return {
+    id: row.id as string,
+    company_id: row.company_id as string,
+    commodities: (row.commodities ?? []) as CommodityConfig[],
+    currency_asset: (row.currency_asset as string) ?? 'USD',
+    currency_unit: (row.currency_unit as string) ?? 'USD/COP',
+    exposure_defaults: (row.exposure_defaults ?? {}) as Record<string, unknown>,
+    rolling_window: (row.rolling_window as number) ?? 180,
+    confidence_level: row.confidence_level != null ? Number(row.confidence_level) : 0.99,
+  };
+}
+
+/**
+ * Save/update risk configuration for a company.
+ */
+export async function saveCompanyRiskConfig(
+  companyId: string,
+  commodities: CommodityConfig[],
+): Promise<RiskCompanyConfig> {
+  // Try insert first, then update if exists
+  const { data: insertData, error: insertError } = await supabase
+    .schema(SCHEMA)
+    .from('risk_company_config')
+    .insert({ company_id: companyId, commodities })
+    .select('*')
+    .single();
+
+  if (insertError) {
+    // If conflict (already exists), update instead
+    const { data: updateData, error: updateError } = await supabase
+      .schema(SCHEMA)
+      .from('risk_company_config')
+      .update({ commodities, updated_at: new Date().toISOString() })
+      .eq('company_id', companyId)
+      .select('*')
+      .single();
+
+    if (updateError) throw new Error(`Failed to save config: ${updateError.message}`);
+    return parseConfigRow(updateData);
+  }
+
+  return parseConfigRow(insertData);
+}
+
+// ── Predefined commodity templates ──
+
+export const COMMODITY_TEMPLATES: CommodityConfig[] = [
+  { asset: 'MAIZ', unit: 'TONS', price_unit: 'cents/bu', contract_multiplier: 5000, chart_color: '#f59e0b', exchange: 'CME', symbol: 'ZC' },
+  { asset: 'AZUCAR', unit: 'TONS', price_unit: 'cents/lb', contract_multiplier: 112000, chart_color: '#10b981', exchange: 'ICE', symbol: 'SB' },
+  { asset: 'CACAO', unit: 'TONS', price_unit: 'USD/ton', contract_multiplier: 10, chart_color: '#8b5cf6', exchange: 'ICE', symbol: 'CC' },
+  { asset: 'CAFE', unit: 'TONS', price_unit: 'cents/lb', contract_multiplier: 37500, chart_color: '#78350f', exchange: 'ICE', symbol: 'KC' },
+  { asset: 'PETROLEO', unit: 'BBL', price_unit: 'USD/bbl', contract_multiplier: 1000, chart_color: '#1e293b', exchange: 'NYMEX', symbol: 'CL' },
+  { asset: 'TRIGO', unit: 'TONS', price_unit: 'cents/bu', contract_multiplier: 5000, chart_color: '#d97706', exchange: 'CME', symbol: 'ZW' },
+  { asset: 'SOYA', unit: 'TONS', price_unit: 'cents/bu', contract_multiplier: 5000, chart_color: '#059669', exchange: 'CME', symbol: 'ZS' },
+];
+
+// ── Helpers to extract config maps ──
+
+export function getAssetList(config: RiskCompanyConfig): string[] {
+  return config.commodities.map((c) => c.asset);
+}
+
+export function getAssetsWithCurrency(config: RiskCompanyConfig): string[] {
+  return [...getAssetList(config), config.currency_asset];
+}
+
+export function getChartColors(config: RiskCompanyConfig): Record<string, string> {
+  const colors: Record<string, string> = {};
+  config.commodities.forEach((c) => { colors[c.asset] = c.chart_color; });
+  colors[config.currency_asset] = '#3b82f6'; // default blue for currency
+  return colors;
+}
+
+export function getMultipliers(config: RiskCompanyConfig): Record<string, number> {
+  const mult: Record<string, number> = {};
+  config.commodities.forEach((c) => { mult[c.asset] = c.contract_multiplier; });
+  return mult;
+}
+
+export function getUnits(config: RiskCompanyConfig): Record<string, string> {
+  const units: Record<string, string> = {};
+  config.commodities.forEach((c) => { units[c.asset] = c.unit; });
+  units[config.currency_asset] = config.currency_unit;
+  return units;
+}
+
+export function getPriceUnits(config: RiskCompanyConfig): Record<string, string> {
+  const units: Record<string, string> = {};
+  config.commodities.forEach((c) => { units[c.asset] = c.price_unit; });
+  return units;
+}

--- a/src/lib/risk/futuresCalculator.ts
+++ b/src/lib/risk/futuresCalculator.ts
@@ -7,13 +7,15 @@
 
 import type { FuturesPosition } from 'src/types/risk';
 import type { FuturesPositionRow } from './supabaseRisk';
+import type { CommodityConfig } from './companyConfig';
 
 // ── Constants ──
 
-const CONTRACT_MULTIPLIERS: Record<string, number> = {
-  MAIZ: 5_000,     // bushels
-  AZUCAR: 112_000, // libras
-  CACAO: 10,        // toneladas metricas
+// Fallback multipliers (used when no company config is available)
+const DEFAULT_MULTIPLIERS: Record<string, number> = {
+  MAIZ: 5_000,
+  AZUCAR: 112_000,
+  CACAO: 10,
 };
 
 const DIRECTION_SIGN: Record<string, number> = {
@@ -21,7 +23,7 @@ const DIRECTION_SIGN: Record<string, number> = {
   SHORT: -1,
 };
 
-const PRICE_UNITS: Record<string, string> = {
+const DEFAULT_PRICE_UNITS: Record<string, string> = {
   MAIZ: 'cents/bu',
   AZUCAR: 'cents/lb',
   CACAO: 'USD/ton',
@@ -68,7 +70,17 @@ export function calculateFuturesPortfolio(
   dates: string[],
   prices: Record<string, (number | null)[]>,
   filterDate: string,
+  commodityConfig?: CommodityConfig[],
 ): FuturesPosition[] {
+  // Build multipliers and price units from config or use defaults
+  const multipliers: Record<string, number> = { ...DEFAULT_MULTIPLIERS };
+  const priceUnits: Record<string, string> = { ...DEFAULT_PRICE_UNITS };
+  if (commodityConfig) {
+    commodityConfig.forEach((c) => {
+      multipliers[c.asset] = c.contract_multiplier;
+      priceUnits[c.asset] = c.price_unit;
+    });
+  }
   const refDate = new Date(filterDate + 'T12:00:00');
   const prevMonthLastBD = lastBusinessDayOfPrevMonth(refDate);
   const prevMonthStr = toDateStr(prevMonthLastBD);
@@ -81,7 +93,7 @@ export function calculateFuturesPortfolio(
   let totalPnlInception = 0;
 
   for (const pos of positions) {
-    const multiplier = CONTRACT_MULTIPLIERS[pos.asset] ?? 1;
+    const multiplier = multipliers[pos.asset] ?? 1;
     const dirSign = DIRECTION_SIGN[pos.direction] ?? 1;
     const assetPrices = prices[pos.asset];
 
@@ -149,7 +161,7 @@ export function calculateFuturesPortfolio(
       valor_t1: valorT1 != null ? Math.round(valorT1) : null,
       pnl_inception: pnlInception != null ? Math.round(pnlInception) : null,
       pnl_month: pnlMonth != null ? Math.round(pnlMonth) : null,
-      price_unit: PRICE_UNITS[pos.asset] ?? '',
+      price_unit: priceUnits[pos.asset] ?? '',
       active: pos.active,
       closed_date: pos.closed_date,
       closed_price: pos.closed_price,

--- a/src/lib/risk/supabaseRisk.ts
+++ b/src/lib/risk/supabaseRisk.ts
@@ -73,6 +73,22 @@ export function pivotPrices(rows: RiskPriceRow[]): {
   return { dates, prices, contracts };
 }
 
+/**
+ * Fetch distinct assets available in risk_prices (for onboarding).
+ */
+export async function fetchAvailableAssets(): Promise<string[]> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_prices')
+    .select('asset')
+    .limit(1000);
+
+  if (error) throw new Error(`Failed to fetch available assets: ${error.message}`);
+  const assets = new Set<string>();
+  (data ?? []).forEach((row: { asset: string }) => assets.add(row.asset));
+  return Array.from(assets).sort();
+}
+
 // ── Risk Positions (per-company) ──
 
 export interface RiskPositionRow {

--- a/src/models/risk/riskApi.ts
+++ b/src/models/risk/riskApi.ts
@@ -20,8 +20,11 @@ import {
 } from 'src/lib/risk/varCalculator';
 import { calcularExposicionTotal } from 'src/lib/risk/exposureCalculator';
 import { calculateFuturesPortfolio, executeRoll } from 'src/lib/risk/futuresCalculator';
+import type { CommodityConfig, RiskCompanyConfig } from 'src/lib/risk/companyConfig';
+import { getUnits } from 'src/lib/risk/companyConfig';
 
-const UNITS: Record<string, string> = {
+// Fallback units (used when no company config)
+const DEFAULT_UNITS: Record<string, string> = {
   MAIZ: 'TONS', AZUCAR: 'TONS', CACAO: 'TONS', USD: 'USD/COP',
 };
 
@@ -48,7 +51,9 @@ function lastBusinessDayOfPrevMonth(filterDate: string): string {
 export async function fetchBenchmarkFactors(
   filterDate: string,
   confidenceLevel = 0.99,
+  companyConfig?: RiskCompanyConfig | null,
 ): Promise<BenchmarkFactorsResponse> {
+  const units = companyConfig ? getUnits(companyConfig) : DEFAULT_UNITS;
   const startDate = getStartDate(filterDate, 400); // ~13 months for 180d rolling + prices
   const rows = await fetchRiskPrices(startDate, filterDate);
   const { dates, prices, contracts } = pivotPrices(rows);
@@ -88,7 +93,7 @@ export async function fetchBenchmarkFactors(
       daily_variance: dailyVar,
       price_start: pStart.price != null ? Math.round(pStart.price * 10000) / 10000 : null,
       price_end: pEnd.price != null ? Math.round(pEnd.price * 10000) / 10000 : null,
-      factor_unit: UNITS[asset] ?? '',
+      factor_unit: units[asset] ?? '',
       contract: contracts[asset],
     };
   }
@@ -193,6 +198,7 @@ export async function fetchFuturesPortfolio(
   filterDate: string,
   activeOnly = true,
   companyId?: string,
+  commodityConfig?: CommodityConfig[],
 ): Promise<FuturesPortfolioResponse> {
   const positions = await fetchFuturesPositionsFromDB(companyId, activeOnly);
 
@@ -202,7 +208,7 @@ export async function fetchFuturesPortfolio(
   const rows = await fetchRiskPrices(startDate, filterDate);
   const { dates, prices } = pivotPrices(rows);
 
-  const portfolio = calculateFuturesPortfolio(positions, dates, prices, filterDate);
+  const portfolio = calculateFuturesPortfolio(positions, dates, prices, filterDate, commodityConfig);
   return { portfolio };
 }
 

--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -35,6 +35,9 @@ import { fetchRollingVar, fetchBenchmarkFactors, fetchExposure, fetchFuturesPort
 import type { RollingVarResponse, BenchmarkFactorsResponse, ExposureParams, ExposureResponse, MarketPrice, FuturesPosition, NewFuturesPosition } from 'src/types/risk';
 import useAppStore from 'src/store';
 import type { Company } from 'src/types/user';
+import RoleGuard from 'src/components/RoleGuard';
+import { fetchCompanyRiskConfig, getAssetsWithCurrency, getChartColors, saveCompanyRiskConfig, COMMODITY_TEMPLATES } from 'src/lib/risk/companyConfig';
+import type { RiskCompanyConfig } from 'src/lib/risk/companyConfig';
 
 const PAGE_TITLE = 'Gestión de Riesgos';
 
@@ -85,10 +88,10 @@ function getExposureForAsset(asset: string, result: ExposureResponse | null): nu
 
 const BENCHMARK_COLUMNS = [
   { key: 'asset', label: 'Activo' },
-  { key: 'position_super', label: 'Super USD' },
+  { key: 'position_super', label: 'Exposición Natural' },
   { key: 'position_gr', label: 'Portafolio GR' },
   { key: 'position_total', label: 'Total' },
-  { key: 'var_super', label: 'VaR Super' },
+  { key: 'var_super', label: 'VaR Exp. Natural' },
   { key: 'var_gr', label: 'VaR GR' },
   { key: 'var_total', label: 'VaR Total' },
   { key: 'factor_var_diario', label: 'Factor VaR Diario' },
@@ -96,7 +99,7 @@ const BENCHMARK_COLUMNS = [
   { key: 'var_portfolio', label: 'Portafolio' },
   { key: 'price_start', label: 'Precio Inicio' },
   { key: 'price_end', label: 'Precio Fin' },
-  { key: 'pnl_super', label: 'P&G Super' },
+  { key: 'pnl_super', label: 'P&G Exp. Natural' },
   { key: 'pnl_gr', label: 'P&G GR' },
   { key: 'pnl_total', label: 'P&G Total' },
   { key: 'information_ratio', label: 'Info Ratio' },
@@ -401,7 +404,7 @@ const METHODOLOGY: Record<string, { title: string; content: React.ReactNode }> =
 
         <p style={methH}>Columnas principales</p>
         <ul>
-          <li><strong>Super USD (Posición Benchmark):</strong> Se obtiene automáticamente del cálculo de Exposición. Representa la exposición natural de la compañía en USD por commodity.</li>
+          <li><strong>Exposición Natural (Posición Benchmark):</strong> Se obtiene automáticamente del cálculo de Exposición. Representa la exposición natural de la compañía en USD por commodity.</li>
           <li><strong>GR USD (Posición Cobertura):</strong> Posición nominal en USD de los instrumentos de cobertura (forwards, futuros). Se ingresa manualmente.</li>
           <li><strong>Posición Total:</strong> Super + GR. Si es cero, la cobertura es perfecta.</li>
         </ul>
@@ -539,7 +542,7 @@ const METHODOLOGY: Record<string, { title: string; content: React.ReactNode }> =
         <div style={methFormula}>
           Exposición Real = Ventas Internacionales (USD) − Total Commodities (USD)
         </div>
-        <p>Representa la exposición neta de la compañía al dólar después de restar el consumo de materias primas. Este valor alimenta la columna Super USD del activo USD en el Benchmark.</p>
+        <p>Representa la exposición neta de la compañía al dólar después de restar el consumo de materias primas. Este valor alimenta la columna Exposición Natural del activo USD en el Benchmark.</p>
 
         <p style={methH}>Precios de Mercado</p>
         <p>Los precios de los futuros se actualizan automáticamente. Los campos con fondo azul indican precios de mercado no editables, mostrando la fecha de cotización y el contrato utilizado. Los demás campos son editables y permiten ajustar manualmente los parámetros de cálculo.</p>
@@ -583,6 +586,88 @@ const METHODOLOGY: Record<string, { title: string; content: React.ReactNode }> =
   },
 };
 
+// ── Setup screen for companies without risk config ──
+function CommoditySetup({ companyId, onSaved }: { companyId: string; onSaved: (cfg: RiskCompanyConfig) => void }) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [saving, setSaving] = useState(false);
+
+  const toggleAsset = (asset: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(asset)) next.delete(asset);
+      else next.add(asset);
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    if (selected.size === 0) {
+      toast.error('Selecciona al menos un commodity');
+      return;
+    }
+    setSaving(true);
+    try {
+      const commodities = COMMODITY_TEMPLATES.filter((c) => selected.has(c.asset));
+      const cfg = await saveCompanyRiskConfig(companyId, commodities);
+      toast.success('Configuración guardada');
+      onSaved(cfg);
+    } catch (e: unknown) {
+      toast.error((e as Error)?.message || 'Error guardando configuración');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Container fluid className="p-4">
+      <div className="text-center py-5">
+        <Icon icon={faShieldAlt} size="3x" className="text-muted mb-3" />
+        <h4>Configurar Gestión de Riesgos</h4>
+        <p className="text-muted mb-4">
+          Selecciona los commodities que tu empresa desea gestionar.
+          Podrás modificar esta selección más adelante.
+        </p>
+        <Row className="justify-content-center mb-4">
+          {COMMODITY_TEMPLATES.map((c) => (
+            <Col key={c.asset} xs="auto" className="mb-2">
+              <div
+                role="button"
+                tabIndex={0}
+                onClick={() => toggleAsset(c.asset)}
+                onKeyDown={(e) => e.key === 'Enter' && toggleAsset(c.asset)}
+                style={{
+                  padding: '12px 24px',
+                  borderRadius: 8,
+                  border: selected.has(c.asset) ? `2px solid ${c.chart_color}` : '2px solid #e2e8f0',
+                  background: selected.has(c.asset) ? `${c.chart_color}15` : '#fff',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s',
+                  minWidth: 120,
+                  textAlign: 'center' as const,
+                }}
+              >
+                <div style={{ fontWeight: 600, color: selected.has(c.asset) ? c.chart_color : '#64748b' }}>
+                  {c.asset}
+                </div>
+                <div style={{ fontSize: '0.75rem', color: '#94a3b8' }}>
+                  {c.exchange} — {c.symbol}
+                </div>
+              </div>
+            </Col>
+          ))}
+        </Row>
+        <Button
+          variant="primary"
+          onClick={handleSave}
+          disabled={saving || selected.size === 0}
+        >
+          {saving ? 'Guardando...' : `Configurar ${selected.size} commodity${selected.size !== 1 ? 's' : ''}`}
+        </Button>
+      </div>
+    </Container>
+  );
+}
+
 function RiskManagement() {
   const { userProfile, companies, isSuperAdmin, loadCompanies } = useAppStore();
   const [selectedCompanyId, setSelectedCompanyId] = useState<string | undefined>(undefined);
@@ -601,6 +686,23 @@ function RiskManagement() {
     }
   }, [userProfile?.company_id, selectedCompanyId]);
 
+  // Company risk configuration (commodities, multipliers, exposure params)
+  const [companyConfig, setCompanyConfig] = useState<RiskCompanyConfig | null>(null);
+  const [, setConfigLoading] = useState(false);
+
+  useEffect(() => {
+    if (!selectedCompanyId) return;
+    setConfigLoading(true);
+    fetchCompanyRiskConfig(selectedCompanyId)
+      .then((cfg) => setCompanyConfig(cfg))
+      .catch(() => setCompanyConfig(null))
+      .finally(() => setConfigLoading(false));
+  }, [selectedCompanyId]);
+
+  // Dynamic assets and colors from config (fallback to defaults)
+  const dynamicAssets = companyConfig ? getAssetsWithCurrency(companyConfig) : DEFAULT_ASSETS;
+  const dynamicColors = companyConfig ? getChartColors(companyConfig) : CHART_COLORS;
+
   const [activeTab, setActiveTab] = useState('benchmark');
   const [pageTabs, setPageTabs] = useState<TabItemType[]>(TAB_ITEMS);
   const [filterDate, setFilterDate] = useState(defaultDate());
@@ -612,7 +714,7 @@ function RiskManagement() {
   const [confidenceLevel, setConfidenceLevel] = useState(0.99);
 
   // Benchmark state
-  const [assets, setAssets] = useState<string[]>(DEFAULT_ASSETS);
+  const [assets, setAssets] = useState<string[]>(dynamicAssets);
   const [benchmarkMonth, setBenchmarkMonth] = useState(currentMonth());
   const [benchmarkRows, setBenchmarkRows] = useState<BenchmarkRow[]>(emptyBenchmarkRows());
   const [benchmarkFactors, setBenchmarkFactors] = useState<BenchmarkFactorsResponse | null>(null);
@@ -963,6 +1065,46 @@ function RiskManagement() {
 
   return (
     <CoreLayout>
+      <RoleGuard requiredRole="corp_admin" fallback={
+        <Container fluid className="p-4">
+          <p className="text-muted">No tienes acceso a esta sección. Contacta a tu administrador.</p>
+        </Container>
+      }>
+      {/* No company assigned — non-admin users see message */}
+      {!selectedCompanyId && userProfile && !isSuperAdmin() && (
+        <Container fluid className="p-4 text-center py-5">
+          <Icon icon={faShieldAlt} size="3x" className="text-muted mb-3" />
+          <h5>Sin empresa asignada</h5>
+          <p className="text-muted">Tu cuenta no tiene una empresa asociada. Contacta a tu administrador para configurar el acceso al módulo de riesgos.</p>
+        </Container>
+      )}
+      {/* Super admin without company — show company selector prompt */}
+      {!selectedCompanyId && isSuperAdmin() && (
+        <Container fluid className="p-4 text-center py-5">
+          <Icon icon={faShieldAlt} size="3x" className="text-muted mb-3" />
+          <h5>Selecciona una empresa</h5>
+          <p className="text-muted mb-3">Como super admin, selecciona una empresa del menú superior para ver su gestión de riesgos.</p>
+          {companies.length > 0 && (
+            <Form.Select
+              size="sm"
+              style={{ maxWidth: 300, margin: '0 auto' }}
+              value=""
+              onChange={(e) => setSelectedCompanyId(e.target.value || undefined)}
+            >
+              <option value="">Seleccionar empresa...</option>
+              {companies.map((c: Company) => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </Form.Select>
+          )}
+        </Container>
+      )}
+      {/* Show setup screen if company has no risk config */}
+      {!companyConfig && selectedCompanyId && (
+        <CommoditySetup companyId={selectedCompanyId} onSaved={(cfg) => setCompanyConfig(cfg)} />
+      )}
+      {/* Show main content only when company has config */}
+      {companyConfig && (
       <Container fluid className="p-4">
         <PageTitle>
           <Icon icon={faShieldAlt} />
@@ -1080,7 +1222,7 @@ function RiskManagement() {
             </Row>
 
             <p className="small text-muted mb-3">
-              <span style={{ background: '#dbeafe', padding: '1px 6px', border: '1px solid #93c5fd', borderRadius: 3 }}>Super USD</span> se llena automáticamente desde Exposición.
+              <span style={{ background: '#dbeafe', padding: '1px 6px', border: '1px solid #93c5fd', borderRadius: 3 }}>Exposición Natural</span> se llena automáticamente desde Exposición.
               Ingresa <strong>Portafolio GR</strong> y <strong>P&G GR</strong> manualmente. Los demás campos se calculan automáticamente.
             </p>
 
@@ -1100,7 +1242,7 @@ function RiskManagement() {
                     <th rowSpan={2}>Info Ratio</th>
                   </tr>
                   <tr>
-                    <th>Super USD</th><th>Portafolio GR</th><th>Total</th>
+                    <th>Exposición Natural</th><th>Portafolio GR</th><th>Total</th>
                     <th>Super</th><th>GR</th><th>Total</th>
                     <th>Diario %</th><th>Unidad</th>
                     <th>Inicio</th><th>Fin</th>
@@ -1282,7 +1424,7 @@ function RiskManagement() {
                   <Row className="g-3">
                     <Col md={6}>
                       <div className="bg-white rounded p-3 h-100" style={{ border: '1px solid #e2e8f0' }}>
-                        <h6 className="mb-3" style={{ color: CHART_COLORS[selectedAsset] || '#7c3aed' }}>
+                        <h6 className="mb-3" style={{ color: dynamicColors[selectedAsset] || '#7c3aed' }}>
                           Precio — {selectedAsset}
                           {rollingData.contracts?.[selectedAsset] && (
                             <span className="ms-1" style={{ fontSize: '0.72rem', color: '#6b7280', fontWeight: 400 }}>
@@ -1296,7 +1438,7 @@ function RiskManagement() {
                             <XAxis dataKey="date" tick={{ fontSize: 10 }} tickFormatter={(d: string) => d.slice(5)} />
                             <YAxis tick={{ fontSize: 10 }} domain={['auto', 'auto']} />
                             <Tooltip labelFormatter={(d: string) => d} formatter={(v: number) => [v?.toFixed(4), 'Precio']} />
-                            <Line type="monotone" dataKey="value" stroke={CHART_COLORS[selectedAsset] || '#7c3aed'} dot={false} strokeWidth={2} />
+                            <Line type="monotone" dataKey="value" stroke={dynamicColors[selectedAsset] || '#7c3aed'} dot={false} strokeWidth={2} />
                           </LineChart>
                         </ResponsiveContainer>
                       </div>
@@ -1330,7 +1472,7 @@ function RiskManagement() {
                   <>
                     {assets.map((asset) => (
                       <div key={asset} className="mb-4">
-                        <h6 className="mb-2" style={{ color: CHART_COLORS[asset], fontWeight: 600 }}>
+                        <h6 className="mb-2" style={{ color: dynamicColors[asset], fontWeight: 600 }}>
                           {asset}
                           {rollingData.contracts?.[asset] && (
                             <span className="ms-1" style={{ fontSize: '0.72rem', color: '#6b7280', fontWeight: 400 }}>
@@ -1348,7 +1490,7 @@ function RiskManagement() {
                                   <XAxis dataKey="date" tick={{ fontSize: 9 }} tickFormatter={(d: string) => d.slice(5)} />
                                   <YAxis tick={{ fontSize: 9 }} domain={['auto', 'auto']} />
                                   <Tooltip labelFormatter={(d: string) => d} formatter={(v: number) => [v?.toFixed(4), 'Precio']} />
-                                  <Line type="monotone" dataKey="value" stroke={CHART_COLORS[asset]} dot={false} strokeWidth={2} />
+                                  <Line type="monotone" dataKey="value" stroke={dynamicColors[asset]} dot={false} strokeWidth={2} />
                                 </LineChart>
                               </ResponsiveContainer>
                             </div>
@@ -1924,9 +2066,9 @@ function RiskManagement() {
                   <Col xs={2}>
                     <Form.Label className="small mb-1">Activo</Form.Label>
                     <Form.Select size="sm" value={newPosition.asset} onChange={(e) => setNewPosition({ ...newPosition, asset: e.target.value })}>
-                      <option value="MAIZ">MAIZ</option>
-                      <option value="AZUCAR">AZUCAR</option>
-                      <option value="CACAO">CACAO</option>
+                      {(companyConfig?.commodities ?? [{asset:'MAIZ'},{asset:'AZUCAR'},{asset:'CACAO'}]).map((c) => (
+                        <option key={c.asset} value={c.asset}>{c.asset}</option>
+                      ))}
                     </Form.Select>
                   </Col>
                   <Col xs={2}>
@@ -2084,6 +2226,7 @@ function RiskManagement() {
           </div>
         )}
       </Container>
+      )}
 
       {/* Edit Position Modal */}
       <Modal show={editModal != null} onHide={() => setEditModal(null)} size="sm">
@@ -2096,9 +2239,9 @@ function RiskManagement() {
           <Form.Group className="mb-2">
             <Form.Label className="small">Activo</Form.Label>
             <Form.Select size="sm" value={editFields.asset ?? ''} onChange={(e) => setEditFields({ ...editFields, asset: e.target.value })}>
-              <option value="MAIZ">MAIZ</option>
-              <option value="AZUCAR">AZUCAR</option>
-              <option value="CACAO">CACAO</option>
+              {(companyConfig?.commodities ?? [{asset:'MAIZ'},{asset:'AZUCAR'},{asset:'CACAO'}]).map((c) => (
+                <option key={c.asset} value={c.asset}>{c.asset}</option>
+              ))}
             </Form.Select>
           </Form.Group>
           <Form.Group className="mb-2">
@@ -2186,6 +2329,7 @@ function RiskManagement() {
           {methModal && METHODOLOGY[methModal]?.content}
         </Modal.Body>
       </Modal>
+    </RoleGuard>
     </CoreLayout>
   );
 }


### PR DESCRIPTION
## Summary
#245
- Only `super_admin` and `corp_admin` can see/access Riesgos section
- Each company loads its commodities from `risk_company_config` table
- Companies without config see a setup screen to select commodities
- Super admin without company sees a company selector
- Renamed "Super USD" → "Exposición Natural" across Benchmark tab
- Dynamic asset dropdowns and chart colors from company config

## Test plan
- [ ] Gestor/lector cannot see Riesgos in sidebar
- [ ] Corp admin with config sees full module
- [ ] Corp admin without config sees setup screen
- [ ] Super admin sees company selector
- [ ] Labels show "Exposición Natural" instead of "Super USD"

🤖 Generated with [Claude Code](https://claude.com/claude-code)