### PR TITLE
feat(concurrency): #293 token monotonico + AbortController en reprices

### DIFF
--- a/src/store/trading/index.ts
+++ b/src/store/trading/index.ts
@@ -38,7 +38,7 @@ import {
   saveMarketDataConfig,
 } from 'src/models/trading';
 import { priceTesBond } from 'src/models/pricing/pricingApi';
-import { telemetry } from 'src/lib/telemetry';
+import { telemetry, isAbortError } from 'src/lib/telemetry';
 
 const genId = () => crypto.randomUUID();
 
@@ -161,6 +161,62 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
     }
   };
 
+  // #293 — Monotonic tokens guard writes to pricedXccy/pricedNdf/pricedIbrSwap
+  // and to refPrices. When repriceAll/repriceAllWithMark/repriceTes or
+  // loadReferencePrices is called while a previous one is still in flight, we:
+  //   1. Abort the previous request (needs #292's AbortSignal plumbing).
+  //   2. Bump the token, capture a local copy.
+  //   3. Before every set({priced...}), verify get().repriceToken === myToken.
+  //      Stale responses get dropped — no more "last to land wins".
+  let repriceToken = 0;
+  let refPricesToken = 0;
+  let repriceAbort: AbortController | null = null;
+  let refPricesAbort: AbortController | null = null;
+
+  const startReprice = (origin: string): { myToken: number; signal: AbortSignal } => {
+    if (repriceAbort) {
+      telemetry.debug('store', 'aborting prior reprice', { origin, prior: repriceToken });
+      repriceAbort.abort();
+    }
+    repriceToken += 1;
+    repriceAbort = new AbortController();
+    return { myToken: repriceToken, signal: repriceAbort.signal };
+  };
+
+  const isStaleReprice = (myToken: number, origin: string): boolean => {
+    if (myToken !== repriceToken) {
+      telemetry.debug('store', 'dropping stale reprice result', {
+        origin,
+        myToken,
+        current: repriceToken,
+      });
+      return true;
+    }
+    return false;
+  };
+
+  const startRefPrices = (origin: string): { myToken: number; signal: AbortSignal } => {
+    if (refPricesAbort) {
+      telemetry.debug('store', 'aborting prior refPrices', { origin, prior: refPricesToken });
+      refPricesAbort.abort();
+    }
+    refPricesToken += 1;
+    refPricesAbort = new AbortController();
+    return { myToken: refPricesToken, signal: refPricesAbort.signal };
+  };
+
+  const isStaleRefPrices = (myToken: number, origin: string): boolean => {
+    if (myToken !== refPricesToken) {
+      telemetry.debug('store', 'dropping stale refPrices result', {
+        origin,
+        myToken,
+        current: refPricesToken,
+      });
+      return true;
+    }
+    return false;
+  };
+
   return {
   ...initialTradingState,
 
@@ -207,11 +263,13 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
       xccyPositions.length + ndfPositions.length + ibrSwapPositions.length;
     if (total === 0) return;
 
+    const { myToken, signal } = startReprice('repriceAll');
     set({ tradingLoading: true, tradingError: undefined });
     try {
       const result = await withInFlight('repriceAll', () =>
-        repricePortfolio(xccyPositions, ndfPositions, ibrSwapPositions),
+        repricePortfolio(xccyPositions, ndfPositions, ibrSwapPositions, { signal }),
       );
+      if (isStaleReprice(myToken, 'repriceAll')) return;
       set({
         pricedXccy: result.xccy_results,
         pricedNdf: result.ndf_results,
@@ -225,6 +283,8 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
         }),
       });
     } catch (e) {
+      if (isAbortError(e)) return;
+      if (isStaleReprice(myToken, 'repriceAll')) return;
       set({
         tradingLoading: false,
         tradingError: e instanceof Error ? e.message : 'Reprice failed',
@@ -234,6 +294,7 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
 
   repriceAllWithMark: async (fecha: string) => {
     const { xccyPositions, ndfPositions, ibrSwapPositions, tesPositions } = get();
+    const { myToken, signal } = startReprice(`repriceAllWithMark(${fecha})`);
     set({ tradingLoading: true, tesLoading: true, tradingError: undefined });
     await withInFlight(`repriceAllWithMark(${fecha})`, async () => {
     try {
@@ -246,21 +307,28 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
       const [portfolioResult, tesResults] = await Promise.allSettled([
         repricePortfolio(filteredXccy, filteredNdf, filteredIbr, {
           valuation_date: fecha,
+          signal,
         }),
         Promise.allSettled(
           tesPositions.map((pos) =>
-            priceTesBond({
-              bond_name: pos.bond_name,
-              issue_date: pos.issue_date,
-              maturity_date: pos.maturity_date,
-              coupon_rate: pos.coupon_rate * 100,
-              face_value: pos.face_value,
-              include_cashflows: true,
-              valuation_date: fecha,
-            }).then((r) => ({ pos, result: r }))
+            priceTesBond(
+              {
+                bond_name: pos.bond_name,
+                issue_date: pos.issue_date,
+                maturity_date: pos.maturity_date,
+                coupon_rate: pos.coupon_rate * 100,
+                face_value: pos.face_value,
+                include_cashflows: true,
+                valuation_date: fecha,
+              },
+              { signal },
+            ).then((r) => ({ pos, result: r }))
           )
         ),
       ]);
+
+      // If a newer reprice replaced us while we were awaiting, drop everything.
+      if (isStaleReprice(myToken, `repriceAllWithMark(${fecha})`)) return;
 
       if (portfolioResult.status === 'fulfilled') {
         const result = portfolioResult.value;
@@ -271,7 +339,7 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
           summary: result.summary,
           pricedAt: fecha,
         });
-      } else {
+      } else if (!isAbortError(portfolioResult.reason)) {
         set({ tradingError: portfolioResult.reason instanceof Error ? portfolioResult.reason.message : 'Reprice failed' });
       }
 
@@ -313,9 +381,15 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
         set({ pricedTesBonds: priced });
       }
     } catch (e) {
+      if (isAbortError(e)) return;
+      if (isStaleReprice(myToken, `repriceAllWithMark(${fecha})`)) return;
       set({ tradingError: e instanceof Error ? e.message : 'Reprice failed' });
     } finally {
-      set({ tradingLoading: false, tesLoading: false });
+      // Only turn loading off if we're still the active reprice; otherwise
+      // the newer one owns the loading state.
+      if (!isStaleReprice(myToken, `repriceAllWithMark(${fecha})`)) {
+        set({ tradingLoading: false, tesLoading: false });
+      }
     }
     });
   },
