### PR TITLE
fix(risk): Portafolio GR per-contract prices + maturity labels

### DIFF
--- a/src/lib/risk/futuresCalculator.ts
+++ b/src/lib/risk/futuresCalculator.ts
@@ -78,6 +78,13 @@ export function calculateFuturesPortfolio(
   prices: Record<string, (number | null)[]>,
   filterDate: string,
   commodityConfig?: CommodityConfig[],
+  // Per-contract prices from risk_prices_all_contracts. Si esta presente,
+  // se usa para cada posicion (lookup por pos.contract). Si el contrato no
+  // tiene datos en pricesByContract, cae al front contract de `prices` (el
+  // comportamiento legacy donde todos los contratos del activo tomaban el
+  // mismo precio).
+  pricesByContract?: Record<string, (number | null)[]>,
+  contractDates?: string[],
 ): FuturesPosition[] {
   // Build multipliers and price units from config or use defaults
   const multipliers: Record<string, number> = { ...DEFAULT_MULTIPLIERS };
@@ -108,12 +115,25 @@ export function calculateFuturesPortfolio(
   for (const pos of filteredPositions) {
     const multiplier = multipliers[pos.asset] ?? 1;
     const dirSign = DIRECTION_SIGN[pos.direction] ?? 1;
-    const assetPrices = prices[pos.asset];
 
-    if (!assetPrices) continue;
+    // Series de precios para ESTE contrato.
+    // Prioridad:
+    //   1. risk_prices_all_contracts → pricesByContract[pos.contract] (precio
+    //      especifico del contrato — lo correcto para mark-to-market).
+    //   2. Fallback: front contract de risk_prices → prices[pos.asset] (puede
+    //      dar resultados incorrectos cuando hay multiples contratos abiertos
+    //      del mismo activo, pero es mejor que mostrar nada).
+    const contractPrices = pos.contract && pricesByContract
+      ? pricesByContract[pos.contract]
+      : undefined;
+    const useContractSeries = contractPrices != null && (contractDates?.length ?? 0) > 0;
+    const seriesDates = useContractSeries ? contractDates! : dates;
+    const seriesPrices = useContractSeries ? contractPrices! : prices[pos.asset];
+
+    if (!seriesPrices) continue;
 
     // Current price: last available on or before filterDate
-    const current = findPrice(dates, assetPrices, filterDate);
+    const current = findPrice(seriesDates, seriesPrices, filterDate);
 
     // Precio previo logic:
     // If position opened in the current month → use entry_price
@@ -130,7 +150,7 @@ export function calculateFuturesPortfolio(
       precioPrevioDate = pos.entry_date;
     } else {
       // Older position — previo = last BD of prev month
-      const prev = findPrice(dates, assetPrices, prevMonthStr);
+      const prev = findPrice(seriesDates, seriesPrices, prevMonthStr);
       precioPrevio = prev.price;
       precioPrevioDate = prev.date;
     }

--- a/src/lib/risk/futuresCalculator.ts
+++ b/src/lib/risk/futuresCalculator.ts
@@ -39,6 +39,34 @@ const PRICE_TO_USD: Record<string, number> = {
 // ── Helpers ──
 
 /**
+ * Parse a futures contract code (e.g. ZCN26, SBV27) into its expiry month/year.
+ * Returns a short label like "Jul 26" or "Oct 27", or null if the code is malformed.
+ *
+ * Month codes (CME/CBOT/ICE convention):
+ *   F=Jan G=Feb H=Mar J=Apr K=May M=Jun N=Jul Q=Aug U=Sep V=Oct X=Nov Z=Dec
+ *
+ * Soporta dos formatos de año:
+ *   - 2 digitos: ZCN26 → "Jul 26"
+ *   - 1 digito:  ZCN6  → "Jul 26" (el collector ocasionalmente guarda asi;
+ *     asumimos decada actual 202X)
+ */
+const FUTURES_MONTH_CODES: Record<string, string> = {
+  F: 'Jan', G: 'Feb', H: 'Mar', J: 'Apr', K: 'May', M: 'Jun',
+  N: 'Jul', Q: 'Aug', U: 'Sep', V: 'Oct', X: 'Nov', Z: 'Dec',
+};
+
+export function parseContractMaturity(contract: string | null | undefined): string | null {
+  if (!contract) return null;
+  // Format: <ROOT 1-3 letters><MONTH 1 letter><YEAR 1-2 digits>
+  const match = contract.match(/^([A-Z]{1,3})([FGHJKMNQUVXZ])(\d{1,2})$/);
+  if (!match) return null;
+  const month = FUTURES_MONTH_CODES[match[2]];
+  if (!month) return null;
+  const year = match[3].length === 1 ? `2${match[3]}` : match[3];
+  return `${month} ${year}`;
+}
+
+/**
  * Last business day of the previous month (skip weekends).
  */
 export function lastBusinessDayOfPrevMonth(refDate: Date): Date {

--- a/src/lib/risk/supabaseRisk.ts
+++ b/src/lib/risk/supabaseRisk.ts
@@ -73,6 +73,78 @@ export function pivotPrices(rows: RiskPriceRow[]): {
   return { dates, prices, contracts };
 }
 
+// ── Risk Prices ALL Contracts (per-contract close price) ──
+//
+// risk_prices stores SOLO el front contract por activo, asi que todos
+// los contratos del mismo activo terminaban tomando el mismo precio
+// (bug: el Portafolio GR mostraba 457.75 para ZCN26, ZCU26, ZCZ26, etc.).
+//
+// risk_prices_all_contracts almacena el close price por (date, asset, contract).
+// Para mark-to-market del Portafolio GR usamos esta tabla, con fallback al
+// front contract si no hay datos para un contrato especifico.
+
+export interface RiskPriceContractRow {
+  date: string;
+  asset: string;
+  contract: string;
+  close: number;
+}
+
+export async function fetchRiskPricesAllContracts(
+  startDate: string,
+  endDate: string,
+  contracts?: string[],
+): Promise<RiskPriceContractRow[]> {
+  let query = supabase
+    .schema(SCHEMA)
+    .from('risk_prices_all_contracts')
+    .select('date, asset, contract, close')
+    .gte('date', startDate)
+    .lte('date', endDate);
+
+  if (contracts && contracts.length > 0) {
+    query = query.in('contract', contracts);
+  }
+
+  const { data, error } = await query.order('date', { ascending: true });
+
+  if (error) throw new Error(`Failed to fetch risk_prices_all_contracts: ${error.message}`);
+  return (data ?? []) as RiskPriceContractRow[];
+}
+
+/**
+ * Pivot per-contract rows into a date-indexed structure keyed by contract.
+ * Returns { dates: string[], pricesByContract: { ZCN26: [...], SBV26: [...], ... } }
+ *
+ * Si un contrato no tiene datos para una fecha, queda null en esa posicion.
+ */
+export function pivotPricesByContract(rows: RiskPriceContractRow[]): {
+  dates: string[];
+  pricesByContract: Record<string, (number | null)[]>;
+} {
+  const dateSet = new Set<string>();
+  const contractSet = new Set<string>();
+  // (date, contract) → close
+  const priceMap = new Map<string, Map<string, number>>();
+
+  for (const row of rows) {
+    dateSet.add(row.date);
+    contractSet.add(row.contract);
+    if (!priceMap.has(row.date)) priceMap.set(row.date, new Map());
+    priceMap.get(row.date)!.set(row.contract, row.close);
+  }
+
+  const dates = Array.from(dateSet).sort();
+  const contracts = Array.from(contractSet).sort();
+
+  const pricesByContract: Record<string, (number | null)[]> = {};
+  for (const contract of contracts) {
+    pricesByContract[contract] = dates.map((d) => priceMap.get(d)?.get(contract) ?? null);
+  }
+
+  return { dates, pricesByContract };
+}
+
 /**
  * Fetch distinct assets available in risk_prices (for onboarding).
  */

--- a/src/models/risk/riskApi.ts
+++ b/src/models/risk/riskApi.ts
@@ -11,6 +11,7 @@ import type {
 } from 'src/types/risk';
 import {
   fetchRiskPrices, pivotPrices,
+  fetchRiskPricesAllContracts, pivotPricesByContract,
   fetchFuturesPositionsFromDB, upsertFuturesPositionsDB,
   closeFuturesPositionDB, deleteFuturesPositionDB, editFuturesPositionDB,
 } from 'src/lib/risk/supabaseRisk';
@@ -205,10 +206,31 @@ export async function fetchFuturesPortfolio(
   if (positions.length === 0) return { portfolio: [] };
 
   const startDate = getStartDate(filterDate, 90);
-  const rows = await fetchRiskPrices(startDate, filterDate);
-  const { dates, prices } = pivotPrices(rows);
 
-  const portfolio = calculateFuturesPortfolio(positions, dates, prices, filterDate, commodityConfig);
+  // Cargamos:
+  // 1) precios per-contrato desde risk_prices_all_contracts (fuente principal
+  //    para mark-to-market — cada contrato tiene su propio precio).
+  // 2) precios del front contract desde risk_prices como FALLBACK por si
+  //    algun contrato del Portafolio GR no tiene datos en
+  //    risk_prices_all_contracts (ej. recien creado, sin collector corrido).
+  const uniqueContracts = Array.from(new Set(positions.map((p) => p.contract).filter(Boolean)));
+  const [allContractRows, frontRows] = await Promise.all([
+    fetchRiskPricesAllContracts(startDate, filterDate, uniqueContracts).catch(() => []),
+    fetchRiskPrices(startDate, filterDate),
+  ]);
+
+  const { dates: contractDates, pricesByContract } = pivotPricesByContract(allContractRows);
+  const { dates: frontDates, prices: frontPrices } = pivotPrices(frontRows);
+
+  const portfolio = calculateFuturesPortfolio(
+    positions,
+    contractDates.length > 0 ? contractDates : frontDates,
+    frontPrices,
+    filterDate,
+    commodityConfig,
+    pricesByContract,
+    contractDates,
+  );
   return { portfolio };
 }
 

--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -38,6 +38,7 @@ import useAppStore from 'src/store';
 import RoleGuard from 'src/components/RoleGuard';
 import { fetchCompanyRiskConfig, getAssetsWithCurrency, getChartColors, saveCompanyRiskConfig, COMMODITY_TEMPLATES, DEFAULT_EXPOSURE_PARAMS } from 'src/lib/risk/companyConfig';
 import type { RiskCompanyConfig } from 'src/lib/risk/companyConfig';
+import { parseContractMaturity } from 'src/lib/risk/futuresCalculator';
 
 const PAGE_TITLE = 'Gestión de Riesgos';
 
@@ -2152,7 +2153,18 @@ function RiskManagement() {
                             {/* eslint-disable-next-line no-nested-ternary */}
                             <span style={{ color: isTotal ? '#1e293b' : (isSubtotal ? '#475569' : '#7c3aed'), fontWeight: 600 }}>{pos.asset}</span>
                           </td>
-                          <td style={{ padding: '8px 6px', color: '#64748b' }}>{isSummaryRow ? '' : (pos.contract ?? '')}</td>
+                          <td style={{ padding: '8px 6px', color: '#64748b' }}>
+                            {isSummaryRow ? '' : (
+                              <>
+                                <span style={{ fontWeight: 600 }}>{pos.contract ?? ''}</span>
+                                {pos.contract && parseContractMaturity(pos.contract) && (
+                                  <span style={{ color: '#94a3b8', fontSize: '0.7rem', marginLeft: 4 }}>
+                                    ({parseContractMaturity(pos.contract)})
+                                  </span>
+                                )}
+                              </>
+                            )}
+                          </td>
                           <td style={{ padding: '8px 6px', color: dirColor, fontWeight: 600, fontSize: '0.75rem' }}>{isSummaryRow ? '' : (pos.direction ?? '')}</td>
                           <td className="text-center" style={{ padding: '8px 6px', fontWeight: isSummaryRow ? 700 : 400 }}>{pos.nominal || ''}</td>
                           <td style={{ padding: '8px 6px', color: '#64748b', fontSize: '0.75rem' }}>{isSummaryRow ? '' : (pos.entry_date ?? '')}</td>


### PR DESCRIPTION
Closes #255

## Problema
\`calculateFuturesPortfolio\` leia siempre del front contract de \`risk_prices\` indexado por activo (\`prices[pos.asset]\`), causando que **todos los contratos del mismo activo mostraran el mismo Px Actual y Px Previo**.

Comparado con el broker StoneX al 2026-03-31:

| Contrato | Antes (Xerenity) | Broker StoneX |
|---|---|---|
| ZCN26, ZCU26, ZCZ26, ZCH27, ZCK27 | todos **457.75** | 468.25 / 470.25 / 484.25 / 495.00 / 501.50 |
| SBN26, SBV26, SBH27, SBK27, SBV27 | todos **15.52** | 15.68 / 16.05 / 16.69 / 16.33 / 16.33 |

Esto rompia los Valor T y los P&G del mes de todas las posiciones que no fueran el front contract.

## Solucion

### Per-contract prices
La tabla \`xerenity.risk_prices_all_contracts\` ya existe (creada en sesion anterior) con \`(date, asset, contract, close)\`. El collector \`collect_all_contracts()\` tambien existe. Solo faltaba que el frontend la consumiera.

- **\`supabaseRisk.ts\`**: nueva \`fetchRiskPricesAllContracts(start, end, contracts)\` filtrada por contratos del portafolio + helper \`pivotPricesByContract\` que devuelve \`{ ZCN26: [...], SBV26: [...] }\`.
- **\`riskApi.ts\`** \`fetchFuturesPortfolio\`: carga en paralelo precios per-contrato + front contract (fallback).
- **\`futuresCalculator.ts\`** \`calculateFuturesPortfolio\`: nueva firma con \`pricesByContract\` + \`contractDates\` opcionales. Para cada posicion intenta primero el contrato especifico; si no hay datos cae al front contract (legacy).

### Maturity label
Helper **\`parseContractMaturity\`** que convierte el codigo del contrato al mes de vencimiento usando los month codes estandar (F=Jan, G=Feb, H=Mar, J=Apr, K=May, M=Jun, N=Jul, Q=Aug, U=Sep, V=Oct, X=Nov, Z=Dec).

UI: la columna Contrato del Portafolio GR ahora muestra \`ZCN26 (Jul 26)\`, \`SBV27 (Oct 27)\`, etc.

## Verificacion local

Match perfecto en los 10 contratos del portafolio actual:

| Contrato | Vencimiento | StoneX | Xerenity (post-fix) |
|---|---|---|---|
| ZCN26 | Jul 26 (Corn) | 468.25 | 468.25 |
| ZCU26 | Sep 26 (Corn) | 470.25 | 470.25 |
| ZCZ26 | Dec 26 (Corn) | 484.25 | 484.25 |
| ZCH27 | Mar 27 (Corn) | 495.00 | 495.00 |
| ZCK27 | May 27 (Corn) | 501.50 | 501.50 |
| SBN26 | Jul 26 (Sugar) | 15.68 | 15.68 |
| SBV26 | Oct 26 (Sugar) | 16.05 | 16.05 |
| SBH27 | Mar 27 (Sugar) | 16.69 | 16.69 |
| SBK27 | May 27 (Sugar) | 16.33 | 16.33 |
| SBV27 | Oct 27 (Sugar) | 16.33 | 16.33 |

## Test plan
- [x] Match 100% con broker StoneX al 2026-03-31
- [x] Mes de vencimiento aparece al lado de cada contrato
- [ ] Verificar que cambiar de mes en el selector recalcula los precios correctamente
- [ ] Verificar que un contrato sin datos en risk_prices_all_contracts cae al fallback

## Nota operativa
Para que el fix funcione en produccion la tabla \`risk_prices_all_contracts\` debe estar poblada al dia. Correr \`collect_all_contracts()\` desde el backend periodicamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)