### PR TITLE
feat(risk): Calculadora USDCOP + fixes UX (Rolling VaR default, USD-only setup)

### DIFF
--- a/src/models/risk/usdcopCalculator.ts
+++ b/src/models/risk/usdcopCalculator.ts
@@ -1,0 +1,21 @@
+/**
+ * USDCOP Calculator — fetch TRM and volatility from pysdk backend.
+ * Endpoint: GET /usdcop_calculator
+ */
+
+const BASE_URL = process.env.NEXT_PUBLIC_PYSDK_URL || 'https://pysdk.fly.dev';
+
+export interface UsdCopData {
+  trm: number;
+  vol_diaria: number;
+  vol_anual: number;
+  fecha: string;
+}
+
+export async function fetchUsdCopCalculator(): Promise<UsdCopData> {
+  const resp = await fetch(`${BASE_URL}/usdcop_calculator`);
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch USDCOP calculator: HTTP ${resp.status}`);
+  }
+  return resp.json();
+}

--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -18,6 +18,7 @@ import {
   faFilePdf,
   faBriefcase,
   faMugHot,
+  faCalculator,
 } from '@fortawesome/free-solid-svg-icons';
 import { toast } from 'react-toastify';
 import PageTitle from '@components/PageTitle';
@@ -32,10 +33,14 @@ import {
   Tooltip,
   ResponsiveContainer,
   Legend,
+  ComposedChart,
+  Area,
 } from 'recharts';
 import { fetchRollingVar, fetchBenchmarkFactors, fetchExposure, fetchFuturesPortfolio, upsertFuturesPositions, rollFuturesPosition, closeFuturesPosition, deleteFuturesPosition, editFuturesPosition } from 'src/models/risk/riskApi';
 import { fetchCoffeePrices } from 'src/lib/risk/supabaseRisk';
 import type { CoffeePriceRow } from 'src/lib/risk/supabaseRisk';
+import { fetchUsdCopCalculator } from 'src/models/risk/usdcopCalculator';
+import type { UsdCopData } from 'src/models/risk/usdcopCalculator';
 import type { RollingVarResponse, BenchmarkFactorsResponse, ExposureParams, ExposureResponse, MarketPrice, FuturesPosition, NewFuturesPosition } from 'src/types/risk';
 import useAppStore from 'src/store';
 // Company type no longer needed — global selector in CoreLayout
@@ -716,13 +721,15 @@ function RiskManagement() {
   const hasCafe = companyConfig?.commodities?.some((c) => c.asset === 'CAFE') ?? false;
 
   const [activeTab, setActiveTab] = useState('benchmark');
-  // Build tabs dynamically: add "Precios Locales" if company has CAFE
+  // Build tabs dynamically: add "Precios Locales" if CAFE, + "Calculadora USDCOP" always
   const [pageTabs, setPageTabs] = useState<TabItemType[]>(TAB_ITEMS);
   useEffect(() => {
     const baseTabs = [...TAB_ITEMS];
     if (hasCafe) {
       baseTabs.push({ name: 'Precios Locales', property: 'coffee', icon: faMugHot, active: false });
     }
+    // Calculadora USDCOP disponible para TODAS las empresas (depende del USD, no de un commodity)
+    baseTabs.push({ name: 'Calculadora USDCOP', property: 'usdcop', icon: faCalculator, active: false });
     setPageTabs(baseTabs.map((t) => ({ ...t, active: t.property === activeTab })));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasCafe]);
@@ -732,6 +739,12 @@ function RiskManagement() {
   const [coffeeLoading, setCoffeeLoading] = useState(false);
   const [fncDateFrom, setFncDateFrom] = useState('');
   const [fncDateTo, setFncDateTo] = useState('');
+
+  // USDCOP calculator state
+  const [usdcopData, setUsdcopData] = useState<UsdCopData | null>(null);
+  const [usdcopLoading, setUsdcopLoading] = useState(false);
+  const [usdcopDays, setUsdcopDays] = useState(30);
+  const [usdcopSigma, setUsdcopSigma] = useState(2.0);
   const [filterDate, setFilterDate] = useState(defaultDate());
 
   // OTC store handles — used by Benchmark USD row auto-fill
@@ -1059,6 +1072,18 @@ function RiskManagement() {
     }
   }, []);
 
+  const handleFetchUsdcop = useCallback(async () => {
+    setUsdcopLoading(true);
+    try {
+      const data = await fetchUsdCopCalculator();
+      setUsdcopData(data);
+    } catch (e: unknown) {
+      toast.error((e as Error)?.message || 'Error cargando calculadora USDCOP');
+    } finally {
+      setUsdcopLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     if (!companyConfig) return; // guard: esperar a que config cargue
     if (activeTab === 'rolling') handleFetchRolling();
@@ -1069,6 +1094,7 @@ function RiskManagement() {
     }
     if (activeTab === 'futures') handleFetchFutures();
     if (activeTab === 'coffee') handleFetchCoffeePrices();
+    if (activeTab === 'usdcop' && !usdcopData) handleFetchUsdcop();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab, futuresMonth, benchmarkDateStr, companyConfig]);
 
@@ -2600,6 +2626,256 @@ function RiskManagement() {
                       </div>
                     </div>
                   )}
+                </>
+              );
+            })()}
+          </div>
+        )}
+
+      {/* ─── CALCULADORA USDCOP TAB ─── */}
+        {activeTab === 'usdcop' && (
+          <div>
+            <Row className="mb-3 align-items-center">
+              <Col xs="auto">
+                <Button variant="primary" size="sm" onClick={handleFetchUsdcop} disabled={usdcopLoading}>
+                  <Icon icon={faSyncAlt} className={usdcopLoading ? 'fa-spin me-1' : 'me-1'} />
+                  Actualizar
+                </Button>
+              </Col>
+              <Col>
+                <span className="text-muted" style={{ fontSize: '0.8rem' }}>
+                  Proyección de rango de precio basada en volatilidad histórica rolling 180 días
+                </span>
+              </Col>
+            </Row>
+
+            {usdcopLoading && !usdcopData && <p className="text-muted">Cargando datos...</p>}
+
+            {usdcopData && (() => {
+              const TRM = usdcopData.trm;
+              const VOL_D = usdcopData.vol_diaria;
+              const CONF: Record<string, number> = {
+                '0.5': 38.3, '1': 68.3, '1.5': 86.6, '2': 95.4, '2.5': 98.8, '3': 99.7,
+              };
+              const bandAt = (t: number, k: number) => {
+                const sig = VOL_D * Math.sqrt(t) * k;
+                return { floor: TRM * (1 - sig), ceil: TRM * (1 + sig) };
+              };
+              const { floor, ceil } = bandAt(usdcopDays, usdcopSigma);
+              const width = ceil - floor;
+              const widthPct = (width / TRM) * 100;
+              const confKey = usdcopSigma.toString();
+              const conf = CONF[confKey] ?? CONF[usdcopSigma.toFixed(1)] ?? 0;
+              const fmtUsdcop = (n: number) => n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+              // Chart data: cono de incertidumbre hasta T días
+              const chartData = Array.from({ length: usdcopDays + 1 }, (_, t) => {
+                if (t === 0) {
+                  return { t, floor: TRM, ceil: TRM, trm: TRM, spread: 0 };
+                }
+                const b = bandAt(t, usdcopSigma);
+                return { t, floor: b.floor, ceil: b.ceil, trm: TRM, spread: b.ceil - b.floor };
+              });
+
+              const statCardStyle = { background: '#f7f9fc', border: '1px solid #d9e1ec', borderRadius: 10, padding: '14px 16px' };
+              const statLabel = { fontSize: '0.72rem', color: '#64748b', textTransform: 'uppercase' as const, letterSpacing: '0.05em', fontWeight: 600 };
+              const statVal = { fontFamily: 'ui-monospace, Consolas, monospace', fontSize: '1.3rem', fontWeight: 600, marginTop: 4 };
+
+              const resultCardStyle = { background: '#eef2f8', border: '1px solid #d9e1ec', borderRadius: 10, padding: '14px', textAlign: 'center' as const };
+              const resultLabel = { fontSize: '0.68rem', color: '#64748b', textTransform: 'uppercase' as const, letterSpacing: '0.06em', fontWeight: 600 };
+              const resultVal = { fontFamily: 'ui-monospace, Consolas, monospace', fontSize: '1.45rem', fontWeight: 700, marginTop: 6 };
+
+              return (
+                <>
+                  {/* Stats cards: TRM / Fecha / Vol D / Vol A */}
+                  <Row className="g-2 mb-3">
+                    <Col xs={6} md={3}>
+                      <div style={statCardStyle}>
+                        <div style={statLabel}>TRM actual</div>
+                        <div style={statVal}>{fmtUsdcop(TRM)}</div>
+                      </div>
+                    </Col>
+                    <Col xs={6} md={3}>
+                      <div style={statCardStyle}>
+                        <div style={statLabel}>Fecha</div>
+                        <div style={statVal}>{usdcopData.fecha.slice(0, 10)}</div>
+                      </div>
+                    </Col>
+                    <Col xs={6} md={3}>
+                      <div style={statCardStyle}>
+                        <div style={statLabel}>Vol. diaria (180d)</div>
+                        <div style={statVal}>{(VOL_D * 100).toFixed(4)}%</div>
+                      </div>
+                    </Col>
+                    <Col xs={6} md={3}>
+                      <div style={statCardStyle}>
+                        <div style={statLabel}>Vol. anual (180d)</div>
+                        <div style={statVal}>{(usdcopData.vol_anual * 100).toFixed(2)}%</div>
+                      </div>
+                    </Col>
+                  </Row>
+
+                  <h5 style={{ fontSize: '1.1rem', marginTop: 24, marginBottom: 12, fontWeight: 700 }}>1. Calculadora interactiva</h5>
+
+                  {/* Controls + Results card */}
+                  <div style={{ background: '#f7f9fc', border: '1px solid #d9e1ec', borderRadius: 12, padding: 22, marginBottom: 20 }}>
+                    <Row className="g-4">
+                      <Col xs={12} md={6}>
+                        <div style={{ marginBottom: 8, display: 'flex', justifyContent: 'space-between', fontSize: '0.78rem', color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                          <span>Días a pronosticar</span>
+                          <span style={{ color: '#059669', fontFamily: 'ui-monospace, Consolas, monospace', fontWeight: 600 }}>{usdcopDays} día{usdcopDays === 1 ? '' : 's'}</span>
+                        </div>
+                        <Form.Range min={1} max={180} step={1} value={usdcopDays} onChange={(e) => setUsdcopDays(parseInt(e.target.value, 10))} />
+                      </Col>
+                      <Col xs={12} md={6}>
+                        <div style={{ marginBottom: 8, display: 'flex', justifyContent: 'space-between', fontSize: '0.78rem', color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                          <span>Desviaciones estándar</span>
+                          <span style={{ color: '#059669', fontFamily: 'ui-monospace, Consolas, monospace', fontWeight: 600 }}>{usdcopSigma.toFixed(1)} σ</span>
+                        </div>
+                        <Form.Range min={0.5} max={3.0} step={0.5} value={usdcopSigma} onChange={(e) => setUsdcopSigma(parseFloat(e.target.value))} />
+                      </Col>
+                    </Row>
+
+                    <Row className="g-2 mt-2">
+                      <Col xs={6} md={3}>
+                        <div style={resultCardStyle}>
+                          <div style={resultLabel}>Piso</div>
+                          <div style={{ ...resultVal, color: '#dc2626' }}>{fmtUsdcop(floor)}</div>
+                        </div>
+                      </Col>
+                      <Col xs={6} md={3}>
+                        <div style={resultCardStyle}>
+                          <div style={resultLabel}>Techo</div>
+                          <div style={{ ...resultVal, color: '#059669' }}>{fmtUsdcop(ceil)}</div>
+                        </div>
+                      </Col>
+                      <Col xs={6} md={3}>
+                        <div style={resultCardStyle}>
+                          <div style={resultLabel}>Amplitud</div>
+                          <div style={{ ...resultVal, color: '#d97706' }}>{fmtUsdcop(width)} ({widthPct.toFixed(1)}%)</div>
+                        </div>
+                      </Col>
+                      <Col xs={6} md={3}>
+                        <div style={resultCardStyle}>
+                          <div style={resultLabel}>Confianza</div>
+                          <div style={{ ...resultVal, color: '#2563eb' }}>{conf.toFixed(1)}%</div>
+                        </div>
+                      </Col>
+                    </Row>
+                  </div>
+
+                  {/* Chart */}
+                  <div style={{ background: '#f7f9fc', border: '1px solid #d9e1ec', borderRadius: 12, padding: 20, marginBottom: 28, height: 420 }}>
+                    <ResponsiveContainer width="100%" height="100%">
+                      <ComposedChart data={chartData} margin={{ top: 10, right: 30, left: 20, bottom: 10 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="rgba(217,225,236,0.6)" />
+                        <XAxis dataKey="t" tick={{ fontSize: 11, fill: '#64748b' }} tickLine={false} label={{ value: 'Días hacia adelante', position: 'insideBottom', offset: -5, fill: '#64748b', fontSize: 12 }} />
+                        <YAxis tick={{ fontSize: 11, fill: '#64748b' }} tickFormatter={(v: number) => fmtUsdcop(v)} width={75} domain={['auto', 'auto']} tickLine={false} label={{ value: 'COP por USD', angle: -90, position: 'insideLeft', fill: '#64748b', fontSize: 12 }} />
+                        <Tooltip
+                          formatter={(value: number, name: string) => {
+                            const labelMap: Record<string, string> = { floor: 'Piso', ceil: 'Techo', trm: 'TRM actual' };
+                            return [fmtUsdcop(value), labelMap[name] ?? name];
+                          }}
+                          labelFormatter={(v: number) => `Día ${v}`}
+                          contentStyle={{ borderRadius: 8, border: '1px solid #d9e1ec' }}
+                        />
+                        <Legend
+                          formatter={(value: string) => {
+                            const labelMap: Record<string, string> = { floor: 'Piso', ceil: 'Techo', trm: 'TRM actual' };
+                            return labelMap[value] ?? value;
+                          }}
+                          wrapperStyle={{ fontSize: '0.78rem' }}
+                        />
+                        <Area type="monotone" dataKey="ceil" stroke="#059669" fill="rgba(5,150,105,0.12)" strokeWidth={2} dot={false} activeDot={false} />
+                        <Area type="monotone" dataKey="floor" stroke="#dc2626" fill="#ffffff" strokeWidth={2} dot={false} activeDot={false} />
+                        <Line type="monotone" dataKey="trm" stroke="#2563eb" strokeDasharray="6 4" strokeWidth={1.5} dot={false} />
+                      </ComposedChart>
+                    </ResponsiveContainer>
+                  </div>
+
+                  {/* Justificación estadística */}
+                  <h5 style={{ fontSize: '1.1rem', marginTop: 24, marginBottom: 12, fontWeight: 700 }}>2. Justificación estadística</h5>
+
+                  <div style={{ background: '#f7f9fc', border: '1px solid #d9e1ec', borderRadius: 12, padding: 22, marginBottom: 20 }}>
+                    <h6 style={{ color: '#2563eb', fontSize: '1rem', marginTop: 0, marginBottom: 8 }}>¿Qué es la volatilidad rolling 180 días y por qué 180?</h6>
+                    <p style={{ color: '#334155', fontSize: '0.92rem' }}>
+                      La <strong>volatilidad rolling</strong> es la desviación estándar de los retornos logarítmicos diarios
+                      calculada sobre una ventana móvil. Con 180 días hábiles (~9 meses calendario) logramos un balance entre:
+                    </p>
+                    <ul style={{ color: '#334155', fontSize: '0.92rem' }}>
+                      <li><strong>Estabilidad estadística:</strong> suficientes observaciones (~180) para un estimador robusto.</li>
+                      <li><strong>Relevancia temporal:</strong> captura el régimen reciente sin arrastrar shocks antiguos.</li>
+                      <li><strong>Ciclos macro:</strong> abarca al menos dos reuniones del Banco de la República y un ciclo fiscal parcial.</li>
+                    </ul>
+                    <p style={{ color: '#334155', fontSize: '0.92rem' }}>
+                      Ventanas más cortas (30–60d) son reactivas pero ruidosas; más largas (365d+) suavizan demasiado y ocultan
+                      cambios de régimen. 180d es el estándar de la industria para pares FX de mercados emergentes.
+                    </p>
+
+                    <h6 style={{ color: '#2563eb', fontSize: '1rem', marginTop: 20, marginBottom: 8 }}>¿Qué significa cada nivel de desviación estándar?</h6>
+                    <p style={{ color: '#334155', fontSize: '0.92rem' }}>Bajo el supuesto de normalidad, el siguiente porcentaje de observaciones cae dentro de ±Nσ respecto a la media:</p>
+                    <table className="table table-sm" style={{ fontSize: '0.88rem', marginBottom: 16 }}>
+                      <thead>
+                        <tr style={{ borderBottom: '2px solid #d9e1ec' }}>
+                          <th style={{ color: '#64748b', textTransform: 'uppercase', fontSize: '0.72rem' }}>Nivel</th>
+                          <th style={{ color: '#64748b', textTransform: 'uppercase', fontSize: '0.72rem' }}>Confianza</th>
+                          <th style={{ color: '#64748b', textTransform: 'uppercase', fontSize: '0.72rem' }}>Interpretación</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr><td style={{ fontFamily: 'monospace' }}>1.0 σ</td><td style={{ fontFamily: 'monospace' }}>68.3%</td><td>Rango típico, ~2 de 3 días</td></tr>
+                        <tr><td style={{ fontFamily: 'monospace' }}>1.5 σ</td><td style={{ fontFamily: 'monospace' }}>86.6%</td><td>Rango amplio, ~6 de 7 días</td></tr>
+                        <tr><td style={{ fontFamily: 'monospace' }}>2.0 σ</td><td style={{ fontFamily: 'monospace' }}>95.4%</td><td>Rango conservador, ~19 de 20 días</td></tr>
+                        <tr><td style={{ fontFamily: 'monospace' }}>2.5 σ</td><td style={{ fontFamily: 'monospace' }}>98.8%</td><td>Rango extremo, ~1 excepción en 83 días</td></tr>
+                        <tr><td style={{ fontFamily: 'monospace' }}>3.0 σ</td><td style={{ fontFamily: 'monospace' }}>99.7%</td><td>Rango máximo, ~1 excepción en 370 días</td></tr>
+                      </tbody>
+                    </table>
+
+                    <h6 style={{ color: '#2563eb', fontSize: '1rem', marginTop: 20, marginBottom: 8 }}>¿Por qué el rango se amplía con el tiempo? (Raíz del tiempo)</h6>
+                    <p style={{ color: '#334155', fontSize: '0.92rem' }}>
+                      Si los retornos diarios son independientes e idénticamente distribuidos, la varianza es aditiva:
+                      la varianza de T días equivale a T veces la varianza de un día. Como la volatilidad es la raíz cuadrada de la varianza:
+                    </p>
+                    <p style={{ textAlign: 'center', fontFamily: 'ui-monospace, Consolas, monospace', fontSize: '1.05rem', color: '#059669', margin: '12px 0' }}>
+                      σ(T días) = σ(1 día) × √T
+                    </p>
+                    <p style={{ color: '#334155', fontSize: '0.92rem' }}>
+                      Por eso el rango crece con <strong>√T</strong>, no linealmente. Duplicar el horizonte amplía la banda solo
+                      en un factor de 1.41, no 2. El cono de incertidumbre tiene forma parabólica.
+                    </p>
+
+                    <h6 style={{ color: '#2563eb', fontSize: '1rem', marginTop: 20, marginBottom: 8 }}>Limitaciones del modelo</h6>
+                    <ul style={{ color: '#334155', fontSize: '0.92rem' }}>
+                      <li><strong>Colas gordas:</strong> los retornos reales tienen más eventos extremos que la normal. Un &quot;2σ&quot; real suele cubrir ~93% en lugar de 95.4%.</li>
+                      <li><strong>Volatilidad estocástica:</strong> la volatilidad no es constante; se agrupa en regímenes (clustering). Modelos GARCH capturan esto mejor.</li>
+                      <li><strong>Eventos discretos:</strong> decisiones del BanRep, datos de inflación US, shocks petroleros o políticos generan gaps que el modelo gaussiano no anticipa.</li>
+                      <li><strong>Correlación serial:</strong> si hay tendencia (drift), el centro de la banda debería desplazarse, no quedar anclado en la TRM actual.</li>
+                      <li><strong>Horizonte largo:</strong> más allá de 60–90 días la distribución real se aleja notablemente de la normal y la proyección pierde precisión.</li>
+                    </ul>
+
+                    <h6 style={{ color: '#2563eb', fontSize: '1rem', marginTop: 20, marginBottom: 8 }}>Guía práctica: ¿qué nivel usar?</h6>
+                    <table className="table table-sm" style={{ fontSize: '0.88rem' }}>
+                      <thead>
+                        <tr style={{ borderBottom: '2px solid #d9e1ec' }}>
+                          <th style={{ color: '#64748b', textTransform: 'uppercase', fontSize: '0.72rem' }}>Horizonte</th>
+                          <th style={{ color: '#64748b', textTransform: 'uppercase', fontSize: '0.72rem' }}>Nivel sugerido</th>
+                          <th style={{ color: '#64748b', textTransform: 'uppercase', fontSize: '0.72rem' }}>Uso típico</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr><td>1–7 días</td><td style={{ fontFamily: 'monospace' }}>1.0–1.5 σ</td><td>Trading intradía, cobertura táctica</td></tr>
+                        <tr><td>8–30 días</td><td style={{ fontFamily: 'monospace' }}>1.5–2.0 σ</td><td>Flujos operativos, importadores/exportadores</td></tr>
+                        <tr><td>31–90 días</td><td style={{ fontFamily: 'monospace' }}>2.0 σ</td><td>Presupuestos trimestrales, forwards cortos</td></tr>
+                        <tr><td>91–180 días</td><td style={{ fontFamily: 'monospace' }}>2.0–2.5 σ</td><td>Planeación semestral, cobertura estratégica</td></tr>
+                        <tr><td>Stress testing</td><td style={{ fontFamily: 'monospace' }}>3.0 σ</td><td>Worst-case, capital regulatorio, colchones</td></tr>
+                      </tbody>
+                    </table>
+
+                    <div style={{ background: 'rgba(217,119,6,0.08)', borderLeft: '3px solid #d97706', padding: '12px 14px', borderRadius: 6, marginTop: 12, color: '#78350f', fontSize: '0.9rem' }}>
+                      <strong>Regla práctica:</strong> a mayor horizonte y mayor sensibilidad a pérdidas, mayor σ. Pero recuerda
+                      que ampliar el rango tiene un costo: decisiones más conservadoras y menos accionables.
+                    </div>
+                  </div>
                 </>
               );
             })()}


### PR DESCRIPTION
Closes #264

## Summary
Tres cambios combinados en una sola rama:

### 1. Tab Calculadora USDCOP (feat)
Nuevo tab en /risk-management — consume \`GET /usdcop_calculator\` del backend pysdk (PR avelezX/xerenity-backend#96).

- 4 stat cards (TRM, Fecha, Vol diaria, Vol anual)
- 2 sliders: dias (1-180), sigma (0.5-3.0)
- 4 result cards: Piso, Techo, Amplitud, Confianza
- Cono de incertidumbre (Recharts ComposedChart: Area + Line)
- Justificacion estadistica completa

### 2. Rolling VaR default asset (fix)
Antes hardcodeaba \`selectedAsset='MAIZ'\` aunque la empresa no tuviera MAIZ. Ahora arranca vacio y un useEffect lo auto-selecciona al primer asset del \`companyConfig\`.

### 3. CommoditySetup USD-only flow (fix)
- Tarjeta fija **USD (fijo) — BanRep TRM** en el grid (siempre incluida)
- Permite guardar con 0 commodities: "Continuar solo con USD"
- Fix layout: el Button custom tiene display:flex, no se centra con text-align. Envuelto en \`d-flex justify-content-center\`.
- Mejor error logging (console.error + toast 8s).

## Requisitos
Backend PR avelezX/xerenity-backend#96 debe estar desplegado en Fly.io para que la Calculadora USDCOP traiga datos reales.

## Test plan
- [ ] Los Coches (solo USD): setup "Continuar solo con USD" funciona y entra al dashboard
- [ ] El Embrujo (CAFE): Rolling VaR abre en CAFE, no en MAIZ vacio
- [ ] Super de Alimentos: Rolling VaR abre en MAIZ (primer asset)
- [ ] Tab Calculadora USDCOP carga stats + cono se mueve con sliders

🤖 Generated with [Claude Code](https://claude.com/claude-code)