### PR TITLE
fix(risk): Resumen Exposicion + MAIZ # Contratos + sidebar Exposicion

### DIFF
--- a/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
+++ b/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
@@ -65,7 +65,7 @@ const NAV_ITEMS: NavItemProps[] = [
 
 const RIESGOS_SUBNAV: NavItemProps[] = [
   { name: 'Resumen', path: '/risk-resumen', icon: faChartPie, active: false },
-  { name: 'Commodities', path: '/risk-management', icon: faChartArea, active: false },
+  { name: 'Exposición', path: '/risk-management', icon: faChartArea, active: false },
   { name: 'Créditos', path: '/loans', icon: faLandmark, active: false },
   { name: 'Portafolio OTC', path: '/portfolio', icon: faBriefcase, active: false },
   { name: 'NDF Pricer', path: '/ndf-pricer', icon: faCalculator, active: false },

--- a/src/lib/risk/exposureCalculator.ts
+++ b/src/lib/risk/exposureCalculator.ts
@@ -11,7 +11,10 @@ import type { ExposureParams } from 'src/types/risk';
 
 const LIBRAS_CONTRATO = 112_000; // lbs per sugar contract
 const LBS_PER_TON = 2204.62;
-const CONV_BU_TON = 0.3936825; // bushels to tons conversion
+const CONV_BU_TON = 0.3936825; // combined factor: cents/bu → USD/ton (= 1/(100×0.0254))
+const TON_PER_BUSHEL = 0.0254; // 1 bushel de maiz = 0.0254 toneladas
+const CORN_BUSHELS_CONTRATO = 5000; // CBOT Corn futures: 5,000 bushels per contract
+const CORN_TON_CONTRATO = CORN_BUSHELS_CONTRATO * TON_PER_BUSHEL; // = 127 tons
 const CREDITO_PCT = 0.26; // corn byproduct credit percentage
 const COCOA_TON_CONTRATO = 10; // tons per cocoa contract
 
@@ -64,33 +67,44 @@ function calcularAzucar(params: ExposureParams): CommodityExposure {
 // ── Corn/Glucose (Maíz CME ZC) ──
 
 function calcularMaiz(params: ExposureParams): CommodityExposure {
-  const tonTotal = (params.proyeccion_glucosa ?? []).reduce((a: number, b: number) => a + b, 0);
+  const tonTotalGlucosa = (params.proyeccion_glucosa ?? []).reduce((a: number, b: number) => a + b, 0);
+  const factorMaizGlucosa = params.factor_maiz_glucosa ?? 1.495;
   const precioCentBu = (params.precio_maiz_cent_bu ?? 0) + (params.base_maiz_cent_bu ?? 0);
-  const precioCentTon = precioCentBu * CONV_BU_TON;
-  const precioUsdTon = precioCentTon / 100;
+  const precioUsdTon = precioCentBu * CONV_BU_TON; // CONV_BU_TON ya combina cents→USD × bu→ton
+  const precioCentTon = precioUsdTon * 100;
   const precioNet = (params.flete_usd_ton ?? 0) + precioUsdTon;
   const creditoSubproductos = precioNet * CREDITO_PCT;
   const precioNeto = precioUsdTon + creditoSubproductos;
-  const glucosaMateria = (params.factor_maiz_glucosa ?? 1.495) * precioNeto;
+  const glucosaMateria = factorMaizGlucosa * precioNeto;
   const procFeeUsdTon = ((params.proc_fee_cop_kg ?? 0) / (params.trm ?? 1)) * 1000;
   const precioGlucosa = procFeeUsdTon + (params.processing_fee_usd ?? 0) + glucosaMateria;
-  const exposicionUsd = tonTotal * precioGlucosa;
+  const exposicionUsd = tonTotalGlucosa * precioGlucosa;
+
+  // # Contratos de maiz (CBOT ZC): se calcula a partir de las toneladas de
+  // MAIZ necesarias (no glucosa) = tons_glucosa × factor_maiz_glucosa.
+  // Contrato estandar CBOT = 5,000 bushels = 127 toneladas.
+  const tonsMaizReales = tonTotalGlucosa * factorMaizGlucosa;
+  const numContratos = tonsMaizReales / CORN_TON_CONTRATO;
 
   return {
     nombre: 'MAIZ',
-    proyeccion_tons: tonTotal,
-    tons_reales: tonTotal,
-    num_contratos: tonTotal * CONV_BU_TON,
+    proyeccion_tons: tonTotalGlucosa,
+    tons_reales: tonsMaizReales,
+    num_contratos: numContratos,
     precio_unitario: precioGlucosa,
     exposicion_usd: exposicionUsd,
     detalle: {
       precio_cent_bu: precioCentBu,
+      precio_cent_ton: precioCentTon,
       precio_usd_ton: precioUsdTon,
       flete_usd_ton: params.flete_usd_ton ?? 0,
       credito_subproductos: creditoSubproductos,
       glucosa_materia: glucosaMateria,
       proc_fee_usd_ton: procFeeUsdTon,
       processing_fee_usd: params.processing_fee_usd ?? 0,
+      precio_glucosa: precioGlucosa,
+      ton_contrato: CORN_TON_CONTRATO,
+      factor_maiz_glucosa: factorMaizGlucosa,
     },
   };
 }

--- a/src/models/risk/riskApi.ts
+++ b/src/models/risk/riskApi.ts
@@ -241,8 +241,14 @@ export async function fetchExposure(
   return {
     ...result,
     market_prices: marketPrices,
-    exposicion_ventas_intl: result.exposicion_real_usd,
-    exposicion_pen: 0,
+    // exposicion_ventas_intl es el INPUT de Ventas Internacionales (USD),
+    // no el resultado de Exposicion Real. Bug anterior: asignaba
+    // result.exposicion_real_usd, lo que hacia que "Ventas Intl" y "Real USD"
+    // mostraran el mismo numero en el resumen (ambos 82.6M) aunque el input
+    // era 130M.
+    exposicion_ventas_intl: result.ventas_intl_usd,
+    // exposicion_pen = input de Ventas Peru (no hardcode 0).
+    exposicion_pen: result.ventas_pe_usd,
   } as unknown as ExposureResponse;
 }
 

--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -1844,15 +1844,19 @@ function RiskManagement() {
                         {priceField('precio_maiz_cent_bu', 'Precio Maíz (¢/bu)')}
                         <tr><td style={labelTd}>Base (¢/bu)</td><td style={inputTd}>{numInput('base_maiz_cent_bu')}</td></tr>
                         <tr><td style={labelTd}>Conversión bu/ton</td><td style={{ ...valTd, ...calcStyle }}>0.3937</td></tr>
-                        <tr><td style={labelTd}>Precio Maíz (¢/ton)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{mz ? n(mz.precio_cent_ton as number) : '—'}</td></tr>
-                        <tr><td style={labelTd}>Precio Maíz (USD/ton)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{mz ? n(mz.precio_usd_ton as number, 4) : '—'}</td></tr>
+                        <tr><td style={labelTd}>Precio Maíz (¢/ton)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{mz ? n((mz.detalle as Record<string, number>).precio_cent_ton) : '—'}</td></tr>
+                        <tr><td style={labelTd}>Precio Maíz (USD/ton)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{mz ? n((mz.detalle as Record<string, number>).precio_usd_ton, 4) : '—'}</td></tr>
                         <tr><td style={labelTd}>Flete Oceánico (USD/ton)</td><td style={inputTd}>{numInput('flete_usd_ton')}</td></tr>
-                        <tr><td style={labelTd}>Crédito Subproductos</td><td style={{ ...valTd, ...calcStyle }}>{mz ? n(mz.credito_subproductos as number) : '—'}</td></tr>
+                        <tr><td style={labelTd}>Crédito Subproductos</td><td style={{ ...valTd, ...calcStyle }}>{mz ? n((mz.detalle as Record<string, number>).credito_subproductos) : '—'}</td></tr>
                         <tr><td style={labelTd}>Factor Maíz→Glucosa</td><td style={inputTd}>{numInput('factor_maiz_glucosa', '0.001')}</td></tr>
-                        <tr><td style={labelTd}>Glucosa Materia (USD/ton)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{mz ? n(mz.glucosa_materia as number) : '—'}</td></tr>
+                        <tr><td style={labelTd}>Glucosa Materia (USD/ton)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{mz ? n((mz.detalle as Record<string, number>).glucosa_materia) : '—'}</td></tr>
                         <tr><td style={labelTd}>Processing Fee (USD/ton)</td><td style={inputTd}>{numInput('processing_fee_usd')}</td></tr>
                         <tr><td style={labelTd}>Processing Fee (COP/kg)</td><td style={inputTd}>{numInput('proc_fee_cop_kg')}</td></tr>
-                        <tr><td style={labelTd}>Precio Glucosa (USD/ton)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{mz ? n(mz.precio_glucosa as number) : '—'}</td></tr>
+                        <tr><td style={labelTd}>Precio Glucosa (USD/ton)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{mz ? n((mz.detalle as Record<string, number>).precio_glucosa) : '—'}</td></tr>
+                        {/* ── Contratos de maiz CBOT ZC ── */}
+                        <tr><td style={labelTd}>TON Contrato (CBOT ZC)</td><td style={{ ...valTd, ...calcStyle }}>{mz ? n((mz.detalle as Record<string, number>).ton_contrato, 0) : '—'}</td></tr>
+                        <tr><td style={labelTd}>TON Maíz reales</td><td style={{ ...valTd, ...calcStyle }}>{mz ? n(mz.tons_reales as number, 0) : '—'}</td></tr>
+                        <tr><td style={labelTd}># Contratos</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{mz ? n(mz.num_contratos as number, 2) : '—'}</td></tr>
                         <tr><td style={{ ...labelTd, fontWeight: 700 }}>Exposición USD</td><td style={resultTd}>{mz ? fmtUsd(mz.exposicion_usd) : '—'}</td></tr>
                       </tbody>
                     </table>


### PR DESCRIPTION
Closes #285

## 1. Fix bug Resumen Exposicion Compañia
\`fetchExposure\` asignaba \`exposicion_ventas_intl = result.exposicion_real_usd\` (el resultado) en vez de \`result.ventas_intl_usd\` (el input). Tambien \`exposicion_pen\` estaba hardcoded a 0.

Para Super de Alimentos antes/despues:

| Campo | Antes | Ahora |
|---|---|---|
| Total Commodities | \$47.3M | \$47.3M |
| Exposición Ventas Intl. | \$82.6M ❌ | **\$130.0M** ✅ |
| Exposición Real USD | \$82.6M | \$82.6M |
| Exposición PEN (Perú) | \$0 ❌ | **\$42.8M** ✅ |

Formula metodologia: \`Real = Ventas Intl − Total Commodities\` → \`82.6M = 130.0M − 47.3M\` ✓

## 2. Calculo # Contratos de MAIZ (CBOT ZC)
Card MAIZ/GLUCOSA no mostraba # Contratos ni valores intermedios (varios campos "—").

**Fix en \`exposureCalculator.ts\`:**
- Constantes: \`CORN_TON_CONTRATO = 5000 × 0.0254 = 127 tons/contrato\`
- \`num_contratos = (tons_glucosa × factor_maiz_glucosa) / 127\` (antes \`tonTotal × 0.3937\`, incorrecto)
- \`detalle\` ahora incluye \`precio_cent_ton\`, \`precio_glucosa\`, \`ton_contrato\`, \`factor_maiz_glucosa\`

**Fix en UI:** leer desde \`mz.detalle.*\` (antes accedia a \`mz.*\` directamente que no existia). 3 filas nuevas: TON Contrato (CBOT ZC), TON Maiz reales, # Contratos.

**Para Super:** 27,324 TON glucosa × 1.495 = 40,849 TON maiz / 127 = **321.65 contratos**.

## 3. Sidebar: "Commodities" → "Exposición"
Solo label. Ruta \`/risk-management\` sin cambios.

## Test plan
- [ ] Super: Resumen muestra Ventas Intl \$130M, PEN \$42.8M, Real \$82.6M
- [ ] Super: card MAIZ muestra TON Contrato 127, TON Maiz reales 40,849, # Contratos 321.65
- [ ] Sidebar muestra "Exposición"

🤖 Generated with [Claude Code](https://claude.com/claude-code)