### PR TITLE
feat(risk): add Resumen tab — consolidated portfolio dashboard

### DIFF
--- a/src/lib/risk/resumenCalculator.ts
+++ b/src/lib/risk/resumenCalculator.ts
@@ -1,0 +1,171 @@
+/* eslint-disable no-restricted-syntax, import/prefer-default-export */
+/**
+ * Resumen calculator — consolidates data from all portfolio sections.
+ * Reads from Supabase (commodities, OTC positions) and Zustand stores (loans, TES).
+ * No Fly.io dependency.
+ */
+
+import type { ResumenData, ResumenSection, ResumenRow } from 'src/types/risk';
+import { fetchFuturesPortfolio } from 'src/models/risk/riskApi';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+
+const supabase = createClientComponentClient();
+
+// ── Commodities (Futures) ──
+
+async function fetchCommoditiesResumen(
+  filterDate: string,
+  companyId?: string,
+): Promise<ResumenSection> {
+  try {
+    const { portfolio } = await fetchFuturesPortfolio(filterDate, true, companyId);
+    const totalRow = portfolio.find((p) => p.asset === 'Total');
+    const positions = portfolio.filter((p) => p.asset !== 'Total');
+
+    const detalle: ResumenRow[] = positions.map((p) => ({
+      nombre: `${p.asset} ${p.direction} x${p.nominal}`,
+      posiciones: 1,
+      valor: p.valor_t,
+      pnl: p.pnl_month,
+      isSubRow: true,
+    }));
+
+    return {
+      nombre: 'Commodities',
+      icon: 'chart-area',
+      posiciones: positions.length,
+      valor_total: totalRow?.valor_t ?? null,
+      pnl_mes: totalRow?.pnl_month ?? null,
+      detalle,
+    };
+  } catch {
+    return { nombre: 'Commodities', icon: 'chart-area', posiciones: 0, valor_total: null, pnl_mes: null, detalle: [] };
+  }
+}
+
+// ── Derivados OTC (XCCY, NDF, IBR) ──
+
+async function fetchOTCResumen(): Promise<ResumenSection> {
+  try {
+    const [xccyRes, ndfRes, ibrRes] = await Promise.all([
+      supabase.schema('xerenity').rpc('get_xccy_positions'),
+      supabase.schema('xerenity').rpc('get_ndf_positions'),
+      supabase.schema('xerenity').rpc('get_ibr_positions'),
+    ]);
+
+    const xccy = (xccyRes.data ?? []) as Array<{ notional_usd: number; label: string }>;
+    const ndf = (ndfRes.data ?? []) as Array<{ notional_usd: number; label: string }>;
+    const ibr = (ibrRes.data ?? []) as Array<{ notional: number; label: string }>;
+
+    const xccyNotional = xccy.reduce((s, p) => s + (p.notional_usd ?? 0), 0);
+    const ndfNotional = ndf.reduce((s, p) => s + (p.notional_usd ?? 0), 0);
+    const ibrNotional = ibr.reduce((s, p) => s + (p.notional ?? 0), 0);
+
+    const detalle: ResumenRow[] = [];
+    if (xccy.length > 0) detalle.push({ nombre: `XCCY Swaps (${xccy.length})`, posiciones: xccy.length, valor: xccyNotional, pnl: null, isSubRow: true });
+    if (ndf.length > 0) detalle.push({ nombre: `NDF Forwards (${ndf.length})`, posiciones: ndf.length, valor: ndfNotional, pnl: null, isSubRow: true });
+    if (ibr.length > 0) detalle.push({ nombre: `IBR Swaps (${ibr.length})`, posiciones: ibr.length, valor: ibrNotional, pnl: null, isSubRow: true });
+
+    return {
+      nombre: 'Derivados OTC',
+      icon: 'exchange',
+      posiciones: xccy.length + ndf.length + ibr.length,
+      valor_total: xccyNotional + ndfNotional + ibrNotional,
+      pnl_mes: null, // P&L requires repricing via Fly.io — not available
+      detalle,
+    };
+  } catch {
+    return { nombre: 'Derivados OTC', icon: 'exchange', posiciones: 0, valor_total: null, pnl_mes: null, detalle: [] };
+  }
+}
+
+// ── Créditos (Loans) — from Zustand store ──
+
+interface LoanStoreData {
+  total_value: number;
+  loan_count: number;
+  accrued_interest: number;
+}
+
+function buildLoansResumen(fullLoan?: LoanStoreData): ResumenSection {
+  if (!fullLoan) {
+    return { nombre: 'Créditos', icon: 'landmark', posiciones: 0, valor_total: null, pnl_mes: null, detalle: [] };
+  }
+
+  return {
+    nombre: 'Créditos',
+    icon: 'landmark',
+    posiciones: fullLoan.loan_count ?? 0,
+    valor_total: fullLoan.total_value ?? null,
+    pnl_mes: null, // Loans don't have monthly P&L
+    detalle: [
+      { nombre: 'Saldo total', posiciones: fullLoan.loan_count, valor: fullLoan.total_value, pnl: null, isSubRow: true },
+      { nombre: 'Intereses causados', posiciones: 0, valor: fullLoan.accrued_interest, pnl: null, isSubRow: true },
+    ],
+  };
+}
+
+// ── Portafolio TES — from Zustand store ──
+
+interface TesBondData {
+  bond_name: string;
+  notional: number;
+  npv?: number;
+  pnl_mtm?: number;
+}
+
+function buildTESResumen(bonds: TesBondData[]): ResumenSection {
+  if (!bonds || bonds.length === 0) {
+    return { nombre: 'Portafolio TES', icon: 'landmark', posiciones: 0, valor_total: null, pnl_mes: null, detalle: [] };
+  }
+
+  const totalNpv = bonds.reduce((s, b) => s + (b.npv ?? b.notional ?? 0), 0);
+  const totalPnl = bonds.reduce((s, b) => s + (b.pnl_mtm ?? 0), 0);
+
+  const detalle: ResumenRow[] = bonds.map((b) => ({
+    nombre: b.bond_name,
+    posiciones: 1,
+    valor: b.npv ?? b.notional,
+    pnl: b.pnl_mtm ?? null,
+    isSubRow: true,
+  }));
+
+  return {
+    nombre: 'Portafolio TES',
+    icon: 'building-columns',
+    posiciones: bonds.length,
+    valor_total: totalNpv,
+    pnl_mes: totalPnl !== 0 ? totalPnl : null,
+    detalle,
+  };
+}
+
+// ── Main: fetch all sections ──
+
+export async function fetchResumenData(
+  filterDate: string,
+  companyId?: string,
+  storeData?: {
+    fullLoan?: LoanStoreData;
+    pricedTesBonds?: TesBondData[];
+  },
+): Promise<ResumenData> {
+  // Fetch commodities and OTC in parallel (async), use store data for loans/TES (sync)
+  const [commodities, otc] = await Promise.all([
+    fetchCommoditiesResumen(filterDate, companyId),
+    fetchOTCResumen(),
+  ]);
+
+  const loans = buildLoansResumen(storeData?.fullLoan);
+  const tes = buildTESResumen(storeData?.pricedTesBonds ?? []);
+
+  const secciones = [commodities, otc, loans, tes];
+
+  const totales = {
+    posiciones: secciones.reduce((s, sec) => s + sec.posiciones, 0),
+    valor_total: secciones.reduce((s, sec) => s + (sec.valor_total ?? 0), 0),
+    pnl_mes: secciones.reduce((s, sec) => s + (sec.pnl_mes ?? 0), 0),
+  };
+
+  return { fecha: filterDate, secciones, totales };
+}

