### PR TITLE
fix(agent): larger chat fonts + crypto/series knowledge

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -14,8 +14,8 @@ const Bubble = styled.div<{ $isUser: boolean }>`
   max-width: 85%;
   padding: 10px 14px;
   border-radius: 12px;
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: 15px;
+  line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
 
@@ -42,7 +42,7 @@ const ToolBadge = styled.div`
   background: #e0e7ff;
   color: #4338ca;
   border-radius: 4px;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
 `;
 
@@ -56,7 +56,7 @@ const NavLink = styled.button`
   color: white;
   border: none;
   border-radius: 6px;
-  font-size: 12px;
+  font-size: 14px;
   cursor: pointer;
   &:hover {
     background: #4338ca;

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -37,7 +37,7 @@ const Header = styled.div`
 
 const Title = styled.div`
   font-weight: 700;
-  font-size: 15px;
+  font-size: 16px;
   color: #1e293b;
 `;
 
@@ -70,7 +70,7 @@ const EmptyState = styled.div`
   justify-content: center;
   height: 100%;
   color: #94a3b8;
-  font-size: 13px;
+  font-size: 15px;
   text-align: center;
   padding: 24px;
   gap: 8px;
@@ -90,7 +90,7 @@ const Input = styled.input`
   padding: 10px 12px;
   border: 1px solid #cbd5e1;
   border-radius: 8px;
-  font-size: 13px;
+  font-size: 15px;
   outline: none;
   &:focus { border-color: #4F46E5; box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.1); }
 `;
@@ -114,7 +114,7 @@ const ErrorBanner = styled.div`
   padding: 8px 16px;
   background: #fef2f2;
   color: #dc2626;
-  font-size: 12px;
+  font-size: 14px;
   border-bottom: 1px solid #fecaca;
 `;
 
@@ -178,7 +178,7 @@ export default function ChatPanel() {
           <EmptyState>
             <div style={{ fontSize: 28 }}>🤖</div>
             <div>Soy el asistente de Xerenity</div>
-            <div style={{ fontSize: 11, color: '#b0b8c4' }}>
+            <div style={{ fontSize: 13, color: '#b0b8c4' }}>
               Puedo consultar datos, generar graficos, navegar la app y crear posiciones.
             </div>
           </EmptyState>

--- a/src/pages/api/chat/system-prompt.ts
+++ b/src/pages/api/chat/system-prompt.ts
@@ -142,6 +142,51 @@ Columnas: id (uuid, PK), owner (uuid), company_id (uuid), label, counterparty, n
 | /admin | Administracion |
 | /settings | Configuracion |
 
+## Pares de Monedas y Criptomonedas
+
+La plataforma tiene una seccion "Par de Monedas" (/par-monedas) donde los usuarios pueden:
+1. Seleccionar una moneda DE (FROM) y una moneda A (TO)
+2. Ver el grafico historico del par
+3. Comparar multiples pares en un mismo grafico
+
+### Monedas FIAT disponibles
+USD, EUR, COP, MXN, BRL, AUD, JPY, CHF, GBP, NOK, SEK, HUF, PLN, CNY, INR, IDR, HKD, MYR, SGD
+
+Los pares FIAT se consultan desde la base de datos:
+- Tabla: xerenity.currency (formato: "USD:COP", "EUR:USD", etc.)
+- Funcion RPC: get_currency(currency_name TEXT)
+
+### Criptomonedas disponibles
+BTC, ETH, SOL, XRP, ADA, DOGE, AVAX, DOT, MATIC, LINK, BNB, LTC, UNI, ATOM, NEAR, APT, ARB, OP, FTM, ALGO
+
+**IMPORTANTE:** Los datos de criptomonedas NO estan en la base de datos de Xerenity. Se obtienen de una API externa (CryptoCompare) directamente desde el frontend. Por lo tanto:
+- NO puedes consultar precios de crypto con query_database
+- Si el usuario pregunta por Bitcoin, Ethereum, u otra crypto, usa navigate_to para llevarlo a /par-monedas donde puede seleccionar la crypto y la moneda base
+- Explica que los datos de crypto se visualizan en la seccion "Par de Monedas" seleccionando la crypto en el panel FROM y la moneda destino (USD, COP, etc.) en el panel TO
+
+### Monedas Dashboard (/monedas-dashboard)
+Otra vista para ver el dashboard de monedas principales con graficos resumidos.
+
+## Series de Datos
+
+La plataforma tiene un amplio catalogo de series economicas accesible desde /series:
+
+### Banrep (Banco de la Republica de Colombia)
+- Catalogo: xerenity.banrep_serie_v2 (id, nombre, description, fuente, grupo)
+- Valores: xerenity.banrep_series_value_v2 (id_serie, fecha, valor)
+- Para buscar series: SELECT id, nombre, description FROM xerenity.banrep_serie_v2 WHERE nombre ILIKE '%termino%' LIMIT 20
+- Para leer valores: SELECT fecha, valor FROM xerenity.banrep_series_value_v2 WHERE id_serie = X ORDER BY fecha DESC LIMIT 100
+
+### Camacol (Sector Construccion Colombia)
+- Catalogo: xerenity.camacol_serie (id, nombre, description, grupo)
+- Valores: xerenity.camacol_series_value (id_serie, fecha, valor)
+
+### BCRP (Banco Central del Peru)
+- Valores: xerenity.bcrp_series_value (id_serie, fecha, valor)
+
+### Series publicas
+- Catalogo general: xerenity.public_series — para buscar cualquier serie disponible
+
 ## Ejemplos de Interaccion
 
 Usuario: "Cual es la TRM hoy?"
@@ -155,5 +200,17 @@ Usuario: "Llevame a prestamos"
 
 Usuario: "Crea una posicion NDF de 1M USD strike 4200 vencimiento junio 2026"
 -> Muestra resumen y pide confirmacion, luego usa create_position
+
+Usuario: "Cual es el precio del Bitcoin?"
+-> Usa navigate_to con path="/par-monedas" y explica que debe seleccionar BTC en el panel izquierdo y USD (o COP) en el panel derecho para ver el precio y grafico historico
+
+Usuario: "Graficame el Bitcoin vs Ethereum"
+-> Usa navigate_to con path="/par-monedas" y explica que puede agregar multiples pares (BTC:USD y ETH:USD) para compararlos en el mismo grafico
+
+Usuario: "Que series economicas tienen de Colombia?"
+-> Usa query_database para consultar SELECT id, nombre, description, grupo FROM xerenity.banrep_serie_v2 ORDER BY grupo, nombre LIMIT 50
+
+Usuario: "Muestrame la base monetaria de Colombia"
+-> Usa query_database para buscar la serie en banrep_serie_v2, luego consultar sus valores y graficar
 `;
 }


### PR DESCRIPTION
## Summary
- Aumenta tamaños de fuente en el chat (13px → 15px) para mejor legibilidad
- Enseña al agente sobre criptomonedas (BTC, ETH, SOL, etc.) y series economicas
- El agente ahora sabe que crypto viene de API externa y redirige a /par-monedas

## UI Changes
- Message bubbles: 13px → 15px, line-height 1.5 → 1.6
- Input field: 13px → 15px
- Empty state, error banner, nav links: fonts aumentados

## Agent Knowledge
- Crypto: 20 cryptos, explica que NO estan en DB, redirige a /par-monedas
- Series: Banrep, Camacol, BCRP catalogs + como buscar y leer valores
- Nuevos ejemplos: Bitcoin, series economicas, base monetaria

## Test plan
- [ ] Chat legible en produccion (fonts mas grandes)
- [ ] Preguntar "precio del Bitcoin" → agente redirige a /par-monedas
- [ ] Preguntar "que series economicas tienen?" → agente consulta banrep_serie_v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)