@@ -433,6 +507,7 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
     // Caché: no recargar si la fecha de marca no cambió
     if (refPricesForDate === fechaMarca) return;
 
+    const { myToken, signal } = startRefPrices(`loadReferencePrices(${fechaMarca})`);
     set({ refPricesLoading: true });
     await withInFlight(`loadReferencePrices(${fechaMarca})`, async () => {
     try {
@@ -453,7 +528,7 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
               filterXccy(refDates.daily),
               filterNdf(refDates.daily),
               filterIbr(refDates.daily),
-              { valuation_date: refDates.daily }
+              { valuation_date: refDates.daily, signal }
             )
           : Promise.resolve(null),
         refDates.mtd
@@ -461,7 +536,7 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
               filterXccy(refDates.mtd),
               filterNdf(refDates.mtd),
               filterIbr(refDates.mtd),
-              { valuation_date: refDates.mtd }
+              { valuation_date: refDates.mtd, signal }
             )
           : Promise.resolve(null),
         refDates.ytd
@@ -469,10 +544,12 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
               filterXccy(refDates.ytd),
               filterNdf(refDates.ytd),
               filterIbr(refDates.ytd),
-              { valuation_date: refDates.ytd }
+              { valuation_date: refDates.ytd, signal }
             )
           : Promise.resolve(null),
       ]);
+
+      if (isStaleRefPrices(myToken, `loadReferencePrices(${fechaMarca})`)) return;
 
       set({
         refPrices: {
@@ -483,7 +560,9 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
         refPricesForDate: fechaMarca,
         refPricesLoading: false,
       });
-    } catch {
+    } catch (e) {
+      if (isAbortError(e)) return;
+      if (isStaleRefPrices(myToken, `loadReferencePrices(${fechaMarca})`)) return;
       set({ refPricesLoading: false });
     }
     });
@@ -509,22 +588,31 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
     const { tesPositions } = get();
     if (tesPositions.length === 0) return;
 
