### PR TITLE
fix(portfolio): #296 distinguir sin precio de precio cero

### DIFF
--- a/src/components/portfolio/BlotterTable.tsx
+++ b/src/components/portfolio/BlotterTable.tsx
@@ -216,8 +216,11 @@ const buildColumns = (
     size: 90,
     cell: (info) => {
       const r = info.row.original;
+      // #296: show em-dash with a tooltip instead of a fake "0" or a loud
+      // red "Err" — keeps the table legible while making "sin precio"
+      // visually distinct from "precio cero".
       return r.error
-        ? <span style={{ color: '#dc3545', fontSize: 11 }}>Err</span>
+        ? <span title={r.error} style={{ color: '#adb5bd', fontSize: 11, fontFamily: 'monospace' }}>—</span>
         : <span style={{ fontFamily: 'monospace', fontSize: 11, color: npvColor(info.getValue()) }}>{fmtMM(info.getValue())}</span>;
     },
   }),
@@ -228,7 +231,7 @@ const buildColumns = (
     cell: (info) => {
       const r = info.row.original;
       return r.error
-        ? <span style={{ color: '#dc3545', fontSize: 11 }}>Err</span>
+        ? <span title={r.error} style={{ color: '#adb5bd', fontSize: 11, fontFamily: 'monospace' }}>—</span>
         : <span style={{ fontFamily: 'monospace', fontSize: 11, color: npvColor(info.getValue()) }}>{fmtMM(info.getValue())}</span>;
     },
   }),

--- a/src/models/trading/repricePortfolio.ts
+++ b/src/models/trading/repricePortfolio.ts
@@ -137,6 +137,21 @@ async function repriceImpl(
   const bind = (r: Record<string, unknown>, posId: string) =>
     (field: string, fallback = 0): number => n(r[field], field, posId, fallback);
 
+  // #296 — When the backend returns a null/undefined NPV (curve missing, partial
+  // pricing, etc.), we must NOT show "0" in the UI. BlotterTable already renders
+  // "Err" when `error` is set, so promote null-NPV to an error status here so
+  // the user sees "Err" instead of a fake zero. Preserves any existing backend
+  // error message so real failure reasons still surface.
+  const promoteNullNpvToError = (
+    r: Record<string, unknown>,
+    criticalFields: string[],
+  ): string | undefined => {
+    if (r.error) return r.error as string;
+    const missing = criticalFields.filter((f) => r[f] === null || r[f] === undefined);
+    if (missing.length === 0) return undefined;
+    return `NPV incompleto (${missing.join(', ')})`;
+  };
+
   const xccyResults: PricedXccy[] = (raw.xccy_results ?? []).map((r) => {
     const pos = xccyById[r.id as string];
     const g = bind(r, (r.id as string) ?? 'unknown');
@@ -157,7 +172,7 @@ async function repriceImpl(
       par_basis_bps: r.par_basis_bps != null ? g('par_basis_bps') : null,
       notional_cop: g('notional_cop'), fx_spot: g('fx_spot'), n_periods: g('n_periods'),
       cashflows: (r.cashflows as PricedXccy['cashflows']) ?? [],
-      error: r.error as string | undefined,
+      error: promoteNullNpvToError(r, ['npv_cop', 'npv_usd']),
     };
   });
 
@@ -177,7 +192,7 @@ async function repriceImpl(
       spot: g('spot'),
       days_open: g('days_open'),
       accrued_cop: g('accrued_cop'),
-      error: r.error as string | undefined,
+      error: promoteNullNpvToError(r, ['npv_cop', 'npv_usd']),
     };
   });
 
@@ -196,7 +211,7 @@ async function repriceImpl(
       ibr_fwd_period_pct: g('ibr_fwd_period_pct'),
       carry_period_cop: g('carry_period_cop'),
       carry_period_diff_bps: g('carry_period_diff_bps'),
-      error: r.error as string | undefined,
+      error: promoteNullNpvToError(r, ['npv']),
     };
   });
 

