### PR TITLE
feat(agent): control_chart — period, normalize, clear, remove

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -173,10 +173,15 @@ export default function ChatPanel() {
     addTickerToChart,
     chartSelections,
     chartPeriod,
+    setChartPeriod,
+    setNormalizeChart,
+    clearChart,
+    removeFromChart,
   } = useAppStore();
 
   const lastNavTarget = useRef<string | null>(null);
   const lastSeriesAction = useRef<string | null>(null);
+  const lastChartAction = useRef<string | null>(null);
 
   // Auto-scroll to bottom
   useEffect(() => {
@@ -215,6 +220,36 @@ export default function ChatPanel() {
       addTickerToChart(ticker, displayName);
     });
   }, [chatMessages, chatLoading, router, addTickerToChart]);
+
+  // Execute chart control actions (period, normalize, clear, remove)
+  useEffect(() => {
+    if (chatLoading) return;
+    const lastMsg = chatMessages[chatMessages.length - 1];
+    if (!lastMsg?.chartControlAction) return;
+
+    const actionKey = JSON.stringify(lastMsg.chartControlAction);
+    if (actionKey === lastChartAction.current) return;
+    lastChartAction.current = actionKey;
+
+    const { action, period, normalize, ticker } = lastMsg.chartControlAction;
+
+    switch (action) {
+      case 'set_period':
+        if (period) setChartPeriod(period as Parameters<typeof setChartPeriod>[0]);
+        break;
+      case 'normalize':
+        setNormalizeChart(normalize !== false);
+        break;
+      case 'clear':
+        clearChart();
+        break;
+      case 'remove_series':
+        if (ticker) removeFromChart(ticker);
+        break;
+      default:
+        break;
+    }
+  }, [chatMessages, chatLoading, setChartPeriod, setNormalizeChart, clearChart, removeFromChart]);
 
   // Focus input on open
   useEffect(() => {

--- a/src/pages/api/chat/index.ts
+++ b/src/pages/api/chat/index.ts
@@ -68,6 +68,15 @@ async function executeToolCalls(
         }
       }
 
+      if (result.chartAction) {
+        sendSSE(res, {
+          type: 'tool_result',
+          tool: toolBlock.name,
+          toolCallId: toolBlock.id,
+          chartAction: result.chartAction,
+        });
+      }
+
       return {
         type: 'tool_result' as const,
         tool_use_id: toolBlock.id,

--- a/src/pages/api/chat/system-prompt.ts
+++ b/src/pages/api/chat/system-prompt.ts
@@ -172,7 +172,23 @@ Cuando el usuario pide comparar, sugiere las combinaciones que tienen sentido ec
 - **FIC fondos** → todos diarios, buena comparacion. NORMALIZAR para ver rendimiento relativo.
 
 ### Normalizacion
-Cuando compares series con escalas muy diferentes (ej: PIB en billones vs inflacion en porcentaje), SUGIERE al usuario activar "Normalizar" en el toolbar del graficador para ver el cambio porcentual relativo.
+Cuando compares series con escalas muy diferentes (ej: PIB en billones vs inflacion en porcentaje), usa control_chart con action=normalize para activar la normalizacion automaticamente. No le digas al usuario que lo haga manualmente — hazlo tu.
+
+### control_chart (controlar el graficador)
+- Usa este tool para ajustar el grafico que el usuario ya tiene abierto.
+- Acciones disponibles:
+  - **set_period**: Cambiar el rango de tiempo. Periodos: 1D, 5D, 1M, 3M, 6M, YTD, 1Y, 3Y, 5Y, 10Y.
+  - **normalize**: Activar/desactivar normalizacion para comparar escalas diferentes.
+  - **clear**: Limpiar todas las series del grafico.
+  - **remove_series**: Quitar una serie especifica (necesita ticker del contexto del grafico).
+- Usa esto DESPUES de cargar series con view_series para ajustar la visualizacion.
+- Flujo tipico: view_series → control_chart(set_period) → control_chart(normalize)
+- Ejemplos:
+  - "Muestrame 5 anos" → control_chart(set_period, period="5Y")
+  - "Normaliza para comparar" → control_chart(normalize, normalize=true)
+  - "Limpia el grafico" → control_chart(clear)
+  - "Quita la TRM" → control_chart(remove_series, ticker=ticker_de_trm)
+  - Cargar PIB + inflacion → automaticamente: control_chart(normalize) + control_chart(set_period, "5Y")
 
 ### navigate_to
 - Usa este tool cuando el usuario pida ir a una seccion especifica.

--- a/src/pages/api/chat/tool-executor.ts
+++ b/src/pages/api/chat/tool-executor.ts
@@ -16,12 +16,20 @@ function getServiceClient() {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabaseClient = ReturnType<typeof createClient> | any;
 
+export interface ChartAction {
+  action: 'set_period' | 'normalize' | 'clear' | 'remove_series';
+  period?: string;
+  normalize?: boolean;
+  ticker?: string;
+}
+
 export interface ToolResult {
   success: boolean;
   data?: unknown;
   error?: string;
   chartData?: unknown;
   navigationTarget?: string;
+  chartAction?: ChartAction;
 }
 
 async function executeQuery(input: Record<string, unknown>): Promise<ToolResult> {
@@ -269,6 +277,43 @@ function executeViewSeries(input: Record<string, unknown>): ToolResult {
   };
 }
 
+function executeControlChart(input: Record<string, unknown>): ToolResult {
+  const action = input.action as string;
+  const validActions = ['set_period', 'normalize', 'clear', 'remove_series'];
+
+  if (!validActions.includes(action)) {
+    return { success: false, error: `Accion invalida: ${action}` };
+  }
+
+  const chartAction: ChartAction = { action: action as ChartAction['action'] };
+
+  if (action === 'set_period') {
+    const period = input.period as string;
+    const validPeriods = ['1D', '5D', '1M', '3M', '6M', 'YTD', '1Y', '3Y', '5Y', '10Y'];
+    if (!period || !validPeriods.includes(period)) {
+      return { success: false, error: `Periodo invalido: ${period}. Validos: ${validPeriods.join(', ')}` };
+    }
+    chartAction.period = period;
+  }
+
+  if (action === 'normalize') {
+    chartAction.normalize = input.normalize !== false;
+  }
+
+  if (action === 'remove_series') {
+    if (!input.ticker) {
+      return { success: false, error: 'Se requiere el ticker de la serie a quitar' };
+    }
+    chartAction.ticker = input.ticker as string;
+  }
+
+  return {
+    success: true,
+    chartAction,
+    data: { action, ...chartAction },
+  };
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export async function executeTool(
   toolName: string,
@@ -288,6 +333,8 @@ export async function executeTool(
       return executeCreateLoan(toolInput, userSupabase);
     case 'view_series':
       return executeViewSeries(toolInput);
+    case 'control_chart':
+      return executeControlChart(toolInput);
     default:
       return { success: false, error: `Tool desconocido: ${toolName}` };
   }

--- a/src/pages/api/chat/tools.ts
+++ b/src/pages/api/chat/tools.ts
@@ -183,4 +183,39 @@ export const tools: Anthropic.Tool[] = [
       required: ['tickers', 'names', 'description'],
     },
   },
+  {
+    name: 'control_chart',
+    description:
+      'Controla el graficador actual: cambiar periodo, normalizar, limpiar, o quitar series. ' +
+      'Usa este tool para ajustar la visualizacion del grafico que el usuario ya tiene abierto.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['set_period', 'normalize', 'clear', 'remove_series'],
+          description:
+            'Accion a ejecutar:\n' +
+            '- set_period: Cambiar el rango de tiempo del grafico\n' +
+            '- normalize: Activar/desactivar normalizacion (util para comparar series de escalas diferentes)\n' +
+            '- clear: Limpiar todas las series del grafico\n' +
+            '- remove_series: Quitar una serie especifica del grafico',
+        },
+        period: {
+          type: 'string',
+          enum: ['1D', '5D', '1M', '3M', '6M', 'YTD', '1Y', '3Y', '5Y', '10Y'],
+          description: 'Periodo de tiempo (solo para action=set_period).',
+        },
+        normalize: {
+          type: 'boolean',
+          description: 'true para activar, false para desactivar (solo para action=normalize).',
+        },
+        ticker: {
+          type: 'string',
+          description: 'Ticker de la serie a quitar (solo para action=remove_series).',
+        },
+      },
+      required: ['action'],
+    },
+  },
 ];