+    // repriceTes shares the pricedXccy/pricedNdf/pricedIbrSwap token because
+    // repriceAllWithMark also writes pricedTesBonds — they compete for the
+    // same downstream slot.
+    const { myToken, signal } = startReprice('repriceTes');
     set({ tesLoading: true, tesError: undefined });
 
     const results = await withInFlight('repriceTes', () =>
       Promise.allSettled(
         tesPositions.map((pos) =>
-          priceTesBond({
-            bond_name: pos.bond_name,
-            issue_date: pos.issue_date,
-            maturity_date: pos.maturity_date,
-            coupon_rate: pos.coupon_rate * 100, // pysdk expects pct
-            face_value: pos.face_value,
-            include_cashflows: true,
-          }).then((r) => ({ pos, result: r }))
+          priceTesBond(
+            {
+              bond_name: pos.bond_name,
+              issue_date: pos.issue_date,
+              maturity_date: pos.maturity_date,
+              coupon_rate: pos.coupon_rate * 100, // pysdk expects pct
+              face_value: pos.face_value,
+              include_cashflows: true,
+            },
+            { signal },
+          ).then((r) => ({ pos, result: r }))
         )
       )
     );
+
+    if (isStaleReprice(myToken, 'repriceTes')) return;
 
     const priced: PricedTesBond[] = results.map((outcome, i) => {
       const pos = tesPositions[i];
@@ -552,6 +640,9 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
           cashflows: r.cashflows,
         };
       }
+      // If individual result was aborted, treat as generic error — the
+      // isStaleReprice guard above already short-circuits the common case
+      // where the whole reprice was superseded.
       return {
         ...pos,
         clean_price: 0, dirty_price: 0, accrued_interest: 0,


### PR DESCRIPTION
## Summary

- Sub-issue #293 — segunda pieza de Fase 1 (#298). Construye sobre #292 (merged).
- **Mata el flicker NPV 1000 ↔ -400.** Cada acción de reprice ahora aborta la anterior, captura un token monotónico, y descarta resultados obsoletos antes de escribir al store.
- Sin cambios en callsites. Los 5 lugares duplicados que llaman `repriceAllWithMark` se consolidan en #295 (siguiente).

## Cómo funciona

Dos pares de token + AbortController, closure-local al slice:

- `repriceToken` / `repriceAbort` — para `repriceAll`, `repriceAllWithMark`, `repriceTes` (todos escriben a `pricedXccy/pricedNdf/pricedIbrSwap/pricedTesBonds`)
- `refPricesToken` / `refPricesAbort` — para `loadReferencePrices` (escribe a `refPrices`)

Helpers `startReprice(origin)` y `isStaleReprice(myToken, origin)` encapsulan el patrón:

```ts
const { myToken, signal } = startReprice('repriceAll');
const result = await repricePortfolio(..., { signal });
if (isStaleReprice(myToken, 'repriceAll')) return;  // dropped
set({ pricedXccy: result.xccy_results, ... });
```

Cuando `startReprice` es llamado de nuevo, llama `abort()` en el controller previo, lo que hace que los `fetch` en vuelo rechacen con `AbortError`. El código distingue `AbortError` (silencio) de errores reales (setea `tradingError`).

## Archivos tocados

- [src/store/trading/index.ts](src/store/trading/index.ts) — las 4 acciones de reprice + helpers nuevos.

## Cómo validar (después de merge)

En DevTools Console, con la telemetría de Fase 0:

1. En `/portfolio`, cambiar `markFecha` 5 veces seguidas en <1s.
2. Ver logs `[store] aborting prior reprice {prior: 1}`, `[store] aborting prior reprice {prior: 2}`, ..., y el último reprice completando normalmente.
3. Los reprices 1-4 emiten `[reprice] portfolio/reprice fail {name: 'AbortError'}` y NO aparecen en el NPV mostrado.
4. Solo el reprice #5 llega al `set({pricedXccy:...})`. No hay flicker.

Si por alguna razón un reprice "antiguo" se escabulle (por ej. completó ANTES del abort porque ya había respondido), el token guard lo atrapa:
`[store] dropping stale reprice result {myToken: 3, current: 5}`.

## Test plan

- [x] `npx tsc --noEmit` limpio
- [x] `npm run lint` sin errores nuevos
- [ ] Manual: cambio rápido de fecha → NPV no salta
- [ ] Manual: consola muestra "aborting prior reprice" en cada cambio
- [ ] Manual: agregar posición mientras reprice en vuelo → reprice previo aborta, nuevo completa

## Siguiente

- #294 — `Promise.all` → `allSettled` en batches de loans + progreso parcial
- #295 — Consolidar los 5 callsites de `repriceAllWithMark` en un solo handler

Closes #293
Refs #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)
