### PR TITLE
fix(risk-resumen): skip exposicion para empresas sin config

### DIFF
--- a/src/pages/risk-resumen/index.tsx
+++ b/src/pages/risk-resumen/index.tsx
@@ -268,14 +268,20 @@ function RiskResumenPage() {
       await repriceWithMark(filterDate);
       await loadOtcRefPrices(filterDate);
 
-      // 2) Commodities: benchmark factors (precios fin de mes) + futures (Portafolio GR) + exposicion
-      //    fetchExposure llama a Supabase con filterDate y trae automaticamente
-      //    los precios del fin del mes seleccionado (precio_azucar_cent_lb,
-      //    precio_maiz_cent_bu, etc se sobreescriben con los precios reales).
+      // 2) Commodities: benchmark factors + futures + exposicion (condicional)
+      //    Solo llamar fetchExposure si la empresa tiene exposure_defaults
+      //    configurados. DEFAULT_EXPOSURE_PARAMS son especificos de Super de
+      //    Alimentos — si se llaman para otra empresa, muestra datos incorrectos
+      //    ($82.7M de exposicion USD que es de Super, no del Embrujo).
+      const hasExposureConfig = companyConfig?.exposure_defaults
+        && Object.keys(companyConfig.exposure_defaults).length > 0;
+
       const [factors, futResp, exposure] = await Promise.all([
         fetchBenchmarkFactors(filterDate, 0.99, companyConfig).catch(() => null),
         fetchFuturesPortfolio(filterDate, true, selectedCompanyId, commodityCfg).catch(() => ({ portfolio: [] as FuturesPosition[] })),
-        fetchExposure(filterDate, DEFAULT_EXPOSURE_PARAMS).catch(() => null as ExposureResponse | null),
+        hasExposureConfig
+          ? fetchExposure(filterDate, DEFAULT_EXPOSURE_PARAMS).catch(() => null as ExposureResponse | null)
+          : Promise.resolve(null as ExposureResponse | null),
       ]);
 
       // 3) FX delta + P&L MTD from store (refresh after reprice/refprice resolved)


### PR DESCRIPTION
Closes #262

## Problema
/risk-resumen llamaba \`fetchExposure(filterDate, DEFAULT_EXPOSURE_PARAMS)\` para TODAS las empresas. \`DEFAULT_EXPOSURE_PARAMS\` son las toneladas/fletes/fees hardcoded de Super de Alimentos. El Embrujo veia \$82.7M de exposicion USD que no le corresponde.

## Fix
Mismo guard que ya aplicamos en /risk-management: solo llamar fetchExposure si \`companyConfig.exposure_defaults\` tiene datos. Para empresas sin config, exposure = null → Exposicion Natural queda vacia.

## Test plan
- [ ] El Embrujo: Resumen → Exposicion Natural = vacio (no $82.7M)
- [ ] Super: Resumen → Exposicion Natural sigue mostrando valores correctos

🤖 Generated with [Claude Code](https://claude.com/claude-code)