### PR TITLE
feat(risk): Super de Alimentos — AKOMEL / CEBES / ALMIDON + Exposicion Natural USD

### DIFF
--- a/src/lib/risk/companyConfig.ts
+++ b/src/lib/risk/companyConfig.ts
@@ -141,6 +141,61 @@ export const DEFAULT_EXPOSURE_PARAMS: ExposureParams = {
   ventas_intl_usd: 130025826,
   ventas_co_usd: 0,
   ventas_pe_usd: 42827644,
+
+  // Defaults de las 3 tablas nuevas de Super de Alimentos (tomados del
+  // instructivo Python — ejemplo con valores actuales de la hoja).
+  // AKOMEL — inputs de mercado
+  akomel_fob_malasya: 1138,
+  akomel_international_freight: 94.8,
+  akomel_risk_futures_fee: 0,
+  akomel_trm: 3716.74,
+  akomel_prima_abastecimiento: 0,
+  akomel_flete_extractora_fabrica: 212,
+  akomel_tariff_aak_my_pct: 0.0004,
+  akomel_bonificacion_calidad_pct: 0.025,
+  // AKOMEL Granel
+  akomel_rend_impurezas_humedad_granel: 0.99,
+  akomel_rend_acidez_aak_granel: 0.96,
+  akomel_costos_transf_granel: 1214,
+  // AKOMEL Sin Lecitina
+  akomel_rend_impurezas_humedad_sl: 0.99,
+  akomel_rend_acidez_aak_sl: 0.96,
+  akomel_costos_transf_sl: 1636,
+  akomel_material_empaque_sl: 180,
+  // AKOMEL Saborizado
+  akomel_rend_impurezas_humedad_sab: 0.99,
+  akomel_rend_acidez_aak_sab: 0.96,
+  akomel_costos_transf_sab: 1739,
+  akomel_material_empaque_sab: 180,
+
+  // CEBES MC 35
+  cebes_precio_palmiste_cif: 1826,
+  cebes_flete_malasia_colombia: 94.8,
+  cebes_flete_malasia_europa: -70.3,
+  cebes_trm: 3698.75,
+  cebes_arancel_pct: 0.001,
+  cebes_risk_futures_fee_palmiste: 0,
+  cebes_prima_rspo_mb: 0,
+  cebes_prima_abastecimiento: 0,
+  cebes_flete_extractora_fabrica: 212,
+  cebes_rend_impurezas_humedad: 0.994,
+  cebes_rend_acidez_aak: 0.94,
+  cebes_costos_transformacion: 3879,
+  cebes_material_empaque: 450,
+  cebes_financiamiento: 278,
+
+  // ALMIDON
+  almidon_flete_maritimo: 50.3,
+  almidon_factor_conversion_bush_ton: 0.3936825,
+  almidon_credito_subproductos_pct: 0.26,
+  almidon_factor_conversion_maiz_almidon: 1.6,
+
+  // KG anual (input manual por el usuario — empieza en 0)
+  kg_akomel_granel_anual: 0,
+  kg_akomel_sl_anual: 0,
+  kg_akomel_sab_anual: 0,
+  kg_cebes_anual: 0,
+  kg_almidon_anual: 0,
 };
 
 // ── Predefined commodity templates ──

--- a/src/lib/risk/exposureCalculator.ts
+++ b/src/lib/risk/exposureCalculator.ts
@@ -26,6 +26,12 @@ export interface CommodityExposure {
   precio_unitario: number;
   exposicion_usd: number;
   detalle: Record<string, number>;
+  // Opcionales para las formulaciones Super (AKOMEL/CEBES/ALMIDON)
+  exchange?: string;
+  unidad_cotizacion?: string;
+  ton_total?: number;
+  precio_por_ton?: number;
+  precio_futuro?: number | null;
 }
 
 export interface ExposureResult {
@@ -169,9 +175,297 @@ function calcularEmpaque(params: ExposureParams): CommodityExposure {
   };
 }
 