--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -17,6 +17,7 @@ import {
   faBookOpen,
   faFilePdf,
   faBriefcase,
+  faChartPie,
 } from '@fortawesome/free-solid-svg-icons';
 import { toast } from 'react-toastify';
 import PageTitle from '@components/PageTitle';
@@ -32,7 +33,8 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { fetchRollingVar, fetchBenchmarkFactors, fetchExposure, fetchFuturesPortfolio, upsertFuturesPositions, rollFuturesPosition, closeFuturesPosition, deleteFuturesPosition, editFuturesPosition } from 'src/models/risk/riskApi';
-import type { RollingVarResponse, BenchmarkFactorsResponse, ExposureParams, ExposureResponse, MarketPrice, FuturesPosition, NewFuturesPosition } from 'src/types/risk';
+import type { RollingVarResponse, BenchmarkFactorsResponse, ExposureParams, ExposureResponse, MarketPrice, FuturesPosition, NewFuturesPosition, ResumenData } from 'src/types/risk';
+import { fetchResumenData } from 'src/lib/risk/resumenCalculator';
 import useAppStore from 'src/store';
 import type { Company } from 'src/types/user';
 import RoleGuard from 'src/components/RoleGuard';
@@ -42,7 +44,8 @@ import type { RiskCompanyConfig } from 'src/lib/risk/companyConfig';
 const PAGE_TITLE = 'Gestión de Riesgos';
 
 const TAB_ITEMS: TabItemType[] = [
-  { name: 'Benchmark', property: 'benchmark', icon: faEdit, active: true },
+  { name: 'Resumen', property: 'resumen', icon: faChartPie, active: true },
+  { name: 'Benchmark', property: 'benchmark', icon: faEdit, active: false },
   { name: 'Rolling VaR', property: 'rolling', icon: faChartLine, active: false },
   { name: 'Exposición', property: 'exposure', icon: faDollarSign, active: false },
   { name: 'Matrices', property: 'matrices', icon: faBorderAll, active: false },
@@ -703,9 +706,18 @@ function RiskManagement() {
   const dynamicAssets = companyConfig ? getAssetsWithCurrency(companyConfig) : DEFAULT_ASSETS;
   const dynamicColors = companyConfig ? getChartColors(companyConfig) : CHART_COLORS;
 
-  const [activeTab, setActiveTab] = useState('benchmark');
+  const [activeTab, setActiveTab] = useState('resumen');
   const [pageTabs, setPageTabs] = useState<TabItemType[]>(TAB_ITEMS);
   const [filterDate, setFilterDate] = useState(defaultDate());
+
+  // Resumen state
+  const [resumenData, setResumenData] = useState<ResumenData | null>(null);
+  const [resumenLoading, setResumenLoading] = useState(false);
+  const [resumenMonth, setResumenMonth] = useState(currentMonth());
+
+  // Access store data for loans and TES
+  const fullLoan = useAppStore((s) => (s as unknown as Record<string, unknown>).fullLoan) as { total_value: number; loan_count: number; accrued_interest: number } | undefined;
+  const pricedTesBonds = useAppStore((s) => (s as unknown as Record<string, unknown>).pricedTesBonds) as Array<{ bond_name: string; notional: number; npv?: number; pnl_mtm?: number }> | undefined;
 
   // Methodology modal
   const [methModal, setMethModal] = useState<string | null>(null);
@@ -795,7 +807,24 @@ function RiskManagement() {
     );
   };
 
-  // handleCalculate removed — benchmark factors loaded via tab useEffect below
+  // ── Resumen handler ──
+  const resumenFilterDate = lastDayOfMonth(resumenMonth.year, resumenMonth.month);
+
+  const handleFetchResumen = useCallback(async () => {
+    setResumenLoading(true);
+    try {
+      const data = await fetchResumenData(resumenFilterDate, selectedCompanyId, {
+        fullLoan,
+        pricedTesBonds: pricedTesBonds ?? [],
+      });
+      setResumenData(data);
+    } catch (e: unknown) {
+      toast.error((e as Error)?.message || 'Error cargando resumen');
+    } finally {
+      setResumenLoading(false);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resumenFilterDate, selectedCompanyId]);
 
   const handleFetchRolling = useCallback(async () => {
     setRollingLoading(true);
@@ -1013,6 +1042,9 @@ function RiskManagement() {
   }, [filterDate, editModal, editFields, handleFetchFutures]);
 
   useEffect(() => {
+    if (activeTab === 'resumen' && !resumenData) {
+      handleFetchResumen();
+    }
     if (activeTab === 'rolling' && !rollingData) {
       handleFetchRolling();
     }
@@ -1023,7 +1055,7 @@ function RiskManagement() {
       handleFetchFutures();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTab, benchmarkFactors, futuresMonth]);
+  }, [activeTab, benchmarkFactors, futuresMonth, resumenData]);
 
   // When exposure results change, update benchmark position_super
   useEffect(() => {
@@ -1148,6 +1180,165 @@ function RiskManagement() {
             </Tab>
           ))}
         </Tabs>
+
+        {/* ─── RESUMEN TAB ─── */}
+        {activeTab === 'resumen' && (
+          <div>
+            {/* Month navigator */}
+            <Row className="mb-3 align-items-center">
+              <Col xs="auto" className="d-flex align-items-center gap-2">
+                <Button
+                  variant="outline-secondary"
+                  size="sm"
+                  onClick={() => {
+                    const prev = resumenMonth.month === 0
+                      ? { year: resumenMonth.year - 1, month: 11 }
+                      : { year: resumenMonth.year, month: resumenMonth.month - 1 };
+                    setResumenMonth(prev);
+                    setResumenData(null);
+                  }}
+                  style={{ padding: '4px 10px' }}
+                >
+                  <Icon icon={faChevronLeft} />
+                </Button>
+                <div className="text-center" style={{ minWidth: 160 }}>
+                  <strong style={{ fontSize: '1.1rem', color: '#7c3aed' }}>
+                    {MONTH_NAMES[resumenMonth.month]} {resumenMonth.year}
+                  </strong>
+                </div>
+                <Button
+                  variant="outline-secondary"
+                  size="sm"
+                  onClick={() => {
+                    const next = resumenMonth.month === 11
+                      ? { year: resumenMonth.year + 1, month: 0 }
+                      : { year: resumenMonth.year, month: resumenMonth.month + 1 };
+                    setResumenMonth(next);
+                    setResumenData(null);
+                  }}
+                  style={{ padding: '4px 10px' }}
+                >
+                  <Icon icon={faChevronRight} />
+                </Button>
+              </Col>
+              <Col xs="auto">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleFetchResumen}
+                  disabled={resumenLoading}
+                >
+                  <Icon icon={faSyncAlt} className={resumenLoading ? 'fa-spin me-1' : 'me-1'} />
+                  Actualizar
+                </Button>
+              </Col>
+            </Row>
+
+            {resumenLoading && <p className="text-muted">Cargando resumen...</p>}
+
+            {resumenData && (
+              <>
+                {/* KPI Cards */}
+                <Row className="mb-4 g-3">
+                  {resumenData.secciones.map((sec) => (
+                    <Col key={sec.nombre} xs={6} md={3}>
+                      <div style={{
+                        background: '#fff',
+                        borderRadius: 8,
+                        padding: '16px 20px',
+                        border: '1px solid #e2e8f0',
+                        boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+                      }}>
+                        <div style={{ fontSize: '0.75rem', color: '#94a3b8', textTransform: 'uppercase', fontWeight: 600 }}>
+                          {sec.nombre}
+                        </div>
+                        <div style={{ fontSize: '1.4rem', fontWeight: 700, color: '#1e293b', marginTop: 4 }}>
+                          {sec.posiciones} <span style={{ fontSize: '0.8rem', fontWeight: 400, color: '#64748b' }}>posiciones</span>
+                        </div>
+                        {sec.valor_total != null && (
+                          <div style={{ fontSize: '0.85rem', color: '#475569', marginTop: 2 }}>
+                            ${Math.abs(sec.valor_total).toLocaleString('en-US', { maximumFractionDigits: 0 })}
+                          </div>
+                        )}
+                        {sec.pnl_mes != null && (
+                          <div style={{
+                            fontSize: '0.85rem',
+                            fontWeight: 600,
+                            color: sec.pnl_mes >= 0 ? '#16a34a' : '#dc2626',
+                            marginTop: 2,
+                          }}>
+                            {sec.pnl_mes >= 0 ? '+' : ''}{fmtUsd(sec.pnl_mes)}
+                          </div>
+                        )}
+                      </div>
+                    </Col>
+                  ))}
+                </Row>
+
+                {/* Consolidated Table */}
+                <div className="table-responsive">
+                  <table className="table table-sm table-bordered mb-0" style={{ fontSize: '0.85rem' }}>
+                    <thead>
+                      <tr style={{ background: '#1e293b', color: '#fff' }}>
+                        <th>Sección</th>
+                        <th className="text-center">Posiciones</th>
+                        <th className="text-end">Valor / Notional</th>
+                        <th className="text-end">P&L Mes</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {resumenData.secciones.map((sec) => (
+                        <React.Fragment key={sec.nombre}>
+                          {/* Section header row */}
+                          <tr style={{ background: '#f8fafc', fontWeight: 600 }}>
+                            <td>{sec.nombre}</td>
+                            <td className="text-center">{sec.posiciones}</td>
+                            <td className="text-end">
+                              {sec.valor_total != null ? `$${Math.abs(sec.valor_total).toLocaleString('en-US', { maximumFractionDigits: 0 })}` : '—'}
+                            </td>
+                            <td className={`text-end ${pnlClass(sec.pnl_mes)}`}>
+                              {sec.pnl_mes != null ? fmtUsd(sec.pnl_mes) : '—'}
+                            </td>
+                          </tr>
+                          {/* Detail sub-rows */}
+                          {sec.detalle.map((row, idx) => (
+                            <tr key={`${sec.nombre}-${idx.toString()}`} style={{ color: '#64748b', fontSize: '0.8rem' }}>
+                              <td style={{ paddingLeft: 28 }}>{row.nombre}</td>
+                              <td className="text-center">{row.posiciones > 0 ? row.posiciones : ''}</td>
+                              <td className="text-end">
+                                {row.valor != null ? `$${Math.abs(row.valor).toLocaleString('en-US', { maximumFractionDigits: 0 })}` : ''}
+                              </td>
+                              <td className={`text-end ${pnlClass(row.pnl)}`}>
+                                {row.pnl != null ? fmtUsd(row.pnl) : ''}
+                              </td>
+                            </tr>
+                          ))}
+                        </React.Fragment>
+                      ))}
+                      {/* Totals row */}
+                      <tr style={{ background: '#1e293b', color: '#fff', fontWeight: 700 }}>
+                        <td>TOTAL</td>
+                        <td className="text-center">{resumenData.totales.posiciones}</td>
+                        <td className="text-end">
+                          ${Math.abs(resumenData.totales.valor_total).toLocaleString('en-US', { maximumFractionDigits: 0 })}
+                        </td>
+                        <td className="text-end">
+                          {resumenData.totales.pnl_mes !== 0 ? fmtUsd(resumenData.totales.pnl_mes) : '—'}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </>
+            )}
+
+            {!resumenLoading && !resumenData && (
+              <p className="text-muted text-center mt-4">
+                Presione &quot;Actualizar&quot; para cargar el resumen del portafolio.
+              </p>
+            )}
+          </div>
+        )}
 
         {/* ─── BENCHMARK TAB ─── */}
         {activeTab === 'benchmark' && (

--- a/src/types/risk.ts
+++ b/src/types/risk.ts
@@ -165,6 +165,33 @@ export interface FuturesCloseParams {
   closed_date?: string;
 }
 
+// ── Resumen (Dashboard) ──
+
+export interface ResumenRow {
+  nombre: string;
+  posiciones: number;
+  valor: number | null;
+  pnl: number | null;
+  isSubRow?: boolean;
+}
+
+export interface ResumenSection {
+  nombre: string;
+  icon: string;
+  posiciones: number;
+  valor_total: number | null;
+  pnl_mes: number | null;
+  detalle: ResumenRow[];
+}
+
+export interface ResumenData {
+  fecha: string;
+  secciones: ResumenSection[];
+  totales: { posiciones: number; valor_total: number; pnl_mes: number };
+}
+
+// ── Futures Edit ──
+
 export interface FuturesEditParams {
   position_id: string;
   updates: Partial<Pick<NewFuturesPosition, 'asset' | 'contract' | 'direction' | 'nominal' | 'entry_price' | 'entry_date'>>;


### PR DESCRIPTION
## Summary
#246
Adds a new "Resumen" tab as the default view in Gestión de Riesgos, consolidating data from all portfolio sections.

## Features

- 4 KPI cards: Commodities, Derivados OTC, Créditos, Portafolio TES
- Consolidated table with positions, values, and P&L grouped by section
- Detail sub-rows for each section
- Month navigator (same pattern as Benchmark)
- All data from frontend (Supabase + Zustand stores, no Fly.io)

## New files

- `src/lib/risk/resumenCalculator.ts` — orchestrates 4 data sources
- Types: `ResumenData`, `ResumenSection`, `ResumenRow` in `src/types/risk.ts`

## Test plan

- [ ] Resumen tab appears as first/default tab
- [ ] Cards show KPIs for each section
- [ ] Table shows consolidated data with sub-rows
- [ ] Month navigation works
- [ ] Sections with no data show 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)