--- a/src/pages/portfolio/index.tsx
+++ b/src/pages/portfolio/index.tsx
@@ -2099,13 +2099,13 @@ function PortfolioPage() {
   // Build unified portfolio rows
   const xccyRows: PricedXccy[] = pricedXccy.length > 0
     ? pricedXccy
-    : xccyPositions.map((p) => ({ ...p, npv_cop: 0, npv_usd: 0, pnl_rate_cop: 0, pnl_rate_usd: 0, pnl_fx_cop: 0, pnl_fx_usd: 0, usd_leg_pv: 0, cop_leg_pv: 0, usd_principal_pv: 0, cop_principal_pv: 0, carry_cop: 0, carry_usd: 0, carry_rate_cop_pct: 0, carry_rate_usd_pct: 0, carry_differential_bps: 0, dv01_ibr: 0, dv01_sofr: 0, dv01_total: 0, fx_delta: 0, fx_exposure_usd: 0, par_basis_bps: null, notional_cop: p.notional_usd * p.fx_initial, fx_spot: 0, n_periods: 0, cashflows: [], error: 'Sin pricear' } as PricedXccy));
+    : xccyPositions.map((p) => ({ ...p, npv_cop: 0, npv_usd: 0, pnl_rate_cop: 0, pnl_rate_usd: 0, pnl_fx_cop: 0, pnl_fx_usd: 0, usd_leg_pv: 0, cop_leg_pv: 0, usd_principal_pv: 0, cop_principal_pv: 0, carry_cop: 0, carry_usd: 0, carry_rate_cop_pct: 0, carry_rate_usd_pct: 0, carry_differential_bps: 0, dv01_ibr: 0, dv01_sofr: 0, dv01_total: 0, fx_delta: 0, fx_exposure_usd: 0, par_basis_bps: null, notional_cop: p.notional_usd * p.fx_initial, fx_spot: 0, n_periods: 0, cashflows: [], error: 'Pendiente de valoración' } as PricedXccy));
   const ndfRows: PricedNdf[] = pricedNdf.length > 0
     ? pricedNdf
-    : ndfPositions.map((p) => ({ ...p, npv_usd: 0, npv_cop: 0, forward: 0, forward_points: 0, carry_cop_daily: 0, carry_usd_daily: 0, days_to_maturity: 0, df_usd: 0, df_cop: 0, delta_cop: 0, dv01_cop: 0, dv01_usd: 0, dv01_total: 0, fx_delta: 0, fx_exposure_usd: 0, spot: 0, error: 'Sin pricear' } as PricedNdf));
+    : ndfPositions.map((p) => ({ ...p, npv_usd: 0, npv_cop: 0, forward: 0, forward_points: 0, carry_cop_daily: 0, carry_usd_daily: 0, days_to_maturity: 0, df_usd: 0, df_cop: 0, delta_cop: 0, dv01_cop: 0, dv01_usd: 0, dv01_total: 0, fx_delta: 0, fx_exposure_usd: 0, spot: 0, error: 'Pendiente de valoración' } as PricedNdf));
   const ibrRows: PricedIbrSwap[] = pricedIbrSwap.length > 0
     ? pricedIbrSwap
-    : ibrSwapPositions.map((p) => ({ ...p, npv: 0, fair_rate: 0, dv01: 0, fixed_leg_npv: 0, floating_leg_npv: 0, ibr_overnight_pct: 0, carry_daily_cop: 0, carry_daily_diff_bps: 0, ibr_fwd_period_pct: 0, carry_period_cop: 0, carry_period_diff_bps: 0, error: 'Sin pricear' } as PricedIbrSwap));
+    : ibrSwapPositions.map((p) => ({ ...p, npv: 0, fair_rate: 0, dv01: 0, fixed_leg_npv: 0, floating_leg_npv: 0, ibr_overnight_pct: 0, carry_daily_cop: 0, carry_daily_diff_bps: 0, ibr_fwd_period_pct: 0, carry_period_cop: 0, carry_period_diff_bps: 0, error: 'Pendiente de valoración' } as PricedIbrSwap));
 
   const portfolioRows = buildPortfolioRows(xccyRows, ndfRows, ibrRows, settlementMap, refPrices, markFecha);
 


### PR DESCRIPTION
## Summary

- Sub-issue #296 — **último** sub-issue de Fase 1 (#298). Con esto la fase queda completa.
- Con #293 el flicker NPV ya está muerto. Este PR cierra el hueco residual: cuando pysdk devuelve `null` en un campo de NPV (curva faltante, pricing parcial, etc), el frontend ya no silencia el problema mostrando "0".
- Scope mínimo deliberado: no migro `PricedXccy/PricedNdf/PricedIbrSwap` a `number | null`. Esa migración de tipos es invasiva y queda para Fase 2 (React Query + type cleanup).

## Cambios

### [src/models/trading/repricePortfolio.ts](src/models/trading/repricePortfolio.ts)

Nuevo helper `promoteNullNpvToError(r, criticalFields)`. Si el backend devuelve null/undefined en algún campo crítico, el `result` gana un `error: "NPV incompleto (<fields>)"` — preservando cualquier error que ya venga del backend. Aplicado a xccy/ndf/ibr_swap results.

```ts
// Antes:
error: r.error as string | undefined,  // solo error del backend
// npv_cop silenciosamente se convierte a 0 si r.npv_cop === null

// Después:
error: promoteNullNpvToError(r, ['npv_cop', 'npv_usd']),
// si npv_cop/npv_usd es null, error="NPV incompleto (npv_cop)"
// el resto del flujo (BlotterTable, filter de totales) ya maneja error
```

### [src/components/portfolio/BlotterTable.tsx](src/components/portfolio/BlotterTable.tsx)

Celdas `npv_cop` y `npv_usd`: cuando `row.error` existe, renderizan **`—` gris con tooltip** en vez del anterior "Err" rojo. Más legible y visualmente distinto de un 0 real.

### [src/pages/portfolio/index.tsx](src/pages/portfolio/index.tsx)

Sentinel rows durante loading inicial renombran `'Sin pricear'` → `'Pendiente de valoración'`. El tooltip del "—" ahora dice explícitamente por qué no hay NPV.

## Criterios de aceptación (issue #296)

- [x] Una posición cuyo backend devolvió `npv_cop: null` (sin setear `error`) ahora muestra `—` con tooltip, NO `0`.
- [x] Aggregates correctos: `portfolioRows.filter(r => !r.error)` sigue excluyendo rows con error de los totales (comportamiento pre-existente).
- [x] Sin regresión de tipos: `PricedXccy.npv_cop: number` se mantiene. La migración a `number | null` es scope de Fase 2.

## Fase 1 completa con este PR

| Sub-issue | Status | PR |
|---|---|---|
| #292 AbortSignal + timeout | ✅ merged | #304 |
| #293 token monotónico | ✅ merged | #306 |
| #294 Promise.allSettled + retry | ✅ merged | #307 |
| #295 consolidar callsites | ✅ merged | #308 |
| #296 distinguir sin precio | **este PR** | #309 |

Después de merge, [épico #298](https://github.com/avelezX/xerenity-fe/issues/298) se puede cerrar.

## Test plan

- [x] `npx tsc --noEmit` limpio
- [x] `npm run lint` sin errores nuevos
- [ ] Manual: forzar un escenario donde pysdk devuelva `npv_cop: null` (ej. posición con fecha fuera de la curva construida) → ver "—" en la celda
- [ ] Manual: hover sobre "—" → ver tooltip con el motivo

## Siguiente

- Cerrar épico #298 (Fase 1 completa)
- Arrancar Fase 2 (#299) — TanStack Query migration

Closes #296
Refs #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)
