### PR TITLE
fix(risk): Portafolio GR Crear button

### DIFF
--- a/src/lib/risk/supabaseRisk.ts
+++ b/src/lib/risk/supabaseRisk.ts
@@ -184,12 +184,17 @@ export async function fetchFuturesPositionsFromDB(
 export async function upsertFuturesPositionsDB(
   records: Partial<FuturesPositionRow>[],
 ): Promise<void> {
+  // Insert puro (no upsert): se elimino el unique constraint
+  // uq_futures_position en risk_futures_portfolio para permitir multiples
+  // entradas al mismo contrato a diferentes precios. Si dejaramos .upsert
+  // con onConflict apuntando a una constraint inexistente, PostgREST
+  // retorna 400 y el "Crear" del Portafolio GR falla en silencio.
   const { error } = await supabase
     .schema(SCHEMA)
     .from('risk_futures_portfolio')
-    .upsert(records, { onConflict: 'company_id,asset,contract,entry_date,direction' });
+    .insert(records);
 
-  if (error) throw new Error(`Failed to upsert futures positions: ${error.message}`);
+  if (error) throw new Error(`Failed to insert futures positions: ${error.message}`);
 }
 
 export async function closeFuturesPositionDB(


### PR DESCRIPTION
Closes #253

## Problema
El boton **Crear** del form "Nueva Posicion" en Portafolio GR no inserta el trade. El form se cierra (aparentemente exitoso) pero la posicion no aparece en la tabla.

## Causa
\`upsertFuturesPositionsDB\` ([src/lib/risk/supabaseRisk.ts:184](src/lib/risk/supabaseRisk.ts#L184)) usaba:

\`\`\`ts
.upsert(records, { onConflict: 'company_id,asset,contract,entry_date,direction' });
\`\`\`

Pero el unique constraint \`uq_futures_position\` sobre esas columnas fue **eliminado** en una sesion anterior para permitir que el usuario registre **multiples entradas al mismo contrato a diferentes precios** (ej. comprar 5 lotes a 16.10 y luego 3 lotes mas a 16.20 — son dos rows).

Cuando PostgREST recibe \`upsert\` con \`onConflict\` apuntando a una constraint que ya no existe, retorna **400 Bad Request**. El frontend captura la excepcion en \`handleAddPosition\` y muestra un \`toast.error\` que probablemente paso desapercibido.

## Fix
Cambiar a \`.insert()\` puro:

\`\`\`ts
const { error } = await supabase
  .schema(SCHEMA)
  .from('risk_futures_portfolio')
  .insert(records);
\`\`\`

Queremos duplicados explicitos, no merge. Si el usuario quiere editar un trade existente usa el modal Edit, no la creacion.

## Test plan
- [ ] Abrir /risk-management → Portafolio GR → click "+ Nueva Posicion"
- [ ] Llenar contract, direction, nominal, entry_price, entry_date
- [ ] Click Crear → toast "Posicion creada" + nueva fila aparece en la tabla
- [ ] Crear OTRA posicion en el mismo contrato/fecha/direccion con precio distinto → debe permitir el duplicado

🤖 Generated with [Claude Code](https://claude.com/claude-code)