### PR TITLE
feat(cds-sovereign): add CDS Sovereign 5Y page

### DIFF
--- a/src/components/marketDashboard/MarketDashboard.tsx
+++ b/src/components/marketDashboard/MarketDashboard.tsx
@@ -43,6 +43,7 @@ const DASHBOARD_TABS = [
   { label: 'FIC', path: '/fic' },
   { label: 'Peru', path: '/peru' },
   { label: 'Chile', path: '/chile' },
+  { label: 'CDS Sovereign', path: '/cds-sovereign' },
   { label: 'Par de Monedas', path: '/par-monedas' },
 ];
 

--- a/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
+++ b/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
@@ -90,7 +90,7 @@ const MONEDAS_SUBNAV: NavItemProps[] = [
   },
 ];
 
-const SERIES_DASHBOARDS_PREFIX = ['/suameca', '/tasas', '/monedas-dashboard', '/fic', '/par-monedas'];
+const SERIES_DASHBOARDS_PREFIX = ['/suameca', '/tasas', '/monedas-dashboard', '/fic', '/par-monedas', '/cds-sovereign'];
 
 const MONEDAS_PREFIX = '/currency';
 

--- a/src/pages/cds-sovereign/index.tsx
+++ b/src/pages/cds-sovereign/index.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { CoreLayout } from '@layout';
+import { faGlobe } from '@fortawesome/free-solid-svg-icons';
+import MarketDashboard from '@components/marketDashboard/MarketDashboard';
+import { DashboardConfig } from 'src/types/watchlist';
+
+const CDS_SOVEREIGN_CONFIG: DashboardConfig = {
+  title: 'CDS Sovereign 5Y',
+  icon: faGlobe,
+  filters: {
+    grupos: ['CDS Sovereign'],
+  },
+  groupByField: 'sub_group',
+  defaultPeriod: '1Y',
+  showNormalize: true,
+};
+
+export default function CDSSovereignPage() {
+  return (
+    <CoreLayout>
+      <MarketDashboard config={CDS_SOVEREIGN_CONFIG} />
+    </CoreLayout>
+  );
+}


### PR DESCRIPTION
Closes #282

## Summary

Adds a new `/cds-sovereign` page that shows DTCC sovereign CDS 5Y spreads for 32 countries, grouped by region (LATAM, Asia-Pacific, EMEA, Europa), reusing the existing `MarketDashboard` / `lightweight-charts` flow that already powers SUAMECA, Tasas, FIC, Peru and Chile.

- New page `src/pages/cds-sovereign/index.tsx` — 22-line SUAMECA-style config wrapper filtering `search_mv` by `grupo = 'CDS Sovereign'`.
- `MarketDashboard.tsx` — adds a new "CDS Sovereign" tab between Chile and Par de Monedas.
- `SidebarNavList.tsx` — includes `/cds-sovereign` in `SERIES_DASHBOARDS_PREFIX` so the "Series" sidebar item stays highlighted on this route.

## Backend dependency

Depends on [xerenity-db PR #66](https://github.com/avelezX/xerenity-db/pull/66) — adds `xerenity.read_cds_sovereign(id, col)` and rebuilds `xerenity.search_mv` with a new UNION ALL block exposing one series per country.

**The migration has already been applied to the production Supabase DB.** 4,750 total rows in `search_mv` (was 4,718) — all existing blocks preserved, 32 new CDS rows added.

## Test plan

- [ ] `npm run dev` from main → navigate to `/cds-sovereign`
- [ ] Verify tab strip shows 8 tabs with "CDS Sovereign" highlighted
- [ ] Verify left/right panels list 32 countries grouped by 4 regions
- [ ] Click a country (e.g. Colombia) → line appears in central chart
- [ ] Add multiple countries and toggle normalize — works as in SUAMECA

🤖 Generated with [Claude Code](https://claude.com/claude-code)