### PR TITLE
feat(agent): chart context + suggestion buttons

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -118,6 +118,44 @@ const ErrorBanner = styled.div`
   border-bottom: 1px solid #fecaca;
 `;
 
+const SuggestionsGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+`;
+
+const SuggestionBtn = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 13px;
+  color: #334155;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.15s ease;
+  &:hover {
+    background: #f0f0ff;
+    border-color: #4F46E5;
+    color: #4F46E5;
+  }
+`;
+
+const ChartContext = styled.div`
+  padding: 8px 16px;
+  background: #f0fdf4;
+  color: #166534;
+  font-size: 12px;
+  border-bottom: 1px solid #bbf7d0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
 export default function ChatPanel() {
   const router = useRouter();
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -133,6 +171,8 @@ export default function ChatPanel() {
     clearChat,
     stopGeneration,
     addTickerToChart,
+    chartSelections,
+    chartPeriod,
   } = useAppStore();
 
   const lastNavTarget = useRef<string | null>(null);
@@ -181,6 +221,24 @@ export default function ChatPanel() {
     inputRef.current?.focus();
   }, []);
 
+  const SUGGESTIONS = [
+    { icon: '📈', text: 'Graficame las tasas IBR por plazo (3m, 6m, 1y)' },
+    { icon: '💹', text: 'Compara la inflacion con la tasa de politica monetaria' },
+    { icon: '🏦', text: 'Muestrame fondos FIC de renta fija' },
+    { icon: '💱', text: 'Cual es la TRM hoy?' },
+    { icon: '📊', text: 'Graficame el PIB vs la inflacion' },
+  ];
+
+  // Build chart context string for the agent
+  const chartContextText = chartSelections.length > 0
+    ? `${chartSelections.map((s) => s.display_name).join(', ')} | Periodo: ${chartPeriod}`
+    : null;
+
+  const handleSuggestion = (text: string) => {
+    if (chatLoading) return;
+    sendMessage(text);
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = input.trim();
@@ -209,6 +267,11 @@ export default function ChatPanel() {
       </Header>
 
       {chatError && <ErrorBanner>{chatError}</ErrorBanner>}
+      {chartContextText && (
+        <ChartContext>
+          📊 En grafico: {chartContextText}
+        </ChartContext>
+      )}
 
       <MessagesArea>
         {chatMessages.length === 0 ? (
@@ -216,8 +279,16 @@ export default function ChatPanel() {
             <div style={{ fontSize: 28 }}>🤖</div>
             <div>Soy el asistente de Xerenity</div>
             <div style={{ fontSize: 13, color: '#b0b8c4' }}>
-              Puedo consultar datos, generar graficos, navegar la app y crear posiciones.
+              Puedo consultar datos, graficar series y crear posiciones.
             </div>
+            <SuggestionsGrid>
+              {SUGGESTIONS.map((s) => (
+                <SuggestionBtn key={s.text} onClick={() => handleSuggestion(s.text)}>
+                  <span>{s.icon}</span>
+                  <span>{s.text}</span>
+                </SuggestionBtn>
+              ))}
+            </SuggestionsGrid>
           </EmptyState>
         ) : (
           chatMessages.map((msg) => (

--- a/src/pages/api/chat/system-prompt.ts
+++ b/src/pages/api/chat/system-prompt.ts
@@ -7,6 +7,14 @@ export function buildSystemPrompt(userName?: string): string {
 Responde siempre en español a menos que el usuario escriba en otro idioma.
 Se conciso y directo. Usa formato markdown cuando sea util.
 
+## Contexto del Grafico
+El primer mensaje del usuario puede incluir un bloque [CONTEXTO DEL GRAFICO ACTUAL: ...] que te dice que series estan cargadas en el graficador y el periodo seleccionado. Usa esta informacion para:
+- Referirte a las series que el usuario ya esta viendo ("Veo que tienes la TRM cargada...")
+- Sugerir agregar series complementarias ("Podrias agregar la tasa de politica monetaria para comparar")
+- Advertir sobre incompatibilidades de periodicidad con las series ya cargadas
+- Ajustar tus recomendaciones de periodo basandote en lo que ya esta seleccionado
+Si no hay contexto del grafico, el usuario no tiene series cargadas.
+
 ## Base de Datos Disponible (Supabase, schema "xerenity")
 
 ### Tablas Principales

--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -65,10 +65,19 @@ const createChatSlice: StateCreator<ChatSlice> = (set, get) => ({
     const abortController = new AbortController();
     set({ chatAbortController: abortController });
 
-    // Build simple messages array for the API
-    const apiMessages = get().chatMessages.map((m) => ({
+    // Build messages array with chart context injected in the first user message
+    const state = get();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const storeAny = state as any;
+    const chartInfo = storeAny.chartSelections?.length > 0
+      ? `[CONTEXTO DEL GRAFICO ACTUAL: Series cargadas: ${storeAny.chartSelections.map((s: { display_name: string }) => s.display_name).join(', ')}. Periodo: ${storeAny.chartPeriod || '1Y'}. El usuario puede ver estas series en pantalla.]`
+      : '';
+
+    const apiMessages = state.chatMessages.map((m, idx) => ({
       role: m.role,
-      content: m.content,
+      content: idx === 0 && m.role === 'user' && chartInfo
+        ? `${chartInfo}\n\n${m.content}`
+        : m.content,
     }));
 
     const assistantId = assistantMessage.id;


### PR DESCRIPTION
## Summary
- Agent now knows what series are in the chart + current period
- 5 suggestion buttons in empty chat state
- Green banner showing current chart context

## Chart context
Agent receives [CONTEXTO DEL GRAFICO: TRM, IBR 3m | Periodo: 1Y] and can:
- Reference loaded series
- Suggest complementary series
- Warn about periodicity mismatches

## Suggestions
Clickable buttons: IBR plazos, Inflación vs monetaria, FIC, TRM, PIB vs inflación

🤖 Generated with [Claude Code](https://claude.com/claude-code)