### PR TITLE
fix(evals): exclude evals from ESLint build

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "ignorePatterns": ["src/evals/**"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",


### PR DESCRIPTION
Adds ignorePatterns for src/evals/** in .eslintrc.json. Evals are CLI scripts run with tsx, not part of the Next.js build.