+// ── AKOMEL COP (Super de Alimentos: aceite de palma de Malasia) ──
+// Port fiel del instructivo Python. Expone TODOS los intermedios por producto
+// para auditoria contra la hoja de calculo (referencias de celda en comentarios).
+
+export interface AkomelResult {
+  // Precio crudo puesto puerto
+  tariff_aak_my: number;             // USD/TON — D10
+  precio_crudo_cop_ton: number;      // COP/TON — D13
+  precio_crudo_cop_kg: number;       // COP/KG  — D14
+  // Base proceso
+  materia_prima: number;             // COP/KG  — D16
+  bonificacion_calidad: number;      // COP/KG  — D17
+  precio_mp_puesto_planta: number;   // COP/KG  — D20
+  // AKOMEL NH Granel
+  paso1_granel: number;              // D27 (tras rend. impurezas+humedad)
+  paso2_granel: number;              // D28 (tras rend. acidez+AAK)
+  precio_akomel_nh_granel: number;   // D30 (PRECIO FINAL)
+  // AKOMEL NH Sin Lecitina Caja 15Kg
+  paso1_sl: number;                  // D33
+  paso2_sl: number;                  // D34
+  precio_akomel_nh_sl_caja15: number; // D37 (PRECIO FINAL)
+  // AKOMEL NH Saborizado Caja 15Kg
+  paso1_sab: number;                 // D40
+  paso2_sab: number;                 // D41
+  precio_akomel_nh_sab_caja15: number; // D44 (PRECIO FINAL)
+}
+
+export function calcularAkomelCop(p: ExposureParams): AkomelResult {
+  const fob = p.akomel_fob_malasya ?? 0;
+  const flete = p.akomel_international_freight ?? 0;
+  const riskFee = p.akomel_risk_futures_fee ?? 0;
+  // TRM = TRM global de Xerenity (alimentada de BanRep via market_prices).
+  // Antes era un campo independiente; se sincronizo para evitar inconsistencias.
+  const trm = p.trm ?? 0;
+  const primaAbast = p.akomel_prima_abastecimiento ?? 0;
+  const fleteExt = p.akomel_flete_extractora_fabrica ?? 0;
+  // Constantes con default
+  const tariffPct = p.akomel_tariff_aak_my_pct ?? 0.0004;
+  const bonifPct = p.akomel_bonificacion_calidad_pct ?? 0.025;
+  // Rendimientos por producto (defaults identicos a la hoja actual)
+  const rendIhG = p.akomel_rend_impurezas_humedad_granel ?? 0.99;
+  const rendAaG = p.akomel_rend_acidez_aak_granel ?? 0.96;
+  const costG = p.akomel_costos_transf_granel ?? 0;
+  const rendIhSL = p.akomel_rend_impurezas_humedad_sl ?? 0.99;
+  const rendAaSL = p.akomel_rend_acidez_aak_sl ?? 0.96;
+  const costSL = p.akomel_costos_transf_sl ?? 0;
+  const empSL = p.akomel_material_empaque_sl ?? 0;
+  const rendIhSab = p.akomel_rend_impurezas_humedad_sab ?? 0.99;
+  const rendAaSab = p.akomel_rend_acidez_aak_sab ?? 0.96;
+  const costSab = p.akomel_costos_transf_sab ?? 0;
+  const empSab = p.akomel_material_empaque_sab ?? 0;
+
+  // Precio crudo puesto puerto (D10/D13/D14)
+  const tariffAakMy = (fob + flete) * tariffPct;
+  const precioCrudoCopTon = (fob + flete + tariffAakMy + riskFee) * trm;
+  const precioCrudoCopKg = precioCrudoCopTon / 1000;
+
+  // BASE PROCESO (D16/D17/D20)
+  const materiaPrima = precioCrudoCopKg;
+  const bonificacion = bonifPct * materiaPrima;
+  const precioMpPlanta = materiaPrima + bonificacion + primaAbast + fleteExt;
+
+  // AKOMEL NH Granel (D27/D28/D30)
+  const paso1Granel = precioMpPlanta / rendIhG;
+  const paso2Granel = paso1Granel / rendAaG;
+  const precioGranel = paso2Granel + costG;
+
+  // AKOMEL NH Sin Lecitina (D33/D34/D37)
+  const paso1SL = precioMpPlanta / rendIhSL;
+  const paso2SL = paso1SL / rendAaSL;
+  const precioSL = paso2SL + costSL + empSL;
+
+  // AKOMEL NH Saborizado (D40/D41/D44)
+  const paso1Sab = precioMpPlanta / rendIhSab;
+  const paso2Sab = paso1Sab / rendAaSab;
+  const precioSab = paso2Sab + costSab + empSab;
+
+  return {
+    tariff_aak_my: tariffAakMy,
+    precio_crudo_cop_ton: precioCrudoCopTon,
+    precio_crudo_cop_kg: precioCrudoCopKg,
+    materia_prima: materiaPrima,
+    bonificacion_calidad: bonificacion,
+    precio_mp_puesto_planta: precioMpPlanta,
+    paso1_granel: paso1Granel,
+    paso2_granel: paso2Granel,
+    precio_akomel_nh_granel: precioGranel,
+    paso1_sl: paso1SL,
+    paso2_sl: paso2SL,
+    precio_akomel_nh_sl_caja15: precioSL,
+    paso1_sab: paso1Sab,
+    paso2_sab: paso2Sab,
+    precio_akomel_nh_sab_caja15: precioSab,
+  };
+}
+
+// ── CEBES MC 35 (Super de Alimentos: Palmiste) ──
+// risk_futures_fee_palmiste y prima_rspo_mb se reciben para trazabilidad
+// pero NO entran en la formula vigente de la hoja (D58). Estan en 0.
+
+export interface CebesResult {
+  arancel: number;                // USD/TON — D54
+  precio_palmiste_cop_kg: number; // COP/KG  — D58
+  materia_prima: number;          // COP/KG  — D60
+  precio_mp_planta: number;       // COP/KG  — D63
+  paso1_cebes: number;            // COP/KG  — D67 (tras rend. impurezas+humedad)
+  paso2_cebes: number;            // COP/KG  — D68 (tras rend. acidez+AAK)
+  precio_cebes_mc35: number;      // COP/KG  — D72 (PRECIO FINAL)
+}
+
+export function calcularCebesMc35(p: ExposureParams): CebesResult {
+  const cif = p.cebes_precio_palmiste_cif ?? 0;
+  const fleteCol = p.cebes_flete_malasia_colombia ?? 0;
+  const fleteEur = p.cebes_flete_malasia_europa ?? 0;
+  // Misma TRM global de Xerenity
+  const trm = p.trm ?? 0;
+  const primaAbast = p.cebes_prima_abastecimiento ?? 0;
+  const fleteExt = p.cebes_flete_extractora_fabrica ?? 0;
+  const costT = p.cebes_costos_transformacion ?? 0;
+  const empaque = p.cebes_material_empaque ?? 0;
+  const financ = p.cebes_financiamiento ?? 0;
+  // Constantes con default
+  const arancelPct = p.cebes_arancel_pct ?? 0.001;
+  const rendIh = p.cebes_rend_impurezas_humedad ?? 0.994;
+  const rendAa = p.cebes_rend_acidez_aak ?? 0.94;
+  // Informativos (no afectan formula vigente pero se reciben)
+  // const _riskFee = p.cebes_risk_futures_fee_palmiste ?? 0;
+  // const _primaRspo = p.cebes_prima_rspo_mb ?? 0;
+
+  // D54
+  const arancel = (cif + fleteCol + fleteEur) * arancelPct;
+  // D58
+  const precioPalmisteCopKg = ((cif + fleteCol + fleteEur + arancel) * trm) / 1000;
+  // D60 / D63
+  const materiaPrima = precioPalmisteCopKg;
+  const precioMpPlanta = materiaPrima + primaAbast + fleteExt;
+  // D67 / D68 / D72
+  const paso1 = precioMpPlanta / rendIh;
+  const paso2 = paso1 / rendAa;
+  const precioCebes = paso2 + costT + empaque + financ;
+
+  return {
+    arancel,
+    precio_palmiste_cop_kg: precioPalmisteCopKg,
+    materia_prima: materiaPrima,
+    precio_mp_planta: precioMpPlanta,
+    paso1_cebes: paso1,
+    paso2_cebes: paso2,
+    precio_cebes_mc35: precioCebes,
+  };
+}
+
+// ── ALMIDON (Super de Alimentos: maiz → almidon) ──
+// Referencias de celda H8-H18 del instructivo.
+
+export interface AlmidonResult {
+  precio_fob_usc_bu: number;      // USc/Bush — H10
+  precio_fob_usd_ton: number;     // USD/TON  — H12
+  precio_maiz_usd_ton: number;    // USD/TON  — H14
+  credito_subproductos: number;   // USD/TON  — H15
+  precio_neto_maiz: number;       // USD/TON  — H16
+  precio_almidon_usd_ton: number; // USD/TON  — H17/H18 (PRECIO FINAL)
+}
+
+export function calcularAlmidon(p: ExposureParams): AlmidonResult {
+  const precioFut = p.precio_maiz_cent_bu ?? 0;   // H8 (reusa precio futuro ZC CBOT)
+  const base = p.base_maiz_cent_bu ?? 0;          // H9 (reusa base USD)
+  const fleteMaritimo = p.almidon_flete_maritimo ?? 0; // H13
+  // Constantes con default (H11, G15, G17)
+  const conv = p.almidon_factor_conversion_bush_ton ?? 0.3936825;
+  const creditoPct = p.almidon_credito_subproductos_pct ?? 0.26;
+  const factorMaizAlmidon = p.almidon_factor_conversion_maiz_almidon ?? 1.6;
+
+  const precioFobUsc = precioFut + base;
+  const precioFobUsdTon = precioFobUsc * conv;
+  const precioMaizUsdTon = precioFobUsdTon + fleteMaritimo;
+  const credito = creditoPct * precioMaizUsdTon;
+  const precioNeto = precioMaizUsdTon - credito;
+  const precioAlmidon = precioNeto * factorMaizAlmidon;
+
+  return {
+    precio_fob_usc_bu: precioFobUsc,
+    precio_fob_usd_ton: precioFobUsdTon,
+    precio_maiz_usd_ton: precioMaizUsdTon,
+    credito_subproductos: credito,
+    precio_neto_maiz: precioNeto,
+    precio_almidon_usd_ton: precioAlmidon,
+  };
+}
+
+// ── Exposicion Natural USD de las formulaciones Super (AKOMEL/CEBES/ALMIDON) ──
+// Requiere KG anual manual del usuario. Formula:
+//   AKOMEL/CEBES (precio en COP/KG): USD = KG × precio_cop_kg / TRM_global
+//   ALMIDON (precio en USD/TON):     USD = KG × precio_usd_ton / 1000
+// TRM a usar: params.trm (Xerenity global, se sincroniza con BanRep via
+// market_prices al correr fetchExposure).
+
+export function buildSuperFormulaCommodities(params: ExposureParams): CommodityExposure[] {
+  const trm = params.trm ?? 1;
+
+  const akomelRes = calcularAkomelCop(params);
+  const cebesRes = calcularCebesMc35(params);
+  const almidonRes = calcularAlmidon(params);
+
+  const kgGranel = params.kg_akomel_granel_anual ?? 0;
+  const kgSL = params.kg_akomel_sl_anual ?? 0;
+  const kgSab = params.kg_akomel_sab_anual ?? 0;
+  const kgCebes = params.kg_cebes_anual ?? 0;
+  const kgAlmidon = params.kg_almidon_anual ?? 0;
+
+  // AKOMEL — suma de los 3 productos derivados
+  const expGranel = (kgGranel * akomelRes.precio_akomel_nh_granel) / trm;
+  const expSL = (kgSL * akomelRes.precio_akomel_nh_sl_caja15) / trm;
+  const expSab = (kgSab * akomelRes.precio_akomel_nh_sab_caja15) / trm;
+  const expAkomelTotal = expGranel + expSL + expSab;
+  const kgAkomelTotal = kgGranel + kgSL + kgSab;
+
+  // CEBES
+  const expCebes = (kgCebes * cebesRes.precio_cebes_mc35) / trm;
+
+  // ALMIDON (precio ya en USD/TON, no necesita TRM)
+  const expAlmidon = (kgAlmidon * almidonRes.precio_almidon_usd_ton) / 1000;
+
+  return [
+    {
+      nombre: 'AKOMEL',
+      exchange: 'Formulación',
+      unidad_cotizacion: 'COP/KG',
+      proyeccion_tons: kgAkomelTotal / 1000,
+      tons_reales: kgAkomelTotal / 1000,
+      num_contratos: 0,
+      precio_unitario: kgAkomelTotal > 0 ? (expAkomelTotal * trm) / kgAkomelTotal : 0,
+      exposicion_usd: expAkomelTotal,
+      ton_total: kgAkomelTotal / 1000,
+      precio_por_ton: kgAkomelTotal > 0 ? (expAkomelTotal / (kgAkomelTotal / 1000)) : 0,
+      precio_futuro: null,
+      detalle: {
+        kg_granel: kgGranel,
+        kg_sl: kgSL,
+        kg_sab: kgSab,
+        exp_granel: expGranel,
+        exp_sl: expSL,
+        exp_sab: expSab,
+        precio_granel: akomelRes.precio_akomel_nh_granel,
+        precio_sl: akomelRes.precio_akomel_nh_sl_caja15,
+        precio_sab: akomelRes.precio_akomel_nh_sab_caja15,
+      },
+    },
+    {
+      nombre: 'CEBES_MC35',
+      exchange: 'Formulación',
+      unidad_cotizacion: 'COP/KG',
+      proyeccion_tons: kgCebes / 1000,
+      tons_reales: kgCebes / 1000,
+      num_contratos: 0,
+      precio_unitario: cebesRes.precio_cebes_mc35,
+      exposicion_usd: expCebes,
+      ton_total: kgCebes / 1000,
+      precio_por_ton: kgCebes > 0 ? expCebes / (kgCebes / 1000) : 0,
+      precio_futuro: null,
+      detalle: {
+        kg: kgCebes,
+        precio_cop_kg: cebesRes.precio_cebes_mc35,
+      },
+    },
+    {
+      nombre: 'ALMIDON',
+      exchange: 'Formulación',
+      unidad_cotizacion: 'USD/TON',
+      proyeccion_tons: kgAlmidon / 1000,
+      tons_reales: kgAlmidon / 1000,
+      num_contratos: 0,
+      precio_unitario: almidonRes.precio_almidon_usd_ton,
+      exposicion_usd: expAlmidon,
+      ton_total: kgAlmidon / 1000,
+      precio_por_ton: almidonRes.precio_almidon_usd_ton,
+      precio_futuro: null,
+      detalle: {
+        kg: kgAlmidon,
+        precio_usd_ton: almidonRes.precio_almidon_usd_ton,
+      },
+    },
+  ];
+}
+
 // ── Total Exposure ──
 
