### PR TITLE
feat(risk): ACEITE_PALMA en COMMODITY_TEMPLATES

### DIFF
--- a/src/lib/risk/companyConfig.ts
+++ b/src/lib/risk/companyConfig.ts
@@ -205,6 +205,7 @@ export const COMMODITY_TEMPLATES: CommodityConfig[] = [
   { asset: 'AZUCAR', unit: 'TONS', price_unit: 'cents/lb', contract_multiplier: 112000, chart_color: '#10b981', exchange: 'ICE', symbol: 'SB' },
   { asset: 'CACAO', unit: 'TONS', price_unit: 'USD/ton', contract_multiplier: 10, chart_color: '#8b5cf6', exchange: 'ICE', symbol: 'CC' },
   { asset: 'CAFE', unit: 'TONS', price_unit: 'cents/lb', contract_multiplier: 37500, chart_color: '#78350f', exchange: 'ICE', symbol: 'KC' },
+  { asset: 'ACEITE_PALMA', unit: 'TONS', price_unit: 'MYR/ton', contract_multiplier: 25, chart_color: '#dc2626', exchange: 'MDEX', symbol: 'FCPO' },
   { asset: 'PETROLEO', unit: 'BBL', price_unit: 'USD/bbl', contract_multiplier: 1000, chart_color: '#1e293b', exchange: 'NYMEX', symbol: 'CL' },
   { asset: 'TRIGO', unit: 'TONS', price_unit: 'cents/bu', contract_multiplier: 5000, chart_color: '#d97706', exchange: 'CME', symbol: 'ZW' },
   { asset: 'SOYA', unit: 'TONS', price_unit: 'cents/bu', contract_multiplier: 5000, chart_color: '#059669', exchange: 'CME', symbol: 'ZS' },


### PR DESCRIPTION
closes #290

## Summary

Agrega template de aceite de palma (FCPO, Bursa Malaysia) al array `COMMODITY_TEMPLATES` en `src/lib/risk/companyConfig.ts` para que cualquier empresa lo pueda seleccionar en el setup.

Super de Alimentos ya tiene ACEITE_PALMA en su `risk_company_config` via PATCH directo.

Backend: avelezX/xerenity-backend#104

🤖 Generated with [Claude Code](https://claude.com/claude-code)