### PR TITLE
feat(agent): view_series tool + larger fonts + crypto knowledge

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -14,8 +14,8 @@ const Bubble = styled.div<{ $isUser: boolean }>`
   max-width: 85%;
   padding: 10px 14px;
   border-radius: 12px;
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: 15px;
+  line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
 
@@ -42,7 +42,7 @@ const ToolBadge = styled.div`
   background: #e0e7ff;
   color: #4338ca;
   border-radius: 4px;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
 `;
 
@@ -56,7 +56,7 @@ const NavLink = styled.button`
   color: white;
   border: none;
   border-radius: 6px;
-  font-size: 12px;
+  font-size: 14px;
   cursor: pointer;
   &:hover {
     background: #4338ca;

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -37,7 +37,7 @@ const Header = styled.div`
 
 const Title = styled.div`
   font-weight: 700;
-  font-size: 15px;
+  font-size: 16px;
   color: #1e293b;
 `;
 
@@ -70,7 +70,7 @@ const EmptyState = styled.div`
   justify-content: center;
   height: 100%;
   color: #94a3b8;
-  font-size: 13px;
+  font-size: 15px;
   text-align: center;
   padding: 24px;
   gap: 8px;
@@ -90,7 +90,7 @@ const Input = styled.input`
   padding: 10px 12px;
   border: 1px solid #cbd5e1;
   border-radius: 8px;
-  font-size: 13px;
+  font-size: 15px;
   outline: none;
   &:focus { border-color: #4F46E5; box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.1); }
 `;
@@ -114,7 +114,7 @@ const ErrorBanner = styled.div`
   padding: 8px 16px;
   background: #fef2f2;
   color: #dc2626;
-  font-size: 12px;
+  font-size: 14px;
   border-bottom: 1px solid #fecaca;
 `;
 
@@ -178,7 +178,7 @@ export default function ChatPanel() {
           <EmptyState>
             <div style={{ fontSize: 28 }}>🤖</div>
             <div>Soy el asistente de Xerenity</div>
-            <div style={{ fontSize: 11, color: '#b0b8c4' }}>
+            <div style={{ fontSize: 13, color: '#b0b8c4' }}>
               Puedo consultar datos, generar graficos, navegar la app y crear posiciones.
             </div>
           </EmptyState>

--- a/src/pages/api/chat/system-prompt.ts
+++ b/src/pages/api/chat/system-prompt.ts
@@ -142,6 +142,51 @@ Columnas: id (uuid, PK), owner (uuid), company_id (uuid), label, counterparty, n
 | /admin | Administracion |
 | /settings | Configuracion |
 
+## Pares de Monedas y Criptomonedas
+
+La plataforma tiene una seccion "Par de Monedas" (/par-monedas) donde los usuarios pueden:
+1. Seleccionar una moneda DE (FROM) y una moneda A (TO)
+2. Ver el grafico historico del par
+3. Comparar multiples pares en un mismo grafico
+
+### Monedas FIAT disponibles
+USD, EUR, COP, MXN, BRL, AUD, JPY, CHF, GBP, NOK, SEK, HUF, PLN, CNY, INR, IDR, HKD, MYR, SGD
+
+Los pares FIAT se consultan desde la base de datos:
+- Tabla: xerenity.currency (formato: "USD:COP", "EUR:USD", etc.)
+- Funcion RPC: get_currency(currency_name TEXT)
+
+### Criptomonedas disponibles
+BTC, ETH, SOL, XRP, ADA, DOGE, AVAX, DOT, MATIC, LINK, BNB, LTC, UNI, ATOM, NEAR, APT, ARB, OP, FTM, ALGO
+
+**IMPORTANTE:** Los datos de criptomonedas NO estan en la base de datos de Xerenity. Se obtienen de una API externa (CryptoCompare) directamente desde el frontend. Por lo tanto:
+- NO puedes consultar precios de crypto con query_database
+- Si el usuario pregunta por Bitcoin, Ethereum, u otra crypto, usa navigate_to para llevarlo a /par-monedas donde puede seleccionar la crypto y la moneda base
+- Explica que los datos de crypto se visualizan en la seccion "Par de Monedas" seleccionando la crypto en el panel FROM y la moneda destino (USD, COP, etc.) en el panel TO
+
+### Monedas Dashboard (/monedas-dashboard)
+Otra vista para ver el dashboard de monedas principales con graficos resumidos.
+
+## Series de Datos
+
+La plataforma tiene un amplio catalogo de series economicas accesible desde /series:
+
+### Banrep (Banco de la Republica de Colombia)
+- Catalogo: xerenity.banrep_serie_v2 (id, nombre, description, fuente, grupo)
+- Valores: xerenity.banrep_series_value_v2 (id_serie, fecha, valor)
+- Para buscar series: SELECT id, nombre, description FROM xerenity.banrep_serie_v2 WHERE nombre ILIKE '%termino%' LIMIT 20
+- Para leer valores: SELECT fecha, valor FROM xerenity.banrep_series_value_v2 WHERE id_serie = X ORDER BY fecha DESC LIMIT 100
+
+### Camacol (Sector Construccion Colombia)
+- Catalogo: xerenity.camacol_serie (id, nombre, description, grupo)
+- Valores: xerenity.camacol_series_value (id_serie, fecha, valor)
+
+### BCRP (Banco Central del Peru)
+- Valores: xerenity.bcrp_series_value (id_serie, fecha, valor)
+
+### Series publicas
+- Catalogo general: xerenity.public_series — para buscar cualquier serie disponible
+
 ## Ejemplos de Interaccion
 
 Usuario: "Cual es la TRM hoy?"
@@ -155,5 +200,17 @@ Usuario: "Llevame a prestamos"
 
 Usuario: "Crea una posicion NDF de 1M USD strike 4200 vencimiento junio 2026"
 -> Muestra resumen y pide confirmacion, luego usa create_position
+
+Usuario: "Cual es el precio del Bitcoin?"
+-> Usa navigate_to con path="/par-monedas" y explica que debe seleccionar BTC en el panel izquierdo y USD (o COP) en el panel derecho para ver el precio y grafico historico
+
+Usuario: "Graficame el Bitcoin vs Ethereum"
+-> Usa navigate_to con path="/par-monedas" y explica que puede agregar multiples pares (BTC:USD y ETH:USD) para compararlos en el mismo grafico
+
+Usuario: "Que series economicas tienen de Colombia?"
+-> Usa query_database para consultar SELECT id, nombre, description, grupo FROM xerenity.banrep_serie_v2 ORDER BY grupo, nombre LIMIT 50
+
+Usuario: "Muestrame la base monetaria de Colombia"
+-> Usa query_database para buscar la serie en banrep_serie_v2, luego consultar sus valores y graficar
 `;
 }

--- a/src/pages/api/chat/system-prompt.ts
+++ b/src/pages/api/chat/system-prompt.ts
@@ -99,9 +99,21 @@ Columnas: id (uuid, PK), owner (uuid), company_id (uuid), label, counterparty, n
 - Para la TRM (tasa representativa del mercado), consulta: SELECT value, time FROM xerenity.currency WHERE currency = 'USD:COP' ORDER BY time DESC LIMIT 1
 
 ### generate_chart
-- Usa este tool DESPUES de obtener datos con query_database.
+- Usa este tool SOLO para graficos rapidos y sencillos dentro del chat (ej: TRM del dia, un solo dato puntual).
+- Para series economicas complejas, comparaciones, o multiples series: usa view_series en su lugar.
 - Formatos de fecha: usa el campo como x_axis_key (ej: "fecha", "day", "time").
 - Colores sugeridos: #4F46E5 (indigo), #10B981 (verde), #F59E0B (amarillo), #EF4444 (rojo), #8B5CF6 (violeta).
+
+### view_series (PREFERIDO para graficas)
+- Usa este tool cuando el usuario quiera ver o graficar series economicas, comparar datos, o visualizar tendencias.
+- Este tool abre la pagina de Series (/series) con las series pre-seleccionadas en el graficador profesional de Xerenity.
+- Flujo: (1) Busca el ticker de la serie con query_database en xerenity.public_series o xerenity.banrep_serie_v2, (2) Usa view_series con los tickers encontrados.
+- La columna "ticker" en la tabla de series es el identificador unico (ej: "banrep_5", "banrep_12").
+- Para buscar series: SELECT ticker, display_name, grupo FROM xerenity.search_mv WHERE display_name ILIKE '%termino%' LIMIT 10
+- Maximo 5 series por visualizacion.
+- Ejemplos:
+  - "Graficame el PIB" → buscar ticker del PIB → view_series(["ticker_pib"])
+  - "Compara inflacion vs politica monetaria" → buscar ambos tickers → view_series(["ticker1", "ticker2"])
 
 ### navigate_to
 - Usa este tool cuando el usuario pida ir a una seccion especifica.
@@ -193,7 +205,13 @@ Usuario: "Cual es la TRM hoy?"
 -> Usa query_database para consultar xerenity.currency WHERE currency='USD:COP' ORDER BY time DESC LIMIT 1
 
 Usuario: "Graficame el USDCOP del ultimo mes"
--> Usa query_database para obtener datos, luego generate_chart con chart_type="line"
+-> Usa query_database para obtener datos de xerenity.currency, luego generate_chart con chart_type="line" (grafico simple en chat)
+
+Usuario: "Graficame el PIB de Colombia"
+-> Busca el ticker en xerenity.search_mv WHERE display_name ILIKE '%PIB%', luego usa view_series con el ticker encontrado
+
+Usuario: "Compara la inflacion con la politica monetaria"
+-> Busca ambos tickers en xerenity.search_mv, luego usa view_series con ambos tickers para abrir el graficador
 
 Usuario: "Llevame a prestamos"
 -> Usa navigate_to con path="/loans"

--- a/src/pages/api/chat/tool-executor.ts
+++ b/src/pages/api/chat/tool-executor.ts
@@ -250,6 +250,26 @@ async function executeCreateLoan(
   }
 }
 
+function executeViewSeries(input: Record<string, unknown>): ToolResult {
+  const tickers = input.tickers as string[];
+
+  if (!Array.isArray(tickers) || tickers.length === 0) {
+    return { success: false, error: 'Se requiere al menos un ticker de serie' };
+  }
+
+  if (tickers.length > 5) {
+    return { success: false, error: 'Maximo 5 series a la vez' };
+  }
+
+  const path = `/series?series=${tickers.join(',')}`;
+
+  return {
+    success: true,
+    navigationTarget: path,
+    data: { path, description: input.description, tickers },
+  };
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export async function executeTool(
   toolName: string,
@@ -267,6 +287,8 @@ export async function executeTool(
       return executeCreatePosition(toolInput, userSupabase);
     case 'create_loan':
       return executeCreateLoan(toolInput, userSupabase);
+    case 'view_series':
+      return executeViewSeries(toolInput);
     default:
       return { success: false, error: `Tool desconocido: ${toolName}` };
   }

--- a/src/pages/api/chat/tools.ts
+++ b/src/pages/api/chat/tools.ts
@@ -155,4 +155,27 @@ export const tools: Anthropic.Tool[] = [
       required: ['params'],
     },
   },
+  {
+    name: 'view_series',
+    description:
+      'Abre la pagina de Series con series pre-seleccionadas para visualizar en el graficador profesional. ' +
+      'Usa este tool cuando el usuario quiera VER o GRAFICAR series economicas. ' +
+      'Primero busca los tickers de las series con query_database en xerenity.banrep_serie_v2 o xerenity.public_series, ' +
+      'luego usa este tool con los tickers encontrados.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        tickers: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Array de tickers de series a visualizar (ej: ["banrep_5", "banrep_12"]). Maximo 5 series.',
+        },
+        description: {
+          type: 'string',
+          description: 'Descripcion breve de que series se van a mostrar.',
+        },
+      },
+      required: ['tickers', 'description'],
+    },
+  },
 ];

--- a/src/pages/series/index.tsx
+++ b/src/pages/series/index.tsx
@@ -11,7 +11,8 @@ import {
   Toast,
   Badge,
 } from 'react-bootstrap';
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useRouter } from 'next/router';
 import { LightSerieEntry, lightSerieValueArray } from 'src/types/lightserie';
 import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import {
@@ -42,8 +43,10 @@ const PAGE_TITLE = 'Series';
 const NORMALIZE_SINCE = 'Normalizar desde:';
 
 export default function Dashboard() {
+  const router = useRouter();
   const normalizeDate = useRef<string>('');
   const searchByName = useRef<string>('');
+  const urlSeriesLoaded = useRef<boolean>(false);
 
   const {
     filteredSeries,
@@ -81,6 +84,30 @@ export default function Dashboard() {
     searchSeries({});
     return () => resetStore(); // Reset when component unmount
   }, [resetStore, searchSeries]);
+
+  // Auto-load series from URL query params (e.g., /series?series=ticker1,ticker2)
+  const loadSeriesFromUrl = useCallback(() => {
+    if (urlSeriesLoaded.current || allSeries.length === 0) return;
+
+    const seriesParam = router.query.series;
+    if (!seriesParam) return;
+
+    const tickers = (typeof seriesParam === 'string' ? seriesParam : seriesParam[0]).split(',');
+    urlSeriesLoaded.current = true;
+
+    tickers.forEach((ticker) => {
+      const trimmed = ticker.trim();
+      const found = allSeries.find((s) => s.ticker === trimmed);
+      if (found) {
+        const color = getGroupColor(found.grupo);
+        addSelectedSerie(found.ticker, color, found.display_name);
+      }
+    });
+  }, [allSeries, router.query.series, addSelectedSerie]);
+
+  useEffect(() => {
+    loadSeriesFromUrl();
+  }, [loadSeriesFromUrl]);
 
   function arrayDifference<T>(array1: T[], array2: T[]): T {
     return array1.filter((item) => !array2.includes(item))[0];


### PR DESCRIPTION
## Summary
- Nuevo tool `view_series` que abre la pagina de Series con series pre-seleccionadas
- Pagina /series ahora acepta query params: `/series?series=ticker1,ticker2`
- Fonts del chat mas grandes (13px → 15px)
- Agente conoce crypto (redirige a /par-monedas) y series economicas

## Key Change: view_series flow
```
User: "Graficame el PIB vs inflacion"
Agent: 1. query_database → busca tickers en search_mv
       2. view_series(["ticker_pib", "ticker_inflacion"])
Result: Navega a /series?series=... con ambas series graficadas
```

## Files changed
- `src/pages/series/index.tsx` — lee `?series=` query params y auto-carga series
- `src/pages/api/chat/tools.ts` — nuevo tool `view_series`
- `src/pages/api/chat/tool-executor.ts` — ejecuta view_series (construye URL)
- `src/pages/api/chat/system-prompt.ts` — enseña al agente sobre crypto, series, y view_series
- `src/components/chat/ChatPanel.tsx` — fonts 13→15px
- `src/components/chat/ChatMessage.tsx` — fonts 13→15px, line-height 1.6

## Test plan
- [ ] "Graficame el PIB" → agente busca ticker y abre /series con la serie
- [ ] "Precio del Bitcoin" → agente redirige a /par-monedas
- [ ] Chat legible (fonts mas grandes)
- [ ] /series?series=eccbc87e4b5ce2fe28308fd9f2a7baf3 carga PIB automaticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)