### PR TITLE
feat(admin): /admin/monitor pages for collector monitoring

### DIFF
--- a/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
+++ b/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
@@ -14,6 +14,7 @@ import {
   faCog,
   faRobot,
   faUsers,
+  faHeartPulse,
 } from '@fortawesome/free-solid-svg-icons';
 import useAppStore from 'src/store';
 import SubNavItem from './SubNavItem';
@@ -173,6 +174,14 @@ const SidebarNavList = ({ currentPath }: SidebarNavProps) => {
           path="/settings/users"
           icon={faUsers}
           active={currentPath.includes('/settings/users')}
+        />
+      )}
+      {userRole === 'super_admin' && (
+        <NavigationItem
+          name="Monitor"
+          path="/admin/monitor"
+          icon={faHeartPulse}
+          active={currentPath.includes('/admin/monitor')}
         />
       )}
       {userRole === 'super_admin' && (

--- a/src/models/monitor/index.ts
+++ b/src/models/monitor/index.ts
@@ -1,0 +1,137 @@
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import {
+  CollectorOverview,
+  CollectorRun,
+  CollectorAlert,
+} from 'src/types/monitor';
+
+const supabase = createClientComponentClient();
+const SCHEMA = 'xerenity';
+
+export type ListResponse<T> = {
+  data: T[];
+  error: string | undefined;
+};
+
+export type ActionResponse = {
+  success: boolean;
+  error: string | undefined;
+};
+
+export const listCollectorOverview = async (): Promise<ListResponse<CollectorOverview>> => {
+  const response: ListResponse<CollectorOverview> = { data: [], error: undefined };
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('list_collector_overview');
+    if (error) {
+      response.error = error.message || 'Error fetching collector overview';
+      return response;
+    }
+    response.data = (data ?? []) as CollectorOverview[];
+    return response;
+  } catch (e) {
+    response.error = e instanceof Error ? e.message : 'Error fetching collector overview';
+    return response;
+  }
+};
+
+export const listActiveAlerts = async (): Promise<ListResponse<CollectorAlert>> => {
+  const response: ListResponse<CollectorAlert> = { data: [], error: undefined };
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('list_active_alerts');
+    if (error) {
+      response.error = error.message || 'Error fetching active alerts';
+      return response;
+    }
+    response.data = (data ?? []) as CollectorAlert[];
+    return response;
+  } catch (e) {
+    response.error = e instanceof Error ? e.message : 'Error fetching active alerts';
+    return response;
+  }
+};
+
+export const listCollectorRuns = async (
+  collectorName: string,
+  limit = 30,
+): Promise<ListResponse<CollectorRun>> => {
+  const response: ListResponse<CollectorRun> = { data: [], error: undefined };
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .from('collector_runs')
+      .select('*')
+      .eq('collector_name', collectorName)
+      .order('started_at', { ascending: false })
+      .limit(limit);
+    if (error) {
+      response.error = error.message || 'Error fetching runs';
+      return response;
+    }
+    response.data = (data ?? []) as CollectorRun[];
+    return response;
+  } catch (e) {
+    response.error = e instanceof Error ? e.message : 'Error fetching runs';
+    return response;
+  }
+};
+
+export const getCollectorDefinition = async (
+  collectorName: string,
+): Promise<{ data: CollectorOverview | null; error: string | undefined }> => {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('list_collector_overview');
+    if (error) {
+      return { data: null, error: error.message };
+    }
+    const rows = (data ?? []) as CollectorOverview[];
+    const found = rows.find((r) => r.name === collectorName) ?? null;
+    return { data: found, error: undefined };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const acknowledgeAlert = async (alertId: string): Promise<ActionResponse> => {
+  try {
+    const { error } = await supabase
+      .schema(SCHEMA)
+      .rpc('acknowledge_alert', { p_alert_id: alertId });
+    if (error) return { success: false, error: error.message };
+    return { success: true, error: undefined };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const silenceAlert = async (
+  alertId: string,
+  duration: string,
+): Promise<ActionResponse> => {
+  try {
+    const { error } = await supabase
+      .schema(SCHEMA)
+      .rpc('silence_alert', { p_alert_id: alertId, p_duration: duration });
+    if (error) return { success: false, error: error.message };
+    return { success: true, error: undefined };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const resolveAlert = async (alertId: string): Promise<ActionResponse> => {
+  try {
+    const { error } = await supabase
+      .schema(SCHEMA)
+      .rpc('resolve_alert', { p_alert_id: alertId });
+    if (error) return { success: false, error: error.message };
+    return { success: true, error: undefined };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};

--- a/src/pages/admin/monitor/[name].tsx
+++ b/src/pages/admin/monitor/[name].tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import { CoreLayout } from '@layout';
+import { Container, Row, Col, Badge } from 'react-bootstrap';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import {
+  faCircleCheck,
+  faCircleXmark,
+  faClock,
+  faCircleExclamation,
+  faArrowUpRightFromSquare,
+  faArrowLeft,
+  faChevronDown,
+  faChevronRight,
+} from '@fortawesome/free-solid-svg-icons';
+import styled from 'styled-components';
+import PageTitle from '@components/PageTitle';
+import RoleGuard from 'src/components/RoleGuard';
+import useAppStore from 'src/store';
+import type { CollectorRun, CollectorOverview, RunStatus } from 'src/types/monitor';
+import { getCollectorDefinition } from 'src/models/monitor';
+
+const PageWrap = styled.div`
+  padding: 16px 24px;
+`;
+
+const InfoCard = styled.div`
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  margin-bottom: 16px;
+
+  h4 { font-size: 14px; text-transform: uppercase; color: #302b63; margin: 0 0 12px 0; font-weight: 700; letter-spacing: 0.5px; }
+  dl { display: grid; grid-template-columns: max-content 1fr; gap: 6px 16px; font-size: 13px; margin: 0; }
+  dt { font-weight: 600; color: #666; }
+  dd { margin: 0; }
+  code { font-family: monospace; background: #f3f3f7; padding: 2px 6px; border-radius: 3px; font-size: 12px; }
+`;
+
+const TimelineCard = styled.div`
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+
+  h4 { font-size: 14px; text-transform: uppercase; color: #302b63; margin: 0; padding: 16px; font-weight: 700; letter-spacing: 0.5px; border-bottom: 1px solid #eee; }
+  table { width: 100%; border-collapse: collapse; }
+  thead th { background: #fafaff; font-size: 11px; text-transform: uppercase; color: #555; font-weight: 600; padding: 8px 12px; text-align: left; border-bottom: 1px solid #eee; }
+  tbody td { padding: 8px 12px; font-size: 13px; border-bottom: 1px solid #f5f5f5; vertical-align: top; }
+  tbody tr.failed { background: #fdf3f4; }
+  tbody tr.failed:hover { background: #fae7ea; }
+  tbody tr:hover { background: rgba(48, 43, 99, 0.03); }
+  .expander { cursor: pointer; user-select: none; }
+  .traceback { background: #222; color: #eee; font-family: monospace; font-size: 11px; padding: 12px; border-radius: 4px; white-space: pre-wrap; word-break: break-word; max-height: 400px; overflow: auto; margin-top: 6px; }
+`;
+
+const BackLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #302b63;
+  font-size: 13px;
+  margin-bottom: 12px;
+  text-decoration: none;
+  &:hover { text-decoration: underline; }
+`;
+
+const statusBadge = (status: RunStatus) => {
+  const cfg: Record<RunStatus, { bg: string; icon: typeof faCircleCheck }> = {
+    success: { bg: '#28a745', icon: faCircleCheck },
+    running: { bg: '#5bc0de', icon: faClock },
+    failed:  { bg: '#dc3545', icon: faCircleXmark },
+    timeout: { bg: '#6c757d', icon: faCircleExclamation },
+  };
+  const { bg, icon } = cfg[status];
+  return (
+    <Badge style={{ background: bg, fontWeight: 500 }}>
+      <Icon icon={icon} style={{ marginRight: 4 }} /> {status}
+    </Badge>
+  );
+};
+
+const formatDuration = (seconds: number | null): string => {
+  if (seconds == null) return '—';
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const mins = Math.floor(seconds / 60);
+  const rem = Math.floor(seconds - mins * 60);
+  return `${mins}m ${rem}s`;
+};
+
+const formatDate = (iso: string | null): string => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleString();
+};
+
+const CollectorDetailPage = () => {
+  const router = useRouter();
+  const nameParam = router.query.name;
+  const name = Array.isArray(nameParam) ? nameParam[0] : nameParam;
+
+  const [definition, setDefinition] = useState<CollectorOverview | null>(null);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const {
+    collectorRuns,
+    loadCollectorRuns,
+  } = useAppStore((s) => ({
+    collectorRuns: s.collectorRuns,
+    loadCollectorRuns: s.loadCollectorRuns,
+  }));
+
+  useEffect(() => {
+    if (!name) return;
+    loadCollectorRuns(name, 30);
+    getCollectorDefinition(name).then((r) => setDefinition(r.data));
+  }, [name, loadCollectorRuns]);
+
+  const runs: CollectorRun[] = name ? collectorRuns[name] ?? [] : [];
+
+  const toggle = (id: string) => setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+
+  return (
+    <CoreLayout>
+      <RoleGuard
+        requiredRole="super_admin"
+        fallback={
+          <PageWrap>
+            <PageTitle>Monitor</PageTitle>
+            <p>Requiere permisos de super admin.</p>
+          </PageWrap>
+        }
+      >
+        <PageWrap>
+          <BackLink href="/admin/monitor">
+            <Icon icon={faArrowLeft} /> Volver al overview
+          </BackLink>
+          <PageTitle>{name ?? 'Collector'}</PageTitle>
+
+          <Container fluid>
+            <Row>
+              <Col md={4}>
+                <InfoCard>
+                  <h4>Catálogo</h4>
+                  {definition ? (
+                    <dl>
+                      <dt>Severity</dt>
+                      <dd><Badge style={{ background: definition.severity_default === 'critical' ? '#dc3545' : definition.severity_default === 'warning' ? '#f0ad4e' : '#5bc0de' }}>{definition.severity_default}</Badge></dd>
+                      <dt>Enabled</dt>
+                      <dd>{definition.enabled ? 'Sí' : 'No'}</dd>
+                      <dt>Cron</dt>
+                      <dd>{definition.schedule_cron ? <code>{definition.schedule_cron}</code> : <em>no-schedule</em>}</dd>
+                      <dt>Tablas</dt>
+                      <dd>{definition.target_tables.length > 0 ? definition.target_tables.join(', ') : <em>—</em>}</dd>
+                      <dt>Alertas</dt>
+                      <dd>{definition.open_alerts}</dd>
+                    </dl>
+                  ) : (
+                    <em style={{ color: '#888' }}>Cargando…</em>
+                  )}
+                </InfoCard>
+              </Col>
+              <Col md={8}>
+                <TimelineCard>
+                  <h4>Últimos runs ({runs.length})</h4>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th />
+                        <th>Inicio</th>
+                        <th>Status</th>
+                        <th>Duración</th>
+                        <th>Filas</th>
+                        <th>Exit</th>
+                        <th>Error</th>
+                        <th />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {runs.map((run) => {
+                        const isExpanded = expanded[run.id] ?? false;
+                        const hasTraceback = Boolean(run.error_traceback);
+                        return (
+                          <React.Fragment key={run.id}>
+                            <tr className={run.status === 'failed' || run.status === 'timeout' ? 'failed' : ''}>
+                              <td
+                                className={hasTraceback ? 'expander' : ''}
+                                onClick={hasTraceback ? () => toggle(run.id) : undefined}
+                              >
+                                {hasTraceback && (
+                                  <Icon icon={isExpanded ? faChevronDown : faChevronRight} />
+                                )}
+                              </td>
+                              <td>{formatDate(run.started_at)}</td>
+                              <td>{statusBadge(run.status)}</td>
+                              <td>{formatDuration(run.duration_seconds)}</td>
+                              <td>{run.rows_inserted ?? '—'}</td>
+                              <td>{run.exit_code ?? '—'}</td>
+                              <td style={{ color: '#888', maxWidth: 280 }}>
+                                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                  {run.error_message ?? ''}
+                                </div>
+                              </td>
+                              <td>
+                                {run.gh_run_url && (
+                                  <a href={run.gh_run_url} target="_blank" rel="noreferrer" style={{ fontSize: 12 }}>
+                                    GH <Icon icon={faArrowUpRightFromSquare} />
+                                  </a>
+                                )}
+                              </td>
+                            </tr>
+                            {isExpanded && hasTraceback && (
+                              <tr>
+                                <td colSpan={8}>
+                                  <div className="traceback">{run.error_traceback}</div>
+                                </td>
+                              </tr>
+                            )}
+                          </React.Fragment>
+                        );
+                      })}
+                      {runs.length === 0 && (
+                        <tr>
+                          <td colSpan={8} style={{ textAlign: 'center', color: '#999', padding: 24 }}>
+                            Sin runs registrados aún.
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </TimelineCard>
+              </Col>
+            </Row>
+          </Container>
+        </PageWrap>
+      </RoleGuard>
+    </CoreLayout>
+  );
+};
+
+export default CollectorDetailPage;

--- a/src/pages/admin/monitor/[name].tsx
+++ b/src/pages/admin/monitor/[name].tsx
@@ -20,8 +20,14 @@ import styled from 'styled-components';
 import PageTitle from '@components/PageTitle';
 import RoleGuard from 'src/components/RoleGuard';
 import useAppStore from 'src/store';
-import type { CollectorRun, CollectorOverview, RunStatus } from 'src/types/monitor';
+import type { CollectorRun, CollectorOverview, RunStatus, Severity } from 'src/types/monitor';
 import { getCollectorDefinition } from 'src/models/monitor';
+
+const SEV_BADGE: Record<Severity, string> = {
+  critical: '#dc3545',
+  warning:  '#f0ad4e',
+  info:     '#5bc0de',
+};
 
 const PageWrap = styled.div`
   padding: 16px 24px;
@@ -149,7 +155,7 @@ const CollectorDetailPage = () => {
                   {definition ? (
                     <dl>
                       <dt>Severity</dt>
-                      <dd><Badge style={{ background: definition.severity_default === 'critical' ? '#dc3545' : definition.severity_default === 'warning' ? '#f0ad4e' : '#5bc0de' }}>{definition.severity_default}</Badge></dd>
+                      <dd><Badge style={{ background: SEV_BADGE[definition.severity_default] }}>{definition.severity_default}</Badge></dd>
                       <dt>Enabled</dt>
                       <dd>{definition.enabled ? 'Sí' : 'No'}</dd>
                       <dt>Cron</dt>
@@ -170,14 +176,14 @@ const CollectorDetailPage = () => {
                   <table>
                     <thead>
                       <tr>
-                        <th />
+                        <th aria-label="expand traceback" />
                         <th>Inicio</th>
                         <th>Status</th>
                         <th>Duración</th>
                         <th>Filas</th>
                         <th>Exit</th>
                         <th>Error</th>
-                        <th />
+                        <th aria-label="external link" />
                       </tr>
                     </thead>
                     <tbody>

--- a/src/pages/admin/monitor/index.tsx
+++ b/src/pages/admin/monitor/index.tsx
@@ -1,0 +1,368 @@
+'use client';
+
+import React, { useEffect, useMemo } from 'react';
+import Link from 'next/link';
+import { CoreLayout } from '@layout';
+import { Container, Row, Col, Badge, Button as BsButton } from 'react-bootstrap';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import {
+  faCircleCheck,
+  faCircleExclamation,
+  faCircleXmark,
+  faCircleMinus,
+  faClock,
+  faArrowUpRightFromSquare,
+  faBellSlash,
+  faCheck,
+  faEye,
+} from '@fortawesome/free-solid-svg-icons';
+import { toast } from 'react-toastify';
+import styled from 'styled-components';
+import PageTitle from '@components/PageTitle';
+import RoleGuard from 'src/components/RoleGuard';
+import useAppStore from 'src/store';
+import type { CollectorOverview, Severity, RunStatus } from 'src/types/monitor';
+
+const PageWrap = styled.div`
+  padding: 16px 24px;
+`;
+
+const StatusDot = styled.span<{ $color: string }>`
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 8px;
+  background: ${(p) => p.$color};
+  vertical-align: middle;
+`;
+
+const TableWrap = styled.div`
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+
+  table { width: 100%; margin-bottom: 0; border-collapse: collapse; }
+  thead th {
+    background: #302b63;
+    color: #fff;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 10px 12px;
+    text-align: left;
+  }
+  tbody td {
+    font-size: 13px;
+    padding: 10px 12px;
+    border-bottom: 1px solid #eee;
+    vertical-align: middle;
+  }
+  tbody tr:hover { background: rgba(48, 43, 99, 0.05); }
+  a { color: #302b63; text-decoration: none; font-weight: 600; }
+  a:hover { text-decoration: underline; }
+`;
+
+const AlertsPanel = styled.div`
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+
+  h4 { font-size: 14px; font-weight: 700; margin: 0 0 12px 0; text-transform: uppercase; letter-spacing: 0.5px; color: #302b63; }
+`;
+
+const AlertCard = styled.div<{ $severity: Severity }>`
+  border-left: 4px solid ${(p) => SEV_COLORS[p.$severity]};
+  background: ${(p) => SEV_BG[p.$severity]};
+  padding: 10px 12px;
+  margin-bottom: 10px;
+  border-radius: 4px;
+
+  .title { font-weight: 600; font-size: 13px; margin-bottom: 4px; }
+  .body  { font-size: 12px; color: #555; margin-bottom: 8px; word-break: break-word; }
+  .meta  { font-size: 11px; color: #888; margin-bottom: 8px; }
+  .actions { display: flex; gap: 6px; flex-wrap: wrap; }
+  .actions button { font-size: 11px; padding: 4px 8px; }
+`;
+
+const EmptyState = styled.div`
+  text-align: center;
+  color: #999;
+  font-size: 13px;
+  padding: 32px 8px;
+`;
+
+const SEV_COLORS: Record<Severity, string> = {
+  critical: '#dc3545',
+  warning:  '#f0ad4e',
+  info:     '#5bc0de',
+};
+const SEV_BG: Record<Severity, string> = {
+  critical: '#fdf3f4',
+  warning:  '#fdf8ef',
+  info:     '#f2f9fc',
+};
+
+const statusColor = (row: CollectorOverview): string => {
+  if (row.has_critical_alert) return '#dc3545';
+  if (row.has_warning_alert) return '#f0ad4e';
+  if (!row.last_run) return '#b0b0b0';
+  if (row.last_run.status === 'success') return '#28a745';
+  if (row.last_run.status === 'running') return '#5bc0de';
+  return '#dc3545';
+};
+
+const statusBadge = (status: RunStatus) => {
+  const cfg: Record<RunStatus, { bg: string; icon: typeof faCircleCheck }> = {
+    success: { bg: '#28a745', icon: faCircleCheck },
+    running: { bg: '#5bc0de', icon: faClock },
+    failed:  { bg: '#dc3545', icon: faCircleXmark },
+    timeout: { bg: '#6c757d', icon: faCircleExclamation },
+  };
+  const { bg, icon } = cfg[status];
+  return (
+    <Badge style={{ background: bg, fontWeight: 500 }}>
+      <Icon icon={icon} style={{ marginRight: 4 }} /> {status}
+    </Badge>
+  );
+};
+
+const formatRelative = (iso: string | null): string => {
+  if (!iso) return '—';
+  const then = new Date(iso).getTime();
+  const diffMs = Date.now() - then;
+  const mins = Math.round(diffMs / 60000);
+  if (mins < 1) return 'justo ahora';
+  if (mins < 60) return `hace ${mins}m`;
+  const hours = Math.round(mins / 60);
+  if (hours < 48) return `hace ${hours}h`;
+  const days = Math.round(hours / 24);
+  return `hace ${days}d`;
+};
+
+const formatDuration = (seconds: number | null): string => {
+  if (seconds == null) return '—';
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const mins = Math.floor(seconds / 60);
+  const rem = Math.floor(seconds - mins * 60);
+  return `${mins}m ${rem}s`;
+};
+
+const MonitorPage = () => {
+  const {
+    collectorOverview,
+    activeAlerts,
+    loadCollectorOverview,
+    loadActiveAlerts,
+    acknowledgeAlert,
+    silenceAlert,
+    resolveAlert,
+  } = useAppStore((s) => ({
+    collectorOverview: s.collectorOverview,
+    activeAlerts: s.activeAlerts,
+    loadCollectorOverview: s.loadCollectorOverview,
+    loadActiveAlerts: s.loadActiveAlerts,
+    acknowledgeAlert: s.acknowledgeAlert,
+    silenceAlert: s.silenceAlert,
+    resolveAlert: s.resolveAlert,
+  }));
+
+  useEffect(() => {
+    loadCollectorOverview();
+    loadActiveAlerts();
+    const interval = setInterval(() => {
+      loadCollectorOverview();
+      loadActiveAlerts();
+    }, 30000);
+    return () => clearInterval(interval);
+  }, [loadCollectorOverview, loadActiveAlerts]);
+
+  const counts = useMemo(() => {
+    const total = collectorOverview.length;
+    const critical = collectorOverview.filter((c) => c.has_critical_alert).length;
+    const warning  = collectorOverview.filter((c) => c.has_warning_alert && !c.has_critical_alert).length;
+    const ok       = collectorOverview.filter((c) => !c.has_critical_alert && !c.has_warning_alert && c.last_run?.status === 'success').length;
+    return { total, critical, warning, ok };
+  }, [collectorOverview]);
+
+  const handleAction = async (
+    action: () => Promise<{ success: boolean; error: string | undefined }>,
+    successMsg: string,
+  ) => {
+    const res = await action();
+    if (res.success) toast.success(successMsg);
+    else toast.error(res.error ?? 'Error');
+  };
+
+  return (
+    <CoreLayout>
+      <RoleGuard
+        requiredRole="super_admin"
+        fallback={
+          <PageWrap>
+            <PageTitle>Monitor</PageTitle>
+            <p>Requiere permisos de super admin.</p>
+          </PageWrap>
+        }
+      >
+        <PageWrap>
+          <PageTitle>Monitor de Collectors</PageTitle>
+          <div style={{ fontSize: 13, color: '#666', marginBottom: 16 }}>
+            {counts.ok}/{counts.total} OK · {counts.warning} en warning · {counts.critical} en critical
+          </div>
+          <Container fluid>
+            <Row>
+              <Col md={8}>
+                <TableWrap>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th style={{ width: 24 }} />
+                        <th>Collector</th>
+                        <th>Severity</th>
+                        <th>Último run</th>
+                        <th>Duración</th>
+                        <th>Alertas</th>
+                        <th>Tablas</th>
+                        <th />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {collectorOverview.map((row) => (
+                        <tr key={row.name}>
+                          <td><StatusDot $color={statusColor(row)} /></td>
+                          <td>
+                            <Link href={`/admin/monitor/${encodeURIComponent(row.name)}`}>
+                              {row.name}
+                            </Link>
+                          </td>
+                          <td>
+                            <Badge
+                              style={{
+                                background: SEV_COLORS[row.severity_default],
+                                fontWeight: 500,
+                              }}
+                            >
+                              {row.severity_default}
+                            </Badge>
+                          </td>
+                          <td>
+                            {row.last_run ? (
+                              <>
+                                {statusBadge(row.last_run.status)}
+                                <span style={{ marginLeft: 8, color: '#888' }}>
+                                  {formatRelative(row.last_run.started_at)}
+                                </span>
+                              </>
+                            ) : (
+                              <span style={{ color: '#999' }}>
+                                <Icon icon={faCircleMinus} style={{ marginRight: 4 }} />
+                                nunca
+                              </span>
+                            )}
+                          </td>
+                          <td>{formatDuration(row.last_run?.duration_s ?? null)}</td>
+                          <td>
+                            {row.open_alerts > 0 ? (
+                              <Badge bg="danger">{row.open_alerts}</Badge>
+                            ) : (
+                              <span style={{ color: '#bbb' }}>0</span>
+                            )}
+                          </td>
+                          <td style={{ fontSize: 11, color: '#666' }}>
+                            {row.target_tables.length > 0
+                              ? row.target_tables.join(', ')
+                              : <em style={{ color: '#bbb' }}>—</em>}
+                          </td>
+                          <td>
+                            {row.last_run?.gh_run_url && (
+                              <a
+                                href={row.last_run.gh_run_url}
+                                target="_blank"
+                                rel="noreferrer"
+                                style={{ fontSize: 12 }}
+                              >
+                                GH <Icon icon={faArrowUpRightFromSquare} />
+                              </a>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                      {collectorOverview.length === 0 && (
+                        <tr>
+                          <td colSpan={8}>
+                            <EmptyState>Sin collectors en el catálogo.</EmptyState>
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </TableWrap>
+              </Col>
+              <Col md={4}>
+                <AlertsPanel>
+                  <h4>Alertas activas ({activeAlerts.length})</h4>
+                  {activeAlerts.length === 0 && (
+                    <EmptyState>
+                      <Icon icon={faCircleCheck} style={{ color: '#28a745', fontSize: 24, marginBottom: 8 }} /><br />
+                      Todo tranquilo.
+                    </EmptyState>
+                  )}
+                  {activeAlerts.map((alert) => (
+                    <AlertCard key={alert.id} $severity={alert.severity}>
+                      <div className="title">{alert.title}</div>
+                      {alert.body && <div className="body">{alert.body}</div>}
+                      <div className="meta">
+                        {alert.collector_name && <>collector: {alert.collector_name}<br /></>}
+                        {alert.table_name && <>tabla: {alert.table_name}<br /></>}
+                        {alert.occurrence_count > 1 && <>×{alert.occurrence_count} · </>}
+                        primera vez {formatRelative(alert.first_seen_at)}
+                      </div>
+                      <div className="actions">
+                        {!alert.acknowledged_at && (
+                          <BsButton
+                            size="sm"
+                            variant="outline-secondary"
+                            onClick={() => handleAction(() => acknowledgeAlert(alert.id), 'ACK')}
+                          >
+                            <Icon icon={faEye} /> ACK
+                          </BsButton>
+                        )}
+                        <BsButton
+                          size="sm"
+                          variant="outline-secondary"
+                          onClick={() => handleAction(() => silenceAlert(alert.id, '1 hour'), 'Silenciada 1h')}
+                        >
+                          <Icon icon={faBellSlash} /> 1h
+                        </BsButton>
+                        <BsButton
+                          size="sm"
+                          variant="outline-secondary"
+                          onClick={() => handleAction(() => silenceAlert(alert.id, '1 day'), 'Silenciada 24h')}
+                        >
+                          <Icon icon={faBellSlash} /> 24h
+                        </BsButton>
+                        <BsButton
+                          size="sm"
+                          variant="outline-success"
+                          onClick={() => handleAction(() => resolveAlert(alert.id), 'Resuelta')}
+                        >
+                          <Icon icon={faCheck} /> Resolver
+                        </BsButton>
+                      </div>
+                    </AlertCard>
+                  ))}
+                </AlertsPanel>
+              </Col>
+            </Row>
+          </Container>
+        </PageWrap>
+      </RoleGuard>
+    </CoreLayout>
+  );
+};
+
+export default MonitorPage;

--- a/src/pages/admin/monitor/index.tsx
+++ b/src/pages/admin/monitor/index.tsx
@@ -74,6 +74,17 @@ const AlertsPanel = styled.div`
   h4 { font-size: 14px; font-weight: 700; margin: 0 0 12px 0; text-transform: uppercase; letter-spacing: 0.5px; color: #302b63; }
 `;
 
+const SEV_COLORS: Record<Severity, string> = {
+  critical: '#dc3545',
+  warning:  '#f0ad4e',
+  info:     '#5bc0de',
+};
+const SEV_BG: Record<Severity, string> = {
+  critical: '#fdf3f4',
+  warning:  '#fdf8ef',
+  info:     '#f2f9fc',
+};
+
 const AlertCard = styled.div<{ $severity: Severity }>`
   border-left: 4px solid ${(p) => SEV_COLORS[p.$severity]};
   background: ${(p) => SEV_BG[p.$severity]};
@@ -94,17 +105,6 @@ const EmptyState = styled.div`
   font-size: 13px;
   padding: 32px 8px;
 `;
-
-const SEV_COLORS: Record<Severity, string> = {
-  critical: '#dc3545',
-  warning:  '#f0ad4e',
-  info:     '#5bc0de',
-};
-const SEV_BG: Record<Severity, string> = {
-  critical: '#fdf3f4',
-  warning:  '#fdf8ef',
-  info:     '#f2f9fc',
-};
 
 const statusColor = (row: CollectorOverview): string => {
   if (row.has_critical_alert) return '#dc3545';
@@ -220,14 +220,14 @@ const MonitorPage = () => {
                   <table>
                     <thead>
                       <tr>
-                        <th style={{ width: 24 }} />
+                        <th style={{ width: 24 }} aria-label="status indicator" />
                         <th>Collector</th>
                         <th>Severity</th>
                         <th>Último run</th>
                         <th>Duración</th>
                         <th>Alertas</th>
                         <th>Tablas</th>
-                        <th />
+                        <th aria-label="external links" />
                       </tr>
                     </thead>
                     <tbody>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,9 +11,10 @@ import createCurveSlice, { CurveSlice } from './curve';
 import createUserSlice, { UserSlice } from './user';
 import createChatSlice, { ChatSlice } from './chat';
 import createAgentConfigSlice, { AgentConfigSlice } from './agentConfig';
+import createMonitorSlice, { MonitorSlice } from './monitor';
 
 const useAppStore = create<
-  LoansSlice & DashboardSlice & SeriesSlice & MarketDashboardSlice & TradingSlice & CurveSlice & UserSlice & ChatSlice & AgentConfigSlice
+  LoansSlice & DashboardSlice & SeriesSlice & MarketDashboardSlice & TradingSlice & CurveSlice & UserSlice & ChatSlice & AgentConfigSlice & MonitorSlice
 >()(
   devtools((...args) => ({
     ...createLoansSlice(...args),
@@ -25,6 +26,7 @@ const useAppStore = create<
     ...createUserSlice(...args),
     ...createChatSlice(...args),
     ...createAgentConfigSlice(...args),
+    ...createMonitorSlice(...args),
   }))
 );
 

--- a/src/store/monitor/index.ts
+++ b/src/store/monitor/index.ts
@@ -1,0 +1,100 @@
+import { StateCreator } from 'zustand';
+import {
+  CollectorOverview,
+  CollectorRun,
+  CollectorAlert,
+} from 'src/types/monitor';
+import {
+  listCollectorOverview,
+  listActiveAlerts,
+  listCollectorRuns,
+  acknowledgeAlert as ackRpc,
+  silenceAlert as silenceRpc,
+  resolveAlert as resolveRpc,
+  ActionResponse,
+} from 'src/models/monitor';
+
+export interface MonitorSlice {
+  collectorOverview: CollectorOverview[];
+  activeAlerts: CollectorAlert[];
+  collectorRuns: Record<string, CollectorRun[]>;
+  monitorLoading: boolean;
+  monitorError: string | undefined;
+
+  loadCollectorOverview: () => Promise<void>;
+  loadActiveAlerts: () => Promise<void>;
+  loadCollectorRuns: (collectorName: string, limit?: number) => Promise<void>;
+  acknowledgeAlert: (alertId: string) => Promise<ActionResponse>;
+  silenceAlert: (alertId: string, duration: string) => Promise<ActionResponse>;
+  resolveAlert: (alertId: string) => Promise<ActionResponse>;
+  resetMonitorStore: () => void;
+}
+
+const initialState = {
+  collectorOverview: [] as CollectorOverview[],
+  activeAlerts: [] as CollectorAlert[],
+  collectorRuns: {} as Record<string, CollectorRun[]>,
+  monitorLoading: false,
+  monitorError: undefined as string | undefined,
+};
+
+const createMonitorSlice: StateCreator<MonitorSlice> = (set, get) => ({
+  ...initialState,
+
+  loadCollectorOverview: async () => {
+    set({ monitorLoading: true, monitorError: undefined });
+    const res = await listCollectorOverview();
+    if (res.error) {
+      set({ monitorLoading: false, monitorError: res.error });
+      return;
+    }
+    set({ collectorOverview: res.data, monitorLoading: false });
+  },
+
+  loadActiveAlerts: async () => {
+    set({ monitorLoading: true, monitorError: undefined });
+    const res = await listActiveAlerts();
+    if (res.error) {
+      set({ monitorLoading: false, monitorError: res.error });
+      return;
+    }
+    set({ activeAlerts: res.data, monitorLoading: false });
+  },
+
+  loadCollectorRuns: async (collectorName: string, limit = 30) => {
+    set({ monitorLoading: true, monitorError: undefined });
+    const res = await listCollectorRuns(collectorName, limit);
+    if (res.error) {
+      set({ monitorLoading: false, monitorError: res.error });
+      return;
+    }
+    set((state) => ({
+      collectorRuns: { ...state.collectorRuns, [collectorName]: res.data },
+      monitorLoading: false,
+    }));
+  },
+
+  acknowledgeAlert: async (alertId: string) => {
+    const res = await ackRpc(alertId);
+    if (res.success) await get().loadActiveAlerts();
+    return res;
+  },
+
+  silenceAlert: async (alertId: string, duration: string) => {
+    const res = await silenceRpc(alertId, duration);
+    if (res.success) await get().loadActiveAlerts();
+    return res;
+  },
+
+  resolveAlert: async (alertId: string) => {
+    const res = await resolveRpc(alertId);
+    if (res.success) {
+      await Promise.all([get().loadActiveAlerts(), get().loadCollectorOverview()]);
+    }
+    return res;
+  },
+
+  resetMonitorStore: () => set(initialState),
+});
+
+export default createMonitorSlice;

--- a/src/types/monitor.ts
+++ b/src/types/monitor.ts
@@ -1,0 +1,61 @@
+export type Severity = 'critical' | 'warning' | 'info';
+export type RunStatus = 'running' | 'success' | 'failed' | 'timeout';
+export type AlertSource = 'run_failed' | 'table_stale' | 'missed_run';
+
+export interface LastRun {
+  id: string;
+  status: RunStatus;
+  started_at: string;
+  finished_at: string | null;
+  duration_s: number | null;
+  rows_inserted: number | null;
+  error_message: string | null;
+  gh_run_url: string | null;
+}
+
+export interface CollectorOverview {
+  name: string;
+  description: string | null;
+  enabled: boolean;
+  severity_default: Severity;
+  target_tables: string[];
+  schedule_cron: string | null;
+  last_run: LastRun | null;
+  open_alerts: number;
+  has_critical_alert: boolean;
+  has_warning_alert: boolean;
+}
+
+export interface CollectorRun {
+  id: string;
+  collector_name: string;
+  started_at: string;
+  finished_at: string | null;
+  duration_seconds: number | null;
+  status: RunStatus;
+  exit_code: number | null;
+  rows_inserted: number | null;
+  error_message: string | null;
+  error_traceback: string | null;
+  gh_run_url: string | null;
+  gh_workflow: string | null;
+  gh_run_id: string | null;
+}
+
+export interface CollectorAlert {
+  id: string;
+  source: AlertSource;
+  collector_name: string | null;
+  table_name: string | null;
+  severity: Severity;
+  fingerprint: string;
+  title: string;
+  body: string | null;
+  first_seen_at: string;
+  last_seen_at: string;
+  occurrence_count: number;
+  acknowledged_at: string | null;
+  acknowledged_by: string | null;
+  silenced_until: string | null;
+  resolved_at: string | null;
+}


### PR DESCRIPTION
## Summary
- `/admin/monitor` overview: semaforo por collector, auto-refresh 30s, panel de alertas activas con ACK / silenciar / resolver.
- `/admin/monitor/[name]`: catalogo + timeline de ultimos 30 runs con traceback expandible para fallos.
- Sidebar: nueva entrada "Monitor" (super_admin only).

## Test plan
- [ ] Build (`npm run build`) pasa en Vercel.
- [ ] Login como super_admin → sidebar muestra "Monitor"; pagina lista 27 collectors.
- [ ] Login como lector / gestor / corp_admin → no aparece en sidebar; `/admin/monitor` muestra "Requiere permisos".
- [ ] Fozar un run failed (via SQL o trigger en GH Actions): la fila se pone roja, el panel muestra alerta nueva.
- [ ] Boton ACK → alerta marcada como acknowledged, toast confirma.
- [ ] Boton Resolver → alerta desaparece del panel.
- [ ] Boton Silenciar 1h → alerta se oculta por 1 hora.
- [ ] Click en nombre del collector → navega al detalle; timeline muestra runs.

## Depends on
- [xerenity-db#67](https://github.com/avelezX/xerenity-db/issues/67), [#69](https://github.com/avelezX/xerenity-db/issues/69) — schema + triggers (ya aplicados).

closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)