-export function calcularExposicionTotal(params: ExposureParams): ExposureResult {
+export function calcularExposicionTotal(
+  params: ExposureParams,
+  opts?: { includeSuperFormulas?: boolean },
+): ExposureResult {
   const precioCocoa = params.precio_cocoa_usd_ton ?? 0;
 
   const azucar = calcularAzucar(params);
@@ -192,7 +486,14 @@ export function calcularExposicionTotal(params: ExposureParams): ExposureResult 
 
   const empaque = calcularEmpaque(params);
 
-  const commodities = [azucar, maiz, cocoaPolvo, manteca, licor, empaque];
+  const commodities: CommodityExposure[] = [azucar, maiz, cocoaPolvo, manteca, licor, empaque];
+
+  // Super de Alimentos: agregar las 3 formulaciones nuevas (AKOMEL, CEBES, ALMIDON)
+  // con sus exposiciones USD basadas en KG anuales del usuario.
+  if (opts?.includeSuperFormulas) {
+    commodities.push(...buildSuperFormulaCommodities(params));
+  }
+
   const totalCommoditiesUsd = commodities.reduce((s, c) => s + c.exposicion_usd, 0);
 
   const ventasIntl = params.ventas_intl_usd ?? 0;

--- a/src/models/risk/riskApi.ts
+++ b/src/models/risk/riskApi.ts
@@ -206,6 +206,7 @@ export async function fetchRollingVar(
 export async function fetchExposure(
   filterDate: string,
   exposureParams: ExposureParams,
+  opts?: { includeSuperFormulas?: boolean },
 ): Promise<ExposureResponse> {
   // Fetch latest prices to override params
   const startDate = getStartDate(filterDate, 60);
@@ -237,7 +238,7 @@ export async function fetchExposure(
     }
   }
 
-  const result = calcularExposicionTotal(params);
+  const result = calcularExposicionTotal(params, { includeSuperFormulas: opts?.includeSuperFormulas });
   return {
     ...result,
     market_prices: marketPrices,

--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -41,6 +41,7 @@ import { fetchCoffeePrices } from 'src/lib/risk/supabaseRisk';
 import type { CoffeePriceRow } from 'src/lib/risk/supabaseRisk';
 import { fetchUsdCopCalculator } from 'src/models/risk/usdcopCalculator';
 import type { UsdCopData } from 'src/models/risk/usdcopCalculator';
+import { calcularAkomelCop, calcularCebesMc35, calcularAlmidon, buildSuperFormulaCommodities } from 'src/lib/risk/exposureCalculator';
 import type { RollingVarResponse, BenchmarkFactorsResponse, ExposureParams, ExposureResponse, MarketPrice, FuturesPosition, NewFuturesPosition } from 'src/types/risk';
 import useAppStore from 'src/store';
 // Company type no longer needed — global selector in CoreLayout
@@ -567,6 +568,52 @@ const METHODOLOGY: Record<string, { title: string; content: React.ReactNode }> =
 
         <p style={methH}>Precios de Mercado</p>
         <p>Los precios de los futuros se actualizan automáticamente. Los campos con fondo azul indican precios de mercado no editables, mostrando la fecha de cotización y el contrato utilizado. Los demás campos son editables y permiten ajustar manualmente los parámetros de cálculo.</p>
+
+        <p style={methH}>Formulaciones Super de Alimentos (AKOMEL, CEBES, ALMIDÓN)</p>
+        <p>Las 3 tarjetas adicionales calculan el precio unitario de cada materia prima transformada partiendo del mercado internacional (FOB/CIF + flete + arancel + TRM) y aplicando rendimientos de proceso y costos operativos. La TRM en cada tarjeta es no editable y se sincroniza con la TRM global de Xerenity (BanRep).</p>
+
+        <p><strong>AKOMEL NH (aceite de palma Malasia → 3 productos):</strong></p>
+        <div style={methFormula}>
+          Paso 1 = Materia Prima (COP/KG) ÷ Rend. Impurezas+Humedad<br />
+          Paso 2 = Paso 1 ÷ Rend. Acidez AAK<br />
+          Precio Granel = Paso 2 + Costos Transf.<br />
+          Precio SL / Sab = Paso 2 + Costos Transf. + Material Empaque
+        </div>
+
+        <p><strong>CEBES MC 35 (palmiste):</strong></p>
+        <div style={methFormula}>
+          Precio MP Planta = Materia Prima + (Prima Abast. / 1000) + Flete Extractora→Fábrica<br />
+          Paso 1 = Precio MP Planta ÷ Rend. Impurezas+Humedad<br />
+          Paso 2 = Paso 1 ÷ Rend. Acidez AAK<br />
+          Precio CEBES = Paso 2 + Costos Transf. + Empaque + Financiamiento
+        </div>
+
+        <p><strong>ALMIDÓN (maíz CBOT ZC → almidón):</strong></p>
+        <div style={methFormula}>
+          Precio FOB (¢/bu) = Precio Futuro + Base<br />
+          Precio FOB (USD/TON) = Precio FOB (¢/bu) × 0.01 ÷ 0.3937<br />
+          Precio Maíz = Precio FOB + Flete Marítimo<br />
+          Precio Neto Maíz = Precio Maíz × (1 − 26%) {/* crédito subproductos */}<br />
+          Precio Almidón = Precio Neto Maíz × 1.60 {/* factor conversión */}
+        </div>
+
+        <p style={methH}>Exposición Natural USD (3 tarjetas nuevas)</p>
+        <p>Cada tarjeta incluye un campo <strong>KG anual (compra)</strong> — el volumen que la compañía planea adquirir durante el año. La Exposición USD se calcula así:</p>
+        <div style={methFormula}>
+          AKOMEL / CEBES: Exp. USD = KG anual × Precio (COP/KG) ÷ TRM<br />
+          ALMIDÓN:       Exp. USD = KG anual × Precio (USD/TON) ÷ 1000
+        </div>
+        <p>Para AKOMEL se muestra una fila <strong>Total Exposición AKOMEL USD</strong> que suma los 3 sub-productos (Granel + Sin Lecitina + Saborizado).</p>
+
+        <p style={methH}>Conexión con la tabla "Exposición por Commodity"</p>
+        <p>Los valores calculados dentro de cada tarjeta alimentan la tabla de resumen en tiempo real:</p>
+        <ul>
+          <li><strong>AKOMEL</strong> → una sola fila con el total de los 3 sub-productos.</li>
+          <li><strong>CEBES_MC35</strong> → fila con la exposición del único producto.</li>
+          <li><strong>ALMIDON</strong> → fila con la exposición del único producto.</li>
+        </ul>
+        <p>Estas 3 filas se suman al <strong>Total Commodities</strong> junto con AZÚCAR, MAÍZ, CACAO y EMPAQUE. Al editar cualquier KG o parámetro de las formulaciones, la tabla se actualiza inmediatamente sin necesidad de hacer clic en "Actualizar".</p>
+        <p>La <strong>Exposición Real USD</strong> también se recalcula en vivo: <code>Ventas Intl. − Total Commodities</code>.</p>
       </div>
     ),
   },
@@ -987,7 +1034,11 @@ function RiskManagement() {
     setExposureLoading(true);
     try {
       const dateToUse = overrideDate ?? filterDate;
-      const data = await fetchExposure(dateToUse, exposureParams);
+      // Super de Alimentos: incluir las 3 formulaciones (AKOMEL, CEBES, ALMIDON)
+      // en el calculo total. Para otras empresas no se incluyen (exposicion_usd = 0).
+      const SUPER_ID = 'e8516f19-7286-4e04-a63e-24ca9364d807';
+      const isSuper = selectedCompanyId === SUPER_ID;
+      const data = await fetchExposure(dateToUse, exposureParams, { includeSuperFormulas: isSuper });
       setExposureResult(data);
 
       // Update local params with DB prices
@@ -1752,6 +1803,15 @@ function RiskManagement() {
           const lc = getComm('LICOR_CACAO');
           const emp = getComm('EMPAQUE');
 
+          // ── Super de Alimentos: tablas especificas (AKOMEL, CEBES MC35, Almidon) ──
+          // Se calculan inline en el render porque NO dependen del fetch a Supabase,
+          // solo de los inputs locales de exposureParams.
+          const SUPER_ALIMENTOS_ID = 'e8516f19-7286-4e04-a63e-24ca9364d807';
+          const isSuperAlimentos = selectedCompanyId === SUPER_ALIMENTOS_ID;
+          const akomel = isSuperAlimentos ? calcularAkomelCop(exposureParams) : null;
+          const cebes = isSuperAlimentos ? calcularCebesMc35(exposureParams) : null;
+          const almidon = isSuperAlimentos ? calcularAlmidon(exposureParams) : null;
+
           return (
             <>
               <Row className="mb-3 align-items-center">
@@ -1941,8 +2001,145 @@ function RiskManagement() {
                 </Col>
               </Row>
 
+              {/* ═════════ TABLAS ADICIONALES — SOLO SUPER DE ALIMENTOS ═════════ */}
+              {isSuperAlimentos && (
+                <Row className="g-3 mb-4 mt-1">
+                    {/* ── AKOMEL COP ── */}
+                    <Col md={6} lg={4}>
+                      <div className="rounded h-100" style={{ border: '1px solid #e2e8f0', overflow: 'hidden', background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+                        <div style={headerStyle}>AKOMEL COP <span className="fw-normal ms-2" style={{ fontSize: '0.7rem' }}>Aceite de palma — Malasia</span></div>
+                        <table className="table table-sm mb-0" style={{ fontSize: '0.78rem' }}>
+                          <tbody>
+                            {/* Inputs — precio crudo puesto puerto */}
+                            <tr><td style={labelTd}>FOB Malasia (USD/TON)</td><td style={inputTd}>{numInput('akomel_fob_malasya', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>International Freight (USD/TON)</td><td style={inputTd}>{numInput('akomel_international_freight', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>Tariff AAK MY (0.04%)</td><td style={{ ...valTd, ...calcStyle }}>{akomel ? n(akomel.tariff_aak_my, 4) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Risk Futures Fee (USD/TON)</td><td style={inputTd}>{numInput('akomel_risk_futures_fee', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>TRM (USD/COP) <span style={{ fontSize: '0.65rem', color: '#94a3b8' }}>(Xerenity)</span></td><td style={{ ...valTd, ...calcStyle }}>{n(exposureParams.trm, 2)}</td></tr>
+                            <tr><td style={labelTd}>Precio Crudo (COP/TON)</td><td style={{ ...valTd, ...calcStyle }}>{akomel ? n(akomel.precio_crudo_cop_ton, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Precio Crudo (COP/KG)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{akomel ? n(akomel.precio_crudo_cop_kg, 2) : '—'}</td></tr>
+                            {/* Base proceso */}
+                            <tr><td style={{ ...labelTd, padding: '8px 12px', fontSize: '0.75rem', color: '#1e293b', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', background: '#f1f5f9', borderTop: '1px solid #e2e8f0', borderBottom: '1px solid #e2e8f0' }} colSpan={2}>Base Proceso</td></tr>
+                            <tr><td style={labelTd}>Materia Prima (COP/KG)</td><td style={{ ...valTd, ...calcStyle }}>{akomel ? n(akomel.materia_prima, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Bonif. Calidad (2.5%)</td><td style={{ ...valTd, ...calcStyle }}>{akomel ? n(akomel.bonificacion_calidad, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Prima Abastecimiento (COP/KG)</td><td style={inputTd}>{numInput('akomel_prima_abastecimiento', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>Flete Extractora→Fábrica (COP/KG)</td><td style={inputTd}>{numInput('akomel_flete_extractora_fabrica', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>Precio MP puesto planta (COP/KG)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{akomel ? n(akomel.precio_mp_puesto_planta, 2) : '—'}</td></tr>
+                            {/* AKOMEL NH Granel */}
+                            <tr><td style={{ ...labelTd, padding: '8px 12px', fontSize: '0.75rem', color: '#1e293b', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', background: '#f1f5f9', borderTop: '1px solid #e2e8f0', borderBottom: '1px solid #e2e8f0' }} colSpan={2}>AKOMEL NH Granel</td></tr>
+                            <tr><td style={labelTd}>Rend. Impurezas + Humedad</td><td style={inputTd}>{numInput('akomel_rend_impurezas_humedad_granel', '0.001')}</td></tr>
+                            <tr><td style={labelTd}>Paso 1 (÷ rend. imp+hum)</td><td style={{ ...valTd, ...calcStyle }}>{akomel ? n(akomel.paso1_granel, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Rend. Acidez AAK</td><td style={inputTd}>{numInput('akomel_rend_acidez_aak_granel', '0.001')}</td></tr>
+                            <tr><td style={labelTd}>Paso 2 (÷ rend. acidez)</td><td style={{ ...valTd, ...calcStyle }}>{akomel ? n(akomel.paso2_granel, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Costos Transformación</td><td style={inputTd}>{numInput('akomel_costos_transf_granel', '1')}</td></tr>
+                            <tr><td style={{ ...labelTd, fontWeight: 700 }}>Akomel NH Granel (COP/KG)</td><td style={resultTd}>{akomel ? n(akomel.precio_akomel_nh_granel, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>KG anual (compra)</td><td style={inputTd}>{numInput('kg_akomel_granel_anual', '1')}</td></tr>
+                            <tr><td style={{ ...labelTd, fontWeight: 700 }}>Exposición USD</td><td style={resultTd}>{akomel ? fmtUsd(((exposureParams.kg_akomel_granel_anual ?? 0) * akomel.precio_akomel_nh_granel) / (exposureParams.trm || 1)) : '—'}</td></tr>
+                            {/* AKOMEL NH Sin Lecitina */}
+                            <tr><td style={{ ...labelTd, padding: '8px 12px', fontSize: '0.75rem', color: '#1e293b', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', background: '#f1f5f9', borderTop: '1px solid #e2e8f0', borderBottom: '1px solid #e2e8f0' }} colSpan={2}>AKOMEL NH Sin Lecitina Caja 15Kg</td></tr>
+                            <tr><td style={labelTd}>Rend. Impurezas + Humedad</td><td style={inputTd}>{numInput('akomel_rend_impurezas_humedad_sl', '0.001')}</td></tr>
+                            <tr><td style={labelTd}>Paso 1</td><td style={{ ...valTd, ...calcStyle }}>{akomel ? n(akomel.paso1_sl, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Rend. Acidez AAK</td><td style={inputTd}>{numInput('akomel_rend_acidez_aak_sl', '0.001')}</td></tr>
+                            <tr><td style={labelTd}>Paso 2</td><td style={{ ...valTd, ...calcStyle }}>{akomel ? n(akomel.paso2_sl, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Costos Transformación</td><td style={inputTd}>{numInput('akomel_costos_transf_sl', '1')}</td></tr>
+                            <tr><td style={labelTd}>Material Empaque</td><td style={inputTd}>{numInput('akomel_material_empaque_sl', '1')}</td></tr>
+                            <tr><td style={{ ...labelTd, fontWeight: 700 }}>Akomel NH SL Caja 15Kg (COP/KG)</td><td style={resultTd}>{akomel ? n(akomel.precio_akomel_nh_sl_caja15, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>KG anual (compra)</td><td style={inputTd}>{numInput('kg_akomel_sl_anual', '1')}</td></tr>
+                            <tr><td style={{ ...labelTd, fontWeight: 700 }}>Exposición USD</td><td style={resultTd}>{akomel ? fmtUsd(((exposureParams.kg_akomel_sl_anual ?? 0) * akomel.precio_akomel_nh_sl_caja15) / (exposureParams.trm || 1)) : '—'}</td></tr>
+                            {/* AKOMEL NH Saborizado */}
+                            <tr><td style={{ ...labelTd, padding: '8px 12px', fontSize: '0.75rem', color: '#1e293b', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', background: '#f1f5f9', borderTop: '1px solid #e2e8f0', borderBottom: '1px solid #e2e8f0' }} colSpan={2}>AKOMEL NH Saborizado Caja 15Kg</td></tr>
+                            <tr><td style={labelTd}>Rend. Impurezas + Humedad</td><td style={inputTd}>{numInput('akomel_rend_impurezas_humedad_sab', '0.001')}</td></tr>
+                            <tr><td style={labelTd}>Paso 1</td><td style={{ ...valTd, ...calcStyle }}>{akomel ? n(akomel.paso1_sab, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Rend. Acidez AAK</td><td style={inputTd}>{numInput('akomel_rend_acidez_aak_sab', '0.001')}</td></tr>
+                            <tr><td style={labelTd}>Paso 2</td><td style={{ ...valTd, ...calcStyle }}>{akomel ? n(akomel.paso2_sab, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Costos Transformación</td><td style={inputTd}>{numInput('akomel_costos_transf_sab', '1')}</td></tr>
+                            <tr><td style={labelTd}>Material Empaque</td><td style={inputTd}>{numInput('akomel_material_empaque_sab', '1')}</td></tr>
+                            <tr><td style={{ ...labelTd, fontWeight: 700 }}>Akomel NH Sab Caja 15Kg (COP/KG)</td><td style={resultTd}>{akomel ? n(akomel.precio_akomel_nh_sab_caja15, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>KG anual (compra)</td><td style={inputTd}>{numInput('kg_akomel_sab_anual', '1')}</td></tr>
+                            <tr><td style={{ ...labelTd, fontWeight: 700 }}>Exposición USD</td><td style={resultTd}>{akomel ? fmtUsd(((exposureParams.kg_akomel_sab_anual ?? 0) * akomel.precio_akomel_nh_sab_caja15) / (exposureParams.trm || 1)) : '—'}</td></tr>
+                            {/* Total AKOMEL USD */}
+                            <tr><td style={{ ...labelTd, padding: '8px 12px', fontSize: '0.75rem', color: '#1e293b', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', background: '#f1f5f9', borderTop: '1px solid #e2e8f0', borderBottom: '1px solid #e2e8f0' }} colSpan={2}>Total</td></tr>
+                            <tr><td style={{ ...labelTd, fontWeight: 700 }}>Total Exposición AKOMEL USD</td><td style={{ ...resultTd, background: '#faf5ff', color: '#7c3aed' }}>{akomel ? fmtUsd((((exposureParams.kg_akomel_granel_anual ?? 0) * akomel.precio_akomel_nh_granel) + ((exposureParams.kg_akomel_sl_anual ?? 0) * akomel.precio_akomel_nh_sl_caja15) + ((exposureParams.kg_akomel_sab_anual ?? 0) * akomel.precio_akomel_nh_sab_caja15)) / (exposureParams.trm || 1)) : '—'}</td></tr>
+                          </tbody>
+                        </table>
+                      </div>
+                    </Col>
+
+                    {/* ── CEBES MC 35 ── */}
+                    <Col md={6} lg={4}>
+                      <div className="rounded h-100" style={{ border: '1px solid #e2e8f0', overflow: 'hidden', background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+                        <div style={headerStyle}>CEBES MC 35 <span className="fw-normal ms-2" style={{ fontSize: '0.7rem' }}>Palmiste — Malasia</span></div>
+                        <table className="table table-sm mb-0" style={{ fontSize: '0.78rem' }}>
+                          <tbody>
+                            <tr><td style={labelTd}>Precio Palmiste CIF (USD/TON)</td><td style={inputTd}>{numInput('cebes_precio_palmiste_cif', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>Flete Malasia→Colombia (USD/TON)</td><td style={inputTd}>{numInput('cebes_flete_malasia_colombia', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>Flete Malasia→Europa (USD/TON)</td><td style={inputTd}>{numInput('cebes_flete_malasia_europa', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>Arancel (0.1%)</td><td style={{ ...valTd, ...calcStyle }}>{cebes ? n(cebes.arancel, 4) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Risk Futures Fee (USD/TON)</td><td style={inputTd}>{numInput('cebes_risk_futures_fee_palmiste', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>TRM (USD/COP) <span style={{ fontSize: '0.65rem', color: '#94a3b8' }}>(Xerenity)</span></td><td style={{ ...valTd, ...calcStyle }}>{n(exposureParams.trm, 2)}</td></tr>
+                            <tr><td style={labelTd}>Prima RSPO MB (USD/TON)</td><td style={inputTd}>{numInput('cebes_prima_rspo_mb', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>Precio Palmiste (COP/KG)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{cebes ? n(cebes.precio_palmiste_cop_kg, 2) : '—'}</td></tr>
+                            {/* Base proceso */}
+                            <tr><td style={{ ...labelTd, padding: '8px 12px', fontSize: '0.75rem', color: '#1e293b', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', background: '#f1f5f9', borderTop: '1px solid #e2e8f0', borderBottom: '1px solid #e2e8f0' }} colSpan={2}>Base Proceso</td></tr>
+                            <tr><td style={labelTd}>Materia Prima (COP/KG)</td><td style={{ ...valTd, ...calcStyle }}>{cebes ? n(cebes.materia_prima, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Prima Abastecimiento (COP)</td><td style={inputTd}>{numInput('cebes_prima_abastecimiento', '1')}</td></tr>
+                            <tr><td style={labelTd}>Flete Extractora→Fábrica (COP/KG)</td><td style={inputTd}>{numInput('cebes_flete_extractora_fabrica', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>Precio MP puesto planta (COP/KG)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{cebes ? n(cebes.precio_mp_planta, 2) : '—'}</td></tr>
+                            {/* CEBES MC 35 */}
+                            <tr><td style={{ ...labelTd, padding: '8px 12px', fontSize: '0.75rem', color: '#1e293b', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', background: '#f1f5f9', borderTop: '1px solid #e2e8f0', borderBottom: '1px solid #e2e8f0' }} colSpan={2}>CEBES MC 35</td></tr>
+                            <tr><td style={labelTd}>Rend. Impurezas + Humedad</td><td style={inputTd}>{numInput('cebes_rend_impurezas_humedad', '0.001')}</td></tr>
+                            <tr><td style={labelTd}>Paso 1</td><td style={{ ...valTd, ...calcStyle }}>{cebes ? n(cebes.paso1_cebes, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Rend. Acidez AAK</td><td style={inputTd}>{numInput('cebes_rend_acidez_aak', '0.001')}</td></tr>
+                            <tr><td style={labelTd}>Paso 2</td><td style={{ ...valTd, ...calcStyle }}>{cebes ? n(cebes.paso2_cebes, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Costos Transformación</td><td style={inputTd}>{numInput('cebes_costos_transformacion', '1')}</td></tr>
+                            <tr><td style={labelTd}>Material Empaque</td><td style={inputTd}>{numInput('cebes_material_empaque', '1')}</td></tr>
+                            <tr><td style={labelTd}>Financiamiento (60 días)</td><td style={inputTd}>{numInput('cebes_financiamiento', '1')}</td></tr>
+                            <tr><td style={{ ...labelTd, fontWeight: 700 }}>CEBES MC 35 (COP/KG)</td><td style={resultTd}>{cebes ? n(cebes.precio_cebes_mc35, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>KG anual (compra)</td><td style={inputTd}>{numInput('kg_cebes_anual', '1')}</td></tr>
+                            <tr><td style={{ ...labelTd, fontWeight: 700 }}>Exposición USD</td><td style={{ ...resultTd, background: '#faf5ff', color: '#7c3aed' }}>{cebes ? fmtUsd(((exposureParams.kg_cebes_anual ?? 0) * cebes.precio_cebes_mc35) / (exposureParams.trm || 1)) : '—'}</td></tr>
+                          </tbody>
+                        </table>
+                      </div>
+                    </Col>
+
+                    {/* ── ALMIDÓN ── */}
+                    <Col md={6} lg={4}>
+                      <div className="rounded h-100" style={{ border: '1px solid #e2e8f0', overflow: 'hidden', background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+                        <div style={headerStyle}>ALMIDÓN <span className="fw-normal ms-2" style={{ fontSize: '0.7rem' }}>Maíz CBOT ZC → Almidón</span></div>
+                        <table className="table table-sm mb-0" style={{ fontSize: '0.78rem' }}>
+                          <tbody>
+                            <tr><td style={labelTd}>Precio Futuro Maíz (¢/bu)</td><td style={inputTd}>{numInput('precio_maiz_cent_bu', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>Base Maíz (¢/bu)</td><td style={inputTd}>{numInput('base_maiz_cent_bu', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>Flete Marítimo (USD/TON)</td><td style={inputTd}>{numInput('almidon_flete_maritimo', '0.01')}</td></tr>
+                            <tr><td style={labelTd}>Conversión bu/ton</td><td style={{ ...valTd, ...calcStyle }}>0.3937</td></tr>
+                            <tr><td style={labelTd}>Precio FOB (¢/bu)</td><td style={{ ...valTd, ...calcStyle }}>{almidon ? n(almidon.precio_fob_usc_bu, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Precio FOB (USD/TON)</td><td style={{ ...valTd, ...calcStyle }}>{almidon ? n(almidon.precio_fob_usd_ton, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Precio Maíz (USD/TON)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{almidon ? n(almidon.precio_maiz_usd_ton, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Crédito Subproductos (26%)</td><td style={{ ...valTd, ...calcStyle }}>{almidon ? n(almidon.credito_subproductos, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Precio Neto Maíz (USD/TON)</td><td style={{ ...valTd, ...calcStyle, fontWeight: 600 }}>{almidon ? n(almidon.precio_neto_maiz, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>Factor Maíz→Almidón</td><td style={{ ...valTd, ...calcStyle }}>1.60</td></tr>
+                            <tr><td style={{ ...labelTd, fontWeight: 700 }}>Precio Almidón (USD/TON)</td><td style={resultTd}>{almidon ? n(almidon.precio_almidon_usd_ton, 2) : '—'}</td></tr>
+                            <tr><td style={labelTd}>KG anual (compra)</td><td style={inputTd}>{numInput('kg_almidon_anual', '1')}</td></tr>
+                            <tr><td style={{ ...labelTd, fontWeight: 700 }}>Exposición USD</td><td style={{ ...resultTd, background: '#faf5ff', color: '#7c3aed' }}>{almidon ? fmtUsd(((exposureParams.kg_almidon_anual ?? 0) * almidon.precio_almidon_usd_ton) / 1000) : '—'}</td></tr>
+                          </tbody>
+                        </table>
+                      </div>
+                    </Col>
+                </Row>
+              )}
+
               {/* Summary tables */}
-              {exposureResult && (
+              {exposureResult && (() => {
+                // Recompute Super formula rows from live exposureParams so typing
+                // KG in a card updates this table instantly (no "Actualizar" click).
+                // Non-Super commodities keep the fetched values (need market prices).
+                const SUPER_IDS = new Set(['AKOMEL', 'CEBES_MC35', 'ALMIDON']);
+                const baseRows = exposureResult.commodities.filter((c) => !SUPER_IDS.has(c.nombre));
+                const liveSuperRows = isSuperAlimentos ? buildSuperFormulaCommodities(exposureParams) : [];
+                const displayRows = [...baseRows, ...liveSuperRows];
+                const liveTotalUsd = displayRows.reduce((s, c) => s + (c.exposicion_usd ?? 0), 0);
+                const liveRealUsd = (exposureResult.exposicion_ventas_intl ?? 0) - liveTotalUsd;
+                return (
                 <>
                   <div className="rounded mb-3" style={{ background: '#fff', border: '1px solid #e2e8f0', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
                     <div style={{ padding: '12px 16px', borderBottom: '1px solid #e2e8f0' }}>
@@ -1962,7 +2159,7 @@ function RiskManagement() {
                           </tr>
                         </thead>
                         <tbody>
-                          {exposureResult.commodities.map((c) => (
+                          {displayRows.map((c) => (
                             <tr key={c.nombre} style={{ borderBottom: '1px solid #f1f5f9' }}>
                               <td style={{ padding: '8px 12px', color: '#7c3aed', fontWeight: 600 }}>{c.nombre}</td>
                               <td className="text-center" style={{ padding: '8px 12px', color: '#64748b' }}>{c.exchange}</td>
@@ -1975,7 +2172,7 @@ function RiskManagement() {
                           ))}
                           <tr style={{ borderTop: '2px solid #1e293b', fontWeight: 700 }}>
                             <td colSpan={5} className="text-end" style={{ padding: '10px 12px' }}>Total Commodities</td>
-                            <td className="text-end" style={{ padding: '10px 12px' }}>{fmtUsd(exposureResult.total_commodities_usd)}</td>
+                            <td className="text-end" style={{ padding: '10px 12px' }}>{fmtUsd(liveTotalUsd)}</td>
                             <td>{' '}</td>
                           </tr>
                         </tbody>
@@ -1991,7 +2188,7 @@ function RiskManagement() {
                       <tbody>
                         <tr>
                           <td style={{ padding: '8px 16px', color: '#64748b' }}>Total Commodities</td>
-                          <td className="text-end" style={{ padding: '8px 16px', fontWeight: 700 }}>{fmtUsd(exposureResult.total_commodities_usd)}</td>
+                          <td className="text-end" style={{ padding: '8px 16px', fontWeight: 700 }}>{fmtUsd(liveTotalUsd)}</td>
                         </tr>
                         <tr style={{ borderTop: '1px solid #f1f5f9' }}>
                           <td style={{ padding: '8px 16px', color: '#64748b' }}>Exposición Ventas Intl.</td>
@@ -1999,7 +2196,7 @@ function RiskManagement() {
                         </tr>
                         <tr style={{ borderTop: '2px solid #16a34a' }}>
                           <td style={{ padding: '10px 16px', fontWeight: 700, color: '#16a34a' }}>Exposición Real USD</td>
-                          <td className="text-end" style={{ padding: '10px 16px', fontWeight: 700, color: '#16a34a' }}>{fmtUsd(exposureResult.exposicion_real_usd)}</td>
+                          <td className="text-end" style={{ padding: '10px 16px', fontWeight: 700, color: '#16a34a' }}>{fmtUsd(liveRealUsd)}</td>
                         </tr>
                         <tr style={{ borderTop: '1px solid #f1f5f9' }}>
                           <td style={{ padding: '8px 16px', color: '#64748b' }}>Exposición PEN (Perú)</td>
@@ -2009,7 +2206,8 @@ function RiskManagement() {
                     </table>
                   </div>
                 </>
-              )}
+                );
+              })()}
             </div>
             </>
           );

--- a/src/types/risk.ts
+++ b/src/types/risk.ts
@@ -83,6 +83,63 @@ export interface ExposureParams {
   ventas_intl_usd?: number;
   ventas_co_usd?: number;
   ventas_pe_usd?: number;
+
+  // ── AKOMEL COP (aceite de palma crudo Malasia → productos terminados) ──
+  // Solo se usa en Super de Alimentos. Port fiel del instructivo Python.
+  akomel_fob_malasya?: number;              // USD/TON — FEP mensual (celda D8)
+  akomel_international_freight?: number;    // USD/TON — FEP mensual (D9)
+  akomel_risk_futures_fee?: number;         // USD/TON — 40/70 segun plazo (D11)
+  akomel_trm?: number;                      // USD/COP — FEP mensual (D12)
+  akomel_prima_abastecimiento?: number;     // COP/KG (D18)
+  akomel_flete_extractora_fabrica?: number; // COP/KG (D19)
+  akomel_tariff_aak_my_pct?: number;        // % arancel (C10, default 0.0004)
+  akomel_bonificacion_calidad_pct?: number; // % bonif (C17, default 0.025)
+  // AKOMEL Granel
+  akomel_rend_impurezas_humedad_granel?: number;  // C27 (default 0.99)
+  akomel_rend_acidez_aak_granel?: number;         // C28 (default 0.96)
+  akomel_costos_transf_granel?: number;           // COP/KG (D29)
+  // AKOMEL Sin Lecitina Caja 15Kg
+  akomel_rend_impurezas_humedad_sl?: number;      // C33 (default 0.99)
+  akomel_rend_acidez_aak_sl?: number;             // C34 (default 0.96)
+  akomel_costos_transf_sl?: number;               // COP/KG (D35)
+  akomel_material_empaque_sl?: number;            // COP/KG (D36)
+  // AKOMEL Saborizado Caja 15Kg
+  akomel_rend_impurezas_humedad_sab?: number;     // C40 (default 0.99)
+  akomel_rend_acidez_aak_sab?: number;            // C41 (default 0.96)
+  akomel_costos_transf_sab?: number;              // COP/KG (D42)
+  akomel_material_empaque_sab?: number;           // COP/KG (D43)
+
+  // ── CEBES MC 35 (Palmiste) ──
+  cebes_precio_palmiste_cif?: number;         // USD/TON (D50)
+  cebes_flete_malasia_colombia?: number;      // USD/TON (D51)
+  cebes_flete_malasia_europa?: number;        // USD/TON (D52, puede ser negativo)
+  cebes_trm?: number;                         // USD/COP (D56)
+  cebes_arancel_pct?: number;                 // % (D53, default 0.001)
+  // Informativos en la hoja (NO entran en la formula vigente D58)
+  cebes_risk_futures_fee_palmiste?: number;   // USD/TON (D55)
+  cebes_prima_rspo_mb?: number;               // USD/TON (D57)
+  // Operativos
+  cebes_prima_abastecimiento?: number;        // COP (D61)
+  cebes_flete_extractora_fabrica?: number;    // COP/KG (D62)
+  cebes_rend_impurezas_humedad?: number;      // C67 (default 0.994)
+  cebes_rend_acidez_aak?: number;             // C68 (default 0.94)
+  cebes_costos_transformacion?: number;       // COP/KG (D69)
+  cebes_material_empaque?: number;            // COP/KG (D70)
+  cebes_financiamiento?: number;              // COP/KG — 60 dias
+
+  // ── ALMIDON (Maiz → almidon) ──
+  almidon_flete_maritimo?: number;            // USD/TON (H13) — flete maritimo adicional
+  almidon_factor_conversion_bush_ton?: number; // H11 (default 0.3936825)
+  almidon_credito_subproductos_pct?: number;  // G15 (default 0.26)
+  almidon_factor_conversion_maiz_almidon?: number; // G17 (default 1.6)
+
+  // ── KG anual (input manual) para Exposicion Natural USD ──
+  // AKOMEL tiene 3 productos derivados; CEBES y ALMIDON uno cada uno.
+  kg_akomel_granel_anual?: number;     // Granel
+  kg_akomel_sl_anual?: number;         // Sin Lecitina Caja 15Kg
+  kg_akomel_sab_anual?: number;        // Saborizado Caja 15Kg
+  kg_cebes_anual?: number;             // CEBES MC 35
+  kg_almidon_anual?: number;           // Almidon
 }
 
 export interface CommodityExposure {


### PR DESCRIPTION
closes #288

## Summary

Agrega 3 tarjetas de formulacion al tab **Exposición** de `/risk-management` para Super de Alimentos, con intermedios visibles para auditoria y Exposición Natural USD conectada en vivo a la tabla "Exposición por Commodity".

- **AKOMEL NH** (aceite de palma Malasia → Granel, Sin Lecitina, Saborizado)
- **CEBES MC 35** (palmiste Malasia)
- **ALMIDÓN** (maíz CBOT ZC → almidón)

## Cambios

- Calculadores puros (`calcularAkomelCop`, `calcularCebesMc35`, `calcularAlmidon`) con 30+ parámetros nuevos en `ExposureParams`, defaults del instructivo Python
- TRM en tarjetas AKOMEL y CEBES es **read-only**, sincronizada con TRM global de Xerenity (BanRep)
- Input `KG anual (compra)` por sub-producto + fila **Exposición USD** — AKOMEL tiene fila adicional **Total Exposición AKOMEL USD**
- `buildSuperFormulaCommodities(params)` exportado para que la tabla de resumen recalcule en vivo desde `exposureParams` sin necesidad de click en "Actualizar"
- `Total Commodities` y `Exposición Real USD` derivan de `displayRows` en vivo
- Metodología actualizada con fórmulas paso a paso
- Divisiones internas con bold + fondo `#f1f5f9`

## Validación

- 8/8 asserts matemáticos del instructivo Python pasan
- `tsc --noEmit` limpio
- `eslint` limpio

🤖 Generated with [Claude Code](https://claude.com/claude-code)