### PR TITLE
feat(concurrency): #292 AbortSignal + 30s timeout en fetchers

### DIFF
--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -11,6 +11,61 @@ const SHORT_ID_LEN = 8;
 
 export type TelemetryNamespace = 'pricing' | 'reprice' | 'loans' | 'store';
 
+/** Default HTTP timeout for pricing/loans fetchers. Also used when no external
+ *  signal is provided. Tracked in sub-issue #292. */
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+/**
+ * Combine an optional external AbortSignal with a timeout signal.
+ * Returns a signal that aborts when either the external one aborts or the
+ * timeout fires. Falls back to a manual aggregator when AbortSignal.any is
+ * not available (older browsers / Node < 20).
+ */
+export function combineAbortSignals(
+  external: AbortSignal | undefined,
+  timeoutMs: number,
+): AbortSignal {
+  const timeoutSignal =
+    typeof AbortSignal.timeout === 'function'
+      ? AbortSignal.timeout(timeoutMs)
+      : (() => {
+          const c = new AbortController();
+          setTimeout(() => c.abort(new DOMException('Timeout', 'TimeoutError')), timeoutMs);
+          return c.signal;
+        })();
+
+  if (!external) return timeoutSignal;
+
+  const anyFn = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;
+  if (typeof anyFn === 'function') {
+    return anyFn([external, timeoutSignal]);
+  }
+
+  const ctrl = new AbortController();
+  const forward = (source: AbortSignal) => {
+    if (source.aborted) {
+      ctrl.abort(source.reason);
+      return;
+    }
+    source.addEventListener('abort', () => ctrl.abort(source.reason), { once: true });
+  };
+  forward(external);
+  forward(timeoutSignal);
+  return ctrl.signal;
+}
+
+/** True if the given error was caused by an abort/timeout. */
+export function isAbortError(e: unknown): boolean {
+  if (!e) return false;
+  if (e instanceof DOMException) {
+    return e.name === 'AbortError' || e.name === 'TimeoutError';
+  }
+  if (e instanceof Error) {
+    return e.name === 'AbortError' || e.name === 'TimeoutError';
+  }
+  return false;
+}
+
 const makeReqId = (): string => {
   try {
     return crypto.randomUUID().slice(0, SHORT_ID_LEN);

--- a/src/models/loans/fetchCashFlows.ts
+++ b/src/models/loans/fetchCashFlows.ts
@@ -1,12 +1,22 @@
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { LoanCashFlowIbr } from 'src/types/loans';
-import { telemetry } from 'src/lib/telemetry';
+import {
+  telemetry,
+  combineAbortSignals,
+  DEFAULT_FETCH_TIMEOUT_MS,
+  isAbortError,
+} from 'src/lib/telemetry';
 
 // CashFlows Response
 export type CashflowResponse = {
   data: LoanCashFlowIbr[];
   error: string | undefined;
 };
+
+export interface FetchCashFlowsOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
 
 const CASH_FLOW = {
   key: 'loan_cash_flow',
@@ -29,7 +39,8 @@ const supabase = createClientComponentClient();
 export const fetchCashFlows = async (
   loanId: string,
   loanType: string,
-  filterDate: string
+  filterDate: string,
+  opts?: FetchCashFlowsOptions,
 ): Promise<CashflowResponse> => {
   let requestKey = CASH_FLOW.key;
 
@@ -42,6 +53,10 @@ export const fetchCashFlows = async (
     data: [],
     error: undefined,
   };
+  const signal = combineAbortSignals(
+    opts?.signal,
+    opts?.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS,
+  );
   return telemetry.time(
     'loans',
     requestKey,
@@ -49,7 +64,8 @@ export const fetchCashFlows = async (
       try {
         const { data, error } = await supabase
           .schema(SCHEMA)
-          .rpc(requestKey, { credito_id: loanId, filter_date: filterDate });
+          .rpc(requestKey, { credito_id: loanId, filter_date: filterDate })
+          .abortSignal(signal);
 
         if (error) {
           telemetry.warn('loans', `${requestKey} rpc error`, {
@@ -64,6 +80,12 @@ export const fetchCashFlows = async (
         response.data = data;
         return response;
       } catch (e) {
+        if (isAbortError(e)) {
+          telemetry.debug('loans', `${requestKey} aborted`, { loanId });
+          // Propagate so callers using Promise.allSettled can distinguish
+          // "my request was cancelled" from "backend error".
+          throw e;
+        }
         telemetry.warn('loans', `${requestKey} threw`, {
           loanId,
           message: e instanceof Error ? e.message : String(e),

--- a/src/models/pricing/pricingApi.ts
+++ b/src/models/pricing/pricingApi.ts
@@ -15,19 +15,40 @@ import type {
   XccyCashflowResponse,
   ParBasisPoint,
 } from 'src/types/pricing';
-import { telemetry } from 'src/lib/telemetry';
+import {
+  telemetry,
+  combineAbortSignals,
+  DEFAULT_FETCH_TIMEOUT_MS,
+} from 'src/lib/telemetry';
 
 const BASE_URL = process.env.NEXT_PUBLIC_PYSDK_URL || 'https://pysdk.fly.dev';
 
-async function pricingFetch<T>(path: string, options?: RequestInit): Promise<T> {
+/** Extra options accepted by all pricing endpoints. `signal` lets callers
+ *  cancel in-flight requests when their inputs change (sub-issue #292). */
+export interface PricingFetchOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+async function pricingFetch<T>(
+  path: string,
+  options?: RequestInit & PricingFetchOptions,
+): Promise<T> {
   const url = `${BASE_URL}/${path}`;
+  const {
+    signal: externalSignal,
+    timeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
+    ...fetchOptions
+  } = options ?? {};
+  const signal = combineAbortSignals(externalSignal, timeoutMs);
   return telemetry.time(
     'pricing',
     path,
     async () => {
       const res = await fetch(url, {
         headers: { 'Content-Type': 'application/json' },
-        ...options,
+        ...fetchOptions,
+        signal,
       });
       if (!res.ok) {
         const text = await res.text();
@@ -42,26 +63,33 @@ async function pricingFetch<T>(path: string, options?: RequestInit): Promise<T> 
 
 // ── Curves ──
 
-export const buildCurves = () =>
-  pricingFetch<BuildResult>('pricing/curves/build', { method: 'POST' });
+export const buildCurves = (opts?: PricingFetchOptions) =>
+  pricingFetch<BuildResult>('pricing/curves/build', { method: 'POST', ...opts });
 
-export const getCurveStatus = () =>
-  pricingFetch<CurveStatus>('pricing/curves/status');
+export const getCurveStatus = (opts?: PricingFetchOptions) =>
+  pricingFetch<CurveStatus>('pricing/curves/status', opts);
 
-export const bumpCurve = (curve: string, bps: number) =>
+export const bumpCurve = (curve: string, bps: number, opts?: PricingFetchOptions) =>
   pricingFetch<unknown>('pricing/curves/bump', {
     method: 'POST',
     body: JSON.stringify({ curve, bps }),
+    ...opts,
   });
 
-export const setCurveNode = (curve: string, node: string | number, rate_pct: number) =>
+export const setCurveNode = (
+  curve: string,
+  node: string | number,
+  rate_pct: number,
+  opts?: PricingFetchOptions,
+) =>
   pricingFetch<unknown>('pricing/curves/bump', {
     method: 'POST',
     body: JSON.stringify({ curve, node, rate_pct }),
+    ...opts,
   });
 
-export const resetCurves = () =>
-  pricingFetch<unknown>('pricing/curves/reset', { method: 'POST' });
+export const resetCurves = (opts?: PricingFetchOptions) =>
+  pricingFetch<unknown>('pricing/curves/reset', { method: 'POST', ...opts });
 
 // ── NDF ──
 
@@ -75,14 +103,15 @@ export interface NdfRequest {
   market_forward?: number;
 }
 
-export const priceNdf = (params: NdfRequest) =>
+export const priceNdf = (params: NdfRequest, opts?: PricingFetchOptions) =>
   pricingFetch<NdfPricingResult>('pricing/ndf', {
     method: 'POST',
     body: JSON.stringify(params),
+    ...opts,
   });
 
-export const getNdfImpliedCurve = () =>
-  pricingFetch<NdfImpliedCurvePoint[]>('pricing/ndf/implied-curve');
+export const getNdfImpliedCurve = (opts?: PricingFetchOptions) =>
+  pricingFetch<NdfImpliedCurvePoint[]>('pricing/ndf/implied-curve', opts);
 
 // ── IBR Swap ──
 
@@ -97,14 +126,15 @@ export interface IbrSwapRequest {
   payment_frequency?: string;
 }
 
-export const priceIbrSwap = (params: IbrSwapRequest) =>
+export const priceIbrSwap = (params: IbrSwapRequest, opts?: PricingFetchOptions) =>
   pricingFetch<IbrSwapPricingResult>('pricing/ibr-swap', {
     method: 'POST',
     body: JSON.stringify(params),
+    ...opts,
   });
 
-export const getIbrParCurve = () =>
-  pricingFetch<ParCurvePoint[]>('pricing/ibr/par-curve');
+export const getIbrParCurve = (opts?: PricingFetchOptions) =>
+  pricingFetch<ParCurvePoint[]>('pricing/ibr/par-curve', opts);
 
 // ── TES Bond ──
 
@@ -120,20 +150,21 @@ export interface TesBondRequest {
   valuation_date?: string;     // pysdk: use historical TES curve for this date
 }
 
-export const priceTesBond = (params: TesBondRequest) =>
+export const priceTesBond = (params: TesBondRequest, opts?: PricingFetchOptions) =>
   pricingFetch<TesBondResult>('pricing/tes-bond', {
     method: 'POST',
     body: JSON.stringify({ include_cashflows: true, ...params }),
+    ...opts,
   });
 
 // Backend returns { count, bonds[] } — unwrap to TesCatalogItem[]
-export const getTesCatalog = () =>
-  pricingFetch<{ count: number; bonds: TesCatalogItem[] }>('pricing/tes/catalog')
+export const getTesCatalog = (opts?: PricingFetchOptions) =>
+  pricingFetch<{ count: number; bonds: TesCatalogItem[] }>('pricing/tes/catalog', opts)
     .then((res) => res.bonds);
 
 // No backend endpoint yet — caller should catch and use mock data
-export const getTesYieldCurve = () =>
-  pricingFetch<TesYieldCurvePoint[]>('pricing/tes/yield-curve');
+export const getTesYieldCurve = (opts?: PricingFetchOptions) =>
+  pricingFetch<TesYieldCurvePoint[]>('pricing/tes/yield-curve', opts);
 
 // ── Xccy Swap ──
 
@@ -152,16 +183,18 @@ export interface XccySwapRequest {
   amortization_schedule?: number[];
 }
 
-export const priceXccySwap = (params: XccySwapRequest) =>
+export const priceXccySwap = (params: XccySwapRequest, opts?: PricingFetchOptions) =>
   pricingFetch<XccySwapResult>('pricing/xccy-swap', {
     method: 'POST',
     body: JSON.stringify(params),
+    ...opts,
   });
 
-export const getXccyCashflows = (params: XccySwapRequest) =>
+export const getXccyCashflows = (params: XccySwapRequest, opts?: PricingFetchOptions) =>
   pricingFetch<XccyCashflowResponse>('pricing/xccy-swap/cashflows', {
     method: 'POST',
     body: JSON.stringify(params),
+    ...opts,
   });
 
 export interface ParBasisCurveRequest {
@@ -172,16 +205,20 @@ export interface ParBasisCurveRequest {
   tenors_years?: number[];
 }
 
-export const getXccyParBasisCurve = (params?: ParBasisCurveRequest) =>
+export const getXccyParBasisCurve = (
+  params?: ParBasisCurveRequest,
+  opts?: PricingFetchOptions,
+) =>
   pricingFetch<ParBasisPoint[]>('pricing/xccy/par-basis-curve', {
     method: 'POST',
     body: JSON.stringify(params || {}),
+    ...opts,
   });
 
 // ── Market Marks ──
 
-export const getMarksDates = () =>
-  pricingFetch<{ dates: string[] }>('pricing/marks/dates');
+export const getMarksDates = (opts?: PricingFetchOptions) =>
+  pricingFetch<{ dates: string[] }>('pricing/marks/dates', opts);
 
 export interface MarketMarkRow {
   fecha: string;
@@ -193,11 +230,11 @@ export interface MarketMarkRow {
   ndf: Record<string, { F_market?: number; fwd_pts_cop?: number; deval_ea?: number } | null> | null;
 }
 
-export const getMarks = () =>
-  pricingFetch<{ marks: MarketMarkRow[]; count: number }>('pricing/marks');
+export const getMarks = (opts?: PricingFetchOptions) =>
+  pricingFetch<{ marks: MarketMarkRow[]; count: number }>('pricing/marks', opts);
 
-export const getMarkByDate = (fecha: string) =>
-  pricingFetch<{ mark: MarketMarkRow | null }>(`pricing/marks?fecha=${fecha}`);
+export const getMarkByDate = (fecha: string, opts?: PricingFetchOptions) =>
+  pricingFetch<{ mark: MarketMarkRow | null }>(`pricing/marks?fecha=${fecha}`, opts);
 
 // ── NDF Settlement ──
 
@@ -219,8 +256,12 @@ export interface NdfSettlementResult {
   maturity_date: string;
 }
 
-export const getNdfSettlement = (params: NdfSettlementRequest) =>
+export const getNdfSettlement = (
+  params: NdfSettlementRequest,
+  opts?: PricingFetchOptions,
+) =>
   pricingFetch<NdfSettlementResult>('pricing/ndf/settlement', {
     method: 'POST',
     body: JSON.stringify(params),
+    ...opts,
   });

--- a/src/models/trading/repricePortfolio.ts
+++ b/src/models/trading/repricePortfolio.ts
@@ -7,7 +7,11 @@ import type {
   PricedIbrSwap,
   PortfolioRepriceResponse,
 } from 'src/types/trading';
-import { telemetry } from 'src/lib/telemetry';
+import {
+  telemetry,
+  combineAbortSignals,
+  DEFAULT_FETCH_TIMEOUT_MS,
+} from 'src/lib/telemetry';
 
 const BASE_URL =
   process.env.NEXT_PUBLIC_PYSDK_URL || 'https://pysdk.fly.dev';
@@ -19,19 +23,31 @@ interface RawRepriceResponse {
   summary: PortfolioRepriceResponse['summary'];
 }
 
+export interface RepricePortfolioOptions {
+  valuation_date?: string;
+  /** Caller-supplied abort signal. Combined with a default timeout. */
+  signal?: AbortSignal;
+  /** Override the default 30s timeout (sub-issue #292). */
+  timeoutMs?: number;
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export const repricePortfolio = async (
   xccyPositions: XccyPosition[],
   ndfPositions: NdfPosition[],
   ibrSwapPositions: IbrSwapPosition[],
-  options?: { valuation_date?: string }
+  options?: RepricePortfolioOptions,
 ): Promise<PortfolioRepriceResponse> => {
   const url = `${BASE_URL}/pricing/portfolio/reprice`;
+  const signal = combineAbortSignals(
+    options?.signal,
+    options?.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS,
+  );
   return telemetry.time(
     'reprice',
     'portfolio/reprice',
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    async () => repriceImpl(url, xccyPositions, ndfPositions, ibrSwapPositions, options),
+    async () => repriceImpl(url, signal, xccyPositions, ndfPositions, ibrSwapPositions, options),
     {
       valuationDate: options?.valuation_date ?? 'today',
       xccyCount: xccyPositions.length,
@@ -43,14 +59,16 @@ export const repricePortfolio = async (
 
 async function repriceImpl(
   url: string,
+  signal: AbortSignal,
   xccyPositions: XccyPosition[],
   ndfPositions: NdfPosition[],
   ibrSwapPositions: IbrSwapPosition[],
-  options?: { valuation_date?: string },
+  options?: RepricePortfolioOptions,
 ): Promise<PortfolioRepriceResponse> {
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    signal,
     body: JSON.stringify({
       ...(options?.valuation_date ? { valuation_date: options.valuation_date } : {}),
       xccy_positions: xccyPositions.map((p) => ({


### PR DESCRIPTION
## Summary

- Sub-issue #292 — primera pieza de Fase 1 (#298). Base para los siguientes parches (#293 token monotónico, #294 allSettled, #295 consolidar call-sites).
- Agrega `AbortSignal` + timeout default de 30s a todos los fetchers de pricing y loans.
- Sin cambios de comportamiento para callers existentes: opts son opcionales. Si no los pasas, aplica el timeout default y nada más.

## Qué hace

### Nuevos helpers en `src/lib/telemetry.ts`

- `DEFAULT_FETCH_TIMEOUT_MS = 30_000`
- `combineAbortSignals(external, timeoutMs)` combina la signal del caller con un timeout. Usa `AbortSignal.any` en browsers modernos y un fallback manual para los viejos.
- `isAbortError(e)` distingue `AbortError`/`TimeoutError` de errores genéricos.

### Fetchers instrumentados

- [pricingApi.ts](src/models/pricing/pricingApi.ts): nuevo `PricingFetchOptions { signal, timeoutMs }`. Todos los exports lo aceptan (priceNdf, priceXccySwap, priceTesBond, buildCurves, getCurveStatus, getNdfSettlement, etc.).
- [repricePortfolio.ts](src/models/trading/repricePortfolio.ts): nueva `RepricePortfolioOptions` con `valuation_date`, `signal`, `timeoutMs`.
- [fetchCashFlows.ts](src/models/loans/fetchCashFlows.ts): supabase-js soporta `.abortSignal(signal)` en el query builder — conectado. `AbortError` se propaga (no se convierte en response.error) para que callers con `Promise.allSettled` puedan distinguir "cancelado" de "fallo backend".

## Qué NO hace (scope explícito)

- No migra los callsites del store de trading (`repriceAllWithMark`, etc.) para que usen la signal — eso es sub-issue #293 (token monotónico).
- No cambia el batching de loans — eso es sub-issue #294 (`Promise.all` → `allSettled`).
- No agrega tests unitarios. El proyecto no tiene jest/vitest instalado; agregarlo es scope de Fase 4 (#301).

## Test plan

- [x] `npx tsc --noEmit` limpio
- [x] `npm run lint` sin errores nuevos (solo warnings pre-existentes)
- [ ] Manual en dev: un fetch lento ahora falla con `TimeoutError` a los 30s en vez de colgar indefinidamente
- [ ] Manual: usar DevTools para throttle la conexión y verificar que el timeout dispara

## Siguiente

- #293 — Request token monotónico en `repriceAllWithMark` + `loadReferencePrices`. Usa la signal de este PR para cancelar requests viejos.

Closes #292
Refs #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)