--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -140,6 +140,8 @@ const createChatSlice: StateCreator<ChatSlice> = (set, get) => ({
                     description: event.seriesData.description as string,
                   }
                   : m.seriesAction,
+                // Store chart control action
+                chartControlAction: event.chartAction || m.chartControlAction,
               }));
               break;
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -4,6 +4,13 @@ export interface SeriesAction {
   description: string;
 }
 
+export interface ChartControlAction {
+  action: 'set_period' | 'normalize' | 'clear' | 'remove_series';
+  period?: string;
+  normalize?: boolean;
+  ticker?: string;
+}
+
 export interface ChatMessage {
   id: string;
   role: 'user' | 'assistant';
@@ -13,6 +20,7 @@ export interface ChatMessage {
   charts?: ChartSpec[];
   navigationTarget?: string;
   seriesAction?: SeriesAction;
+  chartControlAction?: ChartControlAction;
 }
 
 export interface ToolCallResult {
@@ -47,6 +55,7 @@ export interface SSEEvent {
   chartData?: ChartSpec;
   navigationTarget?: string;
   seriesData?: { tickers: string[]; names: string[]; description: string };
+  chartAction?: ChartControlAction;
   error?: string;
 }
 


### PR DESCRIPTION
## Summary
Agent can now control the chart directly: change period, normalize, clear, remove series.

## Examples
- "Muestrame 5 años" → set_period("5Y")
- "Normaliza" → normalize(true)
- "Limpia el gráfico" → clear
- "Quita la TRM" → remove_series(ticker)
- Auto: PIB + inflación → normalize + set_period("5Y")

## Files
- tools.ts: new control_chart tool
- tool-executor.ts: executeControlChart + ChartAction type
- index.ts: chartAction SSE event
- chat.ts: ChartControlAction type
- store/chat: handles chartControlAction events
- ChatPanel: executes actions via store

🤖 Generated with [Claude Code](https://claude.com/claude-code)