### PR TITLE
feat(agent): admin UI para entrenar el agente

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -256,13 +256,16 @@ export default function ChatPanel() {
     inputRef.current?.focus();
   }, []);
 
-  const SUGGESTIONS = [
-    { icon: '📈', text: 'Graficame las tasas IBR por plazo (3m, 6m, 1y)' },
-    { icon: '💹', text: 'Compara la inflacion con la tasa de politica monetaria' },
-    { icon: '🏦', text: 'Muestrame fondos FIC de renta fija' },
-    { icon: '💱', text: 'Cual es la TRM hoy?' },
-    { icon: '📊', text: 'Graficame el PIB vs la inflacion' },
-  ];
+  // Fetch suggestions from DB (super_admin can edit these via /admin/agent)
+  const [suggestions, setSuggestions] = useState<
+    Array<{ id: string; icon: string; title: string; prompt: string }>
+  >([]);
+  useEffect(() => {
+    fetch('/api/chat/suggestions')
+      .then((r) => (r.ok ? r.json() : { suggestions: [] }))
+      .then((data) => setSuggestions(data.suggestions || []))
+      .catch(() => setSuggestions([]));
+  }, []);
 
   // Build chart context string for the agent
   const chartContextText = chartSelections.length > 0
@@ -316,14 +319,16 @@ export default function ChatPanel() {
             <div style={{ fontSize: 13, color: '#b0b8c4' }}>
               Puedo consultar datos, graficar series y crear posiciones.
             </div>
-            <SuggestionsGrid>
-              {SUGGESTIONS.map((s) => (
-                <SuggestionBtn key={s.text} onClick={() => handleSuggestion(s.text)}>
-                  <span>{s.icon}</span>
-                  <span>{s.text}</span>
-                </SuggestionBtn>
-              ))}
-            </SuggestionsGrid>
+            {suggestions.length > 0 && (
+              <SuggestionsGrid>
+                {suggestions.map((s) => (
+                  <SuggestionBtn key={s.id} onClick={() => handleSuggestion(s.prompt)}>
+                    <span>{s.icon}</span>
+                    <span>{s.title}</span>
+                  </SuggestionBtn>
+                ))}
+              </SuggestionsGrid>
+            )}
           </EmptyState>
         ) : (
           chatMessages.map((msg) => (

--- a/src/evals/manual-test.ts
+++ b/src/evals/manual-test.ts
@@ -7,7 +7,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import Anthropic from '@anthropic-ai/sdk';
-import { buildSystemPrompt } from '../pages/api/chat/system-prompt';
 import { tools } from '../pages/api/chat/tools';
 
 // Load env
@@ -24,7 +23,9 @@ if (fs.existsSync(envPath)) {
 }
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
-const systemPrompt = buildSystemPrompt('Test User');
+// buildSystemPrompt is now async and reads from DB. For manual test, use a minimal fallback prompt.
+// Run this test from a context with Supabase connection (or refactor later to load skills in test).
+const systemPrompt = 'Eres el asistente de IA de Xerenity. Use view_series para graficar series buscando tickers en xerenity.search_mv.';
 
 // Synthetic responses for tool results
 function syntheticResult(toolName: string, toolInput: Record<string, unknown>): string {

--- a/src/evals/runner.ts
+++ b/src/evals/runner.ts
@@ -1,5 +1,4 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { buildSystemPrompt } from '../pages/api/chat/system-prompt';
 import { tools } from '../pages/api/chat/tools';
 import { evaluateTurn, isTurnPassing } from './evaluator';
 import type { TestCase, TestResult, TurnResult, ToolCallCapture } from './types';
@@ -169,7 +168,8 @@ export async function runTestCase(
   verbose: boolean = false,
 ): Promise<TestResult> {
   const startTime = Date.now();
-  const systemPrompt = buildSystemPrompt('Test User');
+  // System prompt is now loaded from DB. For evals, use a minimal fallback.
+  const systemPrompt = 'Eres el asistente de IA de Xerenity. Use view_series para graficar series buscando tickers en xerenity.search_mv.';
   const messages: Anthropic.MessageParam[] = [];
   const turnResults: TurnResult[] = [];
   let totalInput = 0;

--- a/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
+++ b/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
@@ -12,6 +12,7 @@ import {
   faChartArea,
   faChartPie,
   faCog,
+  faRobot,
   faUsers,
 } from '@fortawesome/free-solid-svg-icons';
 import useAppStore from 'src/store';
@@ -179,7 +180,15 @@ const SidebarNavList = ({ currentPath }: SidebarNavProps) => {
           name="Admin"
           path="/admin"
           icon={faCog}
-          active={currentPath.includes('/admin')}
+          active={currentPath === '/admin'}
+        />
+      )}
+      {userRole === 'super_admin' && (
+        <NavigationItem
+          name="Agente IA"
+          path="/admin/agent"
+          icon={faRobot}
+          active={currentPath === '/admin/agent'}
         />
       )}
     </ul>

--- a/src/models/agentConfig/index.ts
+++ b/src/models/agentConfig/index.ts
@@ -1,0 +1,189 @@
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import type {
+  AgentSkill,
+  AgentSkillVersion,
+  AgentSuggestion,
+  NewSkill,
+  NewSuggestion,
+} from 'src/types/agent-config';
+
+const supabase = createClientComponentClient();
+const SCHEMA = 'xerenity';
+
+export type MutationResponse = { success: boolean; error?: string; data?: unknown };
+export type ListResponse<T> = { data: T[]; error?: string };
+
+// ─── Skills ─────────────────────────────────────────────────
+
+export const listAgentSkills = async (): Promise<ListResponse<AgentSkill>> => {
+  try {
+    const { data, error } = await supabase.schema(SCHEMA).rpc('list_agent_skills');
+    if (error) return { data: [], error: error.message };
+    return { data: (data as AgentSkill[]) || [] };
+  } catch (e) {
+    return { data: [], error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const createAgentSkill = async (skill: NewSkill): Promise<MutationResponse> => {
+  try {
+    const { data, error } = await supabase.schema(SCHEMA).rpc('create_agent_skill', {
+      p_name: skill.name,
+      p_description: skill.description || null,
+      p_content: skill.content,
+      p_display_order: skill.display_order,
+    });
+    if (error) return { success: false, error: error.message };
+    return { success: true, data };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const updateAgentSkill = async (
+  id: string,
+  updates: Partial<NewSkill>,
+  changeNote: string,
+): Promise<MutationResponse> => {
+  try {
+    const { data, error } = await supabase.schema(SCHEMA).rpc('update_agent_skill', {
+      p_id: id,
+      p_name: updates.name ?? null,
+      p_description: updates.description ?? null,
+      p_content: updates.content ?? null,
+      p_display_order: updates.display_order ?? null,
+      p_change_note: changeNote,
+    });
+    if (error) return { success: false, error: error.message };
+    return { success: true, data };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const toggleAgentSkill = async (id: string, active: boolean): Promise<MutationResponse> => {
+  try {
+    const { error } = await supabase.schema(SCHEMA).rpc('toggle_agent_skill', {
+      p_id: id,
+      p_active: active,
+    });
+    if (error) return { success: false, error: error.message };
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const deleteAgentSkill = async (id: string): Promise<MutationResponse> => {
+  try {
+    const { error } = await supabase.schema(SCHEMA).rpc('delete_agent_skill', { p_id: id });
+    if (error) return { success: false, error: error.message };
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const listAgentSkillVersions = async (
+  skillId: string,
+): Promise<ListResponse<AgentSkillVersion>> => {
+  try {
+    const { data, error } = await supabase.schema(SCHEMA).rpc('list_agent_skill_versions', {
+      p_skill_id: skillId,
+    });
+    if (error) return { data: [], error: error.message };
+    return { data: (data as AgentSkillVersion[]) || [] };
+  } catch (e) {
+    return { data: [], error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const revertAgentSkill = async (
+  skillId: string,
+  versionId: string,
+  changeNote: string,
+): Promise<MutationResponse> => {
+  try {
+    const { data, error } = await supabase.schema(SCHEMA).rpc('revert_agent_skill', {
+      p_skill_id: skillId,
+      p_version_id: versionId,
+      p_change_note: changeNote,
+    });
+    if (error) return { success: false, error: error.message };
+    return { success: true, data };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+// ─── Suggestions ────────────────────────────────────────────
+
+export const listAgentSuggestions = async (): Promise<ListResponse<AgentSuggestion>> => {
+  try {
+    const { data, error } = await supabase.schema(SCHEMA).rpc('list_agent_suggestions');
+    if (error) return { data: [], error: error.message };
+    return { data: (data as AgentSuggestion[]) || [] };
+  } catch (e) {
+    return { data: [], error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const createAgentSuggestion = async (s: NewSuggestion): Promise<MutationResponse> => {
+  try {
+    const { data, error } = await supabase.schema(SCHEMA).rpc('create_agent_suggestion', {
+      p_icon: s.icon,
+      p_title: s.title,
+      p_prompt: s.prompt,
+      p_display_order: s.display_order,
+    });
+    if (error) return { success: false, error: error.message };
+    return { success: true, data };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const updateAgentSuggestion = async (
+  id: string,
+  updates: Partial<NewSuggestion>,
+): Promise<MutationResponse> => {
+  try {
+    const { error } = await supabase.schema(SCHEMA).rpc('update_agent_suggestion', {
+      p_id: id,
+      p_icon: updates.icon ?? null,
+      p_title: updates.title ?? null,
+      p_prompt: updates.prompt ?? null,
+      p_display_order: updates.display_order ?? null,
+    });
+    if (error) return { success: false, error: error.message };
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const toggleAgentSuggestion = async (
+  id: string,
+  active: boolean,
+): Promise<MutationResponse> => {
+  try {
+    const { error } = await supabase.schema(SCHEMA).rpc('toggle_agent_suggestion', {
+      p_id: id,
+      p_active: active,
+    });
+    if (error) return { success: false, error: error.message };
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};
+
+export const deleteAgentSuggestion = async (id: string): Promise<MutationResponse> => {
+  try {
+    const { error } = await supabase.schema(SCHEMA).rpc('delete_agent_suggestion', { p_id: id });
+    if (error) return { success: false, error: error.message };
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+};

--- a/src/pages/admin/agent/_SkillEditorModal.tsx
+++ b/src/pages/admin/agent/_SkillEditorModal.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Form } from 'react-bootstrap';
+import { toast } from 'react-toastify';
+import Button from '@components/UI/Button';
+import useAppStore from 'src/store';
+import type { AgentSkill } from 'src/types/agent-config';
+
+interface Props {
+  show: boolean;
+  skill: AgentSkill | null;
+  onClose: () => void;
+}
+
+export default function SkillEditorModal({ show, skill, onClose }: Props) {
+  const { createAgentSkill, updateAgentSkill } = useAppStore();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [content, setContent] = useState('');
+  const [displayOrder, setDisplayOrder] = useState(100);
+  const [changeNote, setChangeNote] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const isEdit = !!skill;
+
+  useEffect(() => {
+    if (show) {
+      if (skill) {
+        setName(skill.name);
+        setDescription(skill.description || '');
+        setContent(skill.content);
+        setDisplayOrder(skill.display_order);
+        setChangeNote('');
+      } else {
+        setName('');
+        setDescription('');
+        setContent('');
+        setDisplayOrder(100);
+        setChangeNote('');
+      }
+    }
+  }, [show, skill]);
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      toast.error('El nombre es obligatorio');
+      return;
+    }
+    if (!content.trim()) {
+      toast.error('El contenido es obligatorio');
+      return;
+    }
+    if (isEdit && !changeNote.trim()) {
+      toast.error('La nota del cambio es obligatoria al editar');
+      return;
+    }
+
+    setSaving(true);
+    const payload = {
+      name: name.trim(),
+      description: description.trim(),
+      content,
+      display_order: displayOrder,
+    };
+
+    const res = isEdit
+      ? await updateAgentSkill(skill!.id, payload, changeNote.trim())
+      : await createAgentSkill(payload);
+
+    setSaving(false);
+
+    if (res.success) {
+      toast.success(isEdit ? 'Skill actualizada' : 'Skill creada');
+      onClose();
+    } else {
+      toast.error(res.error || 'Error al guardar');
+    }
+  };
+
+  return (
+    <Modal show={show} onHide={onClose} size="xl" centered>
+      <Modal.Header closeButton>
+        <Modal.Title>{isEdit ? `Editar Skill: ${skill!.name}` : 'Nueva Skill'}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form>
+          <div className="row">
+            <div className="col-sm-9">
+              <Form.Group className="mb-3">
+                <Form.Label>Nombre</Form.Label>
+                <Form.Control
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Ej: Inteligencia economica"
+                />
+              </Form.Group>
+            </div>
+            <div className="col-sm-3">
+              <Form.Group className="mb-3">
+                <Form.Label>Orden</Form.Label>
+                <Form.Control
+                  type="number"
+                  value={displayOrder}
+                  onChange={(e) => setDisplayOrder(parseInt(e.target.value, 10) || 100)}
+                />
+              </Form.Group>
+            </div>
+          </div>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Descripcion (opcional)</Form.Label>
+            <Form.Control
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Resumen corto del skill"
+            />
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Contenido (markdown)</Form.Label>
+            <Form.Control
+              as="textarea"
+              rows={20}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="## Titulo&#10;&#10;Instrucciones del skill en markdown..."
+              style={{ fontFamily: 'monospace', fontSize: 12 }}
+            />
+          </Form.Group>
+
+          {isEdit && (
+            <Form.Group className="mb-3">
+              <Form.Label>Nota del cambio (obligatoria)</Form.Label>
+              <Form.Control
+                value={changeNote}
+                onChange={(e) => setChangeNote(e.target.value)}
+                placeholder="Ej: Agregue patron de busqueda para empleo"
+              />
+            </Form.Group>
+          )}
+        </Form>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onClose}>Cancelar</Button>
+        <Button variant="primary" onClick={handleSave} disabled={saving}>
+          {saving ? 'Guardando...' : 'Guardar'}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/pages/admin/agent/_SkillHistoryModal.tsx
+++ b/src/pages/admin/agent/_SkillHistoryModal.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Form, Badge } from 'react-bootstrap';
+import { toast } from 'react-toastify';
+import styled from 'styled-components';
+import Button from '@components/UI/Button';
+import useAppStore from 'src/store';
+import type { AgentSkill, AgentSkillVersion } from 'src/types/agent-config';
+
+const SplitLayout = styled.div`
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 16px;
+  min-height: 500px;
+`;
+
+const VersionList = styled.div`
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  overflow-y: auto;
+  max-height: 500px;
+`;
+
+const VersionItem = styled.div<{ $selected?: boolean }>`
+  padding: 10px 12px;
+  border-bottom: 1px solid #f1f5f9;
+  cursor: pointer;
+  background: ${(p) => (p.$selected ? '#eef2ff' : 'white')};
+  &:hover { background: ${(p) => (p.$selected ? '#eef2ff' : '#f8fafc')}; }
+
+  .version-num { font-weight: 600; font-size: 12px; color: #4F46E5; }
+  .version-meta { font-size: 11px; color: #64748b; margin-top: 2px; }
+  .version-note { font-size: 11px; color: #334155; margin-top: 4px; font-style: italic; }
+`;
+
+interface Props {
+  show: boolean;
+  skill: AgentSkill | null;
+  onClose: () => void;
+}
+
+export default function SkillHistoryModal({ show, skill, onClose }: Props) {
+  const {
+    agentSkillVersions,
+    agentSkillVersionsLoading,
+    loadAgentSkillVersions,
+    revertAgentSkill,
+  } = useAppStore();
+
+  const [selected, setSelected] = useState<AgentSkillVersion | null>(null);
+  const [reverting, setReverting] = useState(false);
+
+  useEffect(() => {
+    if (show && skill) {
+      loadAgentSkillVersions(skill.id);
+      setSelected(null);
+    }
+  }, [show, skill, loadAgentSkillVersions]);
+
+  useEffect(() => {
+    if (agentSkillVersions.length > 0 && !selected) {
+      setSelected(agentSkillVersions[0]);
+    }
+  }, [agentSkillVersions, selected]);
+
+  const handleRevert = async () => {
+    if (!skill || !selected) return;
+    if (selected.version_number === skill.current_version) {
+      toast.info('Esta es la version actual');
+      return;
+    }
+    // eslint-disable-next-line no-alert
+    const note = window.prompt(
+      `Revertir a v${selected.version_number}?\n\nNota del cambio (opcional):`,
+      `Revert a version ${selected.version_number}`,
+    );
+    if (note === null) return;
+
+    setReverting(true);
+    const res = await revertAgentSkill(skill.id, selected.id, note);
+    setReverting(false);
+
+    if (res.success) {
+      toast.success('Revertido exitosamente');
+      onClose();
+    } else {
+      toast.error(res.error || 'Error al revertir');
+    }
+  };
+
+  if (!skill) return null;
+
+  return (
+    <Modal show={show} onHide={onClose} size="xl" centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Historial: {skill.name}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <SplitLayout>
+          <VersionList>
+            {agentSkillVersionsLoading && (
+              <div style={{ padding: 16, textAlign: 'center', color: '#64748b' }}>Cargando...</div>
+            )}
+            {!agentSkillVersionsLoading && agentSkillVersions.length === 0 && (
+              <div style={{ padding: 16, textAlign: 'center', color: '#64748b' }}>Sin versiones</div>
+            )}
+            {agentSkillVersions.map((v) => (
+              <VersionItem
+                key={v.id}
+                $selected={selected?.id === v.id}
+                onClick={() => setSelected(v)}
+              >
+                <div className="version-num">
+                  v{v.version_number}
+                  {v.version_number === skill.current_version && (
+                    <Badge bg="success" className="ms-2" style={{ fontSize: 9 }}>ACTUAL</Badge>
+                  )}
+                </div>
+                <div className="version-meta">
+                  {new Date(v.changed_at).toLocaleString()}
+                  {v.changed_by_email && ` · ${v.changed_by_email}`}
+                </div>
+                {v.change_note && (
+                  <div className="version-note">{v.change_note}</div>
+                )}
+              </VersionItem>
+            ))}
+          </VersionList>
+
+          <div>
+            {selected ? (
+              <>
+                <div className="mb-2">
+                  <strong>{selected.name}</strong> — v{selected.version_number}
+                </div>
+                <Form.Control
+                  as="textarea"
+                  rows={22}
+                  value={selected.content}
+                  readOnly
+                  style={{ fontFamily: 'monospace', fontSize: 11 }}
+                />
+              </>
+            ) : (
+              <div style={{ color: '#94a3b8', padding: 24 }}>Selecciona una version para ver el contenido</div>
+            )}
+          </div>
+        </SplitLayout>
+      </Modal.Body>
+      <Modal.Footer>
+        {selected && selected.version_number !== skill.current_version && (
+          <Button variant="primary" onClick={handleRevert} disabled={reverting}>
+            {reverting ? 'Revirtiendo...' : `Revertir a v${selected.version_number}`}
+          </Button>
+        )}
+        <Button variant="secondary" onClick={onClose}>Cerrar</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/pages/admin/agent/_SkillsTab.tsx
+++ b/src/pages/admin/agent/_SkillsTab.tsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useState } from 'react';
+import { Form, Badge } from 'react-bootstrap';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import {
+  faPlus, faPenToSquare, faTrash, faClockRotateLeft,
+} from '@fortawesome/free-solid-svg-icons';
+import { toast } from 'react-toastify';
+import styled from 'styled-components';
+import Button from '@components/UI/Button';
+import useAppStore from 'src/store';
+import type { AgentSkill } from 'src/types/agent-config';
+import SkillEditorModal from './_SkillEditorModal';
+import SkillHistoryModal from './_SkillHistoryModal';
+
+const TableWrap = styled.div`
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  margin-bottom: 16px;
+
+  .table { margin-bottom: 0; }
+  .table thead th {
+    background: #302b63 !important;
+    color: #fff !important;
+    font-size: 11px !important;
+    font-weight: 600 !important;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 10px 12px !important;
+  }
+  .table tbody td {
+    font-size: 13px;
+    vertical-align: middle !important;
+    padding: 8px 12px !important;
+    border-color: #eee !important;
+  }
+  .table tbody tr:nth-child(even) { background: #fafaff; }
+  .table tbody tr:hover { background: rgba(48, 43, 99, 0.06) !important; }
+`;
+
+const ActionBtn = styled.button`
+  background: none;
+  border: none;
+  color: #6c757d;
+  cursor: pointer;
+  padding: 4px 6px;
+  margin-right: 4px;
+  &:hover { color: #302b63; }
+  &.danger:hover { color: #dc3545; }
+`;
+
+export default function SkillsTab() {
+  const {
+    agentSkills,
+    agentSkillsLoading,
+    loadAgentSkills,
+    toggleAgentSkill,
+    deleteAgentSkill,
+  } = useAppStore();
+
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingSkill, setEditingSkill] = useState<AgentSkill | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [historySkill, setHistorySkill] = useState<AgentSkill | null>(null);
+
+  useEffect(() => {
+    loadAgentSkills();
+  }, [loadAgentSkills]);
+
+  const handleNew = () => {
+    setEditingSkill(null);
+    setEditorOpen(true);
+  };
+
+  const handleEdit = (skill: AgentSkill) => {
+    setEditingSkill(skill);
+    setEditorOpen(true);
+  };
+
+  const handleHistory = (skill: AgentSkill) => {
+    setHistorySkill(skill);
+    setHistoryOpen(true);
+  };
+
+  const handleToggle = async (skill: AgentSkill) => {
+    const res = await toggleAgentSkill(skill.id, !skill.active);
+    if (res.success) {
+      toast.success(`Skill ${skill.active ? 'desactivada' : 'activada'}`);
+    } else {
+      toast.error(res.error || 'Error');
+    }
+  };
+
+  const handleDelete = async (skill: AgentSkill) => {
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(`Eliminar skill "${skill.name}"? Esta accion borra todas sus versiones.`)) return;
+    const res = await deleteAgentSkill(skill.id);
+    if (res.success) {
+      toast.success('Skill eliminada');
+    } else {
+      toast.error(res.error || 'Error');
+    }
+  };
+
+  return (
+    <>
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <div>
+          <strong>Skills del Agente ({agentSkills.length})</strong>
+          <div style={{ fontSize: 12, color: '#6c757d' }}>
+            Los skills se concatenan al prompt del agente en orden. Los cambios tardan hasta 60s en reflejarse (cache).
+          </div>
+        </div>
+        <Button variant="primary" onClick={handleNew}>
+          <Icon icon={faPlus} className="me-2" />
+          Nueva Skill
+        </Button>
+      </div>
+
+      <TableWrap>
+        <table className="table">
+          <thead>
+            <tr>
+              <th style={{ width: 60 }}>Orden</th>
+              <th>Nombre</th>
+              <th>Descripcion</th>
+              <th style={{ width: 80 }}>Version</th>
+              <th style={{ width: 80 }}>Activa</th>
+              <th style={{ width: 150 }}>Actualizada</th>
+              <th style={{ width: 140 }}>Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {agentSkillsLoading && (
+              <tr><td colSpan={7} className="text-center">Cargando...</td></tr>
+            )}
+            {!agentSkillsLoading && agentSkills.length === 0 && (
+              <tr><td colSpan={7} className="text-center text-muted">No hay skills configuradas</td></tr>
+            )}
+            {agentSkills.map((skill) => (
+              <tr key={skill.id}>
+                <td>{skill.display_order}</td>
+                <td><strong>{skill.name}</strong></td>
+                <td style={{ color: '#6c757d' }}>{skill.description || '—'}</td>
+                <td><Badge bg="secondary">v{skill.current_version}</Badge></td>
+                <td>
+                  <Form.Check
+                    type="switch"
+                    checked={skill.active}
+                    onChange={() => handleToggle(skill)}
+                  />
+                </td>
+                <td style={{ fontSize: 11, color: '#6c757d' }}>
+                  {new Date(skill.updated_at).toLocaleString()}
+                </td>
+                <td>
+                  <ActionBtn onClick={() => handleEdit(skill)} title="Editar">
+                    <Icon icon={faPenToSquare} />
+                  </ActionBtn>
+                  <ActionBtn onClick={() => handleHistory(skill)} title="Historial">
+                    <Icon icon={faClockRotateLeft} />
+                  </ActionBtn>
+                  <ActionBtn className="danger" onClick={() => handleDelete(skill)} title="Eliminar">
+                    <Icon icon={faTrash} />
+                  </ActionBtn>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableWrap>
+
+      <SkillEditorModal
+        show={editorOpen}
+        skill={editingSkill}
+        onClose={() => setEditorOpen(false)}
+      />
+      <SkillHistoryModal
+        show={historyOpen}
+        skill={historySkill}
+        onClose={() => setHistoryOpen(false)}
+      />
+    </>
+  );
+}

--- a/src/pages/admin/agent/_SuggestionEditorModal.tsx
+++ b/src/pages/admin/agent/_SuggestionEditorModal.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Form } from 'react-bootstrap';
+import { toast } from 'react-toastify';
+import Button from '@components/UI/Button';
+import useAppStore from 'src/store';
+import type { AgentSuggestion } from 'src/types/agent-config';
+
+interface Props {
+  show: boolean;
+  suggestion: AgentSuggestion | null;
+  onClose: () => void;
+}
+
+export default function SuggestionEditorModal({ show, suggestion, onClose }: Props) {
+  const { createAgentSuggestion, updateAgentSuggestion } = useAppStore();
+
+  const [icon, setIcon] = useState('💬');
+  const [title, setTitle] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [displayOrder, setDisplayOrder] = useState(100);
+  const [saving, setSaving] = useState(false);
+
+  const isEdit = !!suggestion;
+
+  useEffect(() => {
+    if (show) {
+      if (suggestion) {
+        setIcon(suggestion.icon);
+        setTitle(suggestion.title);
+        setPrompt(suggestion.prompt);
+        setDisplayOrder(suggestion.display_order);
+      } else {
+        setIcon('💬');
+        setTitle('');
+        setPrompt('');
+        setDisplayOrder(100);
+      }
+    }
+  }, [show, suggestion]);
+
+  const handleSave = async () => {
+    if (!title.trim() || !prompt.trim()) {
+      toast.error('Titulo y prompt son obligatorios');
+      return;
+    }
+
+    setSaving(true);
+    const payload = {
+      icon: icon || '💬',
+      title: title.trim(),
+      prompt: prompt.trim(),
+      display_order: displayOrder,
+    };
+
+    const res = isEdit
+      ? await updateAgentSuggestion(suggestion!.id, payload)
+      : await createAgentSuggestion(payload);
+
+    setSaving(false);
+
+    if (res.success) {
+      toast.success(isEdit ? 'Sugerencia actualizada' : 'Sugerencia creada');
+      onClose();
+    } else {
+      toast.error(res.error || 'Error');
+    }
+  };
+
+  return (
+    <Modal show={show} onHide={onClose} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>{isEdit ? 'Editar Sugerencia' : 'Nueva Sugerencia'}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form>
+          <div className="row">
+            <div className="col-sm-3">
+              <Form.Group className="mb-3">
+                <Form.Label>Icono</Form.Label>
+                <Form.Control
+                  value={icon}
+                  onChange={(e) => setIcon(e.target.value)}
+                  placeholder="💬"
+                  maxLength={4}
+                  style={{ fontSize: 20, textAlign: 'center' }}
+                />
+              </Form.Group>
+            </div>
+            <div className="col-sm-3">
+              <Form.Group className="mb-3">
+                <Form.Label>Orden</Form.Label>
+                <Form.Control
+                  type="number"
+                  value={displayOrder}
+                  onChange={(e) => setDisplayOrder(parseInt(e.target.value, 10) || 100)}
+                />
+              </Form.Group>
+            </div>
+          </div>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Titulo (texto del boton)</Form.Label>
+            <Form.Control
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Graficame la TRM"
+            />
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Prompt (lo que se envia al agente al hacer click)</Form.Label>
+            <Form.Control
+              as="textarea"
+              rows={4}
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Graficame la TRM de los ultimos 6 meses"
+            />
+            <Form.Text className="text-muted">
+              Puede ser distinto al titulo si quieres que el boton diga algo corto pero el prompt sea mas especifico.
+            </Form.Text>
+          </Form.Group>
+        </Form>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onClose}>Cancelar</Button>
+        <Button variant="primary" onClick={handleSave} disabled={saving}>
+          {saving ? 'Guardando...' : 'Guardar'}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/pages/admin/agent/_SuggestionsTab.tsx
+++ b/src/pages/admin/agent/_SuggestionsTab.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useState } from 'react';
+import { Form } from 'react-bootstrap';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import { faPlus, faPenToSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { toast } from 'react-toastify';
+import styled from 'styled-components';
+import Button from '@components/UI/Button';
+import useAppStore from 'src/store';
+import type { AgentSuggestion } from 'src/types/agent-config';
+import SuggestionEditorModal from './_SuggestionEditorModal';
+
+const TableWrap = styled.div`
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+
+  .table { margin-bottom: 0; }
+  .table thead th {
+    background: #302b63 !important;
+    color: #fff !important;
+    font-size: 11px !important;
+    font-weight: 600 !important;
+    text-transform: uppercase;
+    padding: 10px 12px !important;
+  }
+  .table tbody td {
+    font-size: 13px;
+    vertical-align: middle !important;
+    padding: 8px 12px !important;
+    border-color: #eee !important;
+  }
+  .table tbody tr:nth-child(even) { background: #fafaff; }
+`;
+
+const ActionBtn = styled.button`
+  background: none;
+  border: none;
+  color: #6c757d;
+  cursor: pointer;
+  padding: 4px 6px;
+  margin-right: 4px;
+  &:hover { color: #302b63; }
+  &.danger:hover { color: #dc3545; }
+`;
+
+export default function SuggestionsTab() {
+  const {
+    agentSuggestions,
+    agentSuggestionsLoading,
+    loadAgentSuggestions,
+    toggleAgentSuggestion,
+    deleteAgentSuggestion,
+  } = useAppStore();
+
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editing, setEditing] = useState<AgentSuggestion | null>(null);
+
+  useEffect(() => {
+    loadAgentSuggestions();
+  }, [loadAgentSuggestions]);
+
+  const handleToggle = async (s: AgentSuggestion) => {
+    const res = await toggleAgentSuggestion(s.id, !s.active);
+    if (res.success) toast.success(`Sugerencia ${s.active ? 'desactivada' : 'activada'}`);
+    else toast.error(res.error || 'Error');
+  };
+
+  const handleDelete = async (s: AgentSuggestion) => {
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(`Eliminar sugerencia "${s.title}"?`)) return;
+    const res = await deleteAgentSuggestion(s.id);
+    if (res.success) toast.success('Sugerencia eliminada');
+    else toast.error(res.error || 'Error');
+  };
+
+  return (
+    <>
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <div>
+          <strong>Sugerencias del Chat ({agentSuggestions.length})</strong>
+          <div style={{ fontSize: 12, color: '#6c757d' }}>
+            Botones que aparecen al abrir el chat vacio. Al hacer click, envian el prompt al agente.
+          </div>
+        </div>
+        <Button
+          variant="primary"
+          onClick={() => {
+            setEditing(null);
+            setEditorOpen(true);
+          }}
+        >
+          <Icon icon={faPlus} className="me-2" />
+          Nueva Sugerencia
+        </Button>
+      </div>
+
+      <TableWrap>
+        <table className="table">
+          <thead>
+            <tr>
+              <th style={{ width: 60 }}>Orden</th>
+              <th style={{ width: 60 }}>Icono</th>
+              <th>Titulo</th>
+              <th>Prompt</th>
+              <th style={{ width: 80 }}>Activa</th>
+              <th style={{ width: 100 }}>Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {agentSuggestionsLoading && (
+              <tr><td colSpan={6} className="text-center">Cargando...</td></tr>
+            )}
+            {!agentSuggestionsLoading && agentSuggestions.length === 0 && (
+              <tr><td colSpan={6} className="text-center text-muted">No hay sugerencias</td></tr>
+            )}
+            {agentSuggestions.map((s) => (
+              <tr key={s.id}>
+                <td>{s.display_order}</td>
+                <td style={{ fontSize: 20 }}>{s.icon}</td>
+                <td><strong>{s.title}</strong></td>
+                <td style={{ color: '#6c757d', maxWidth: 400 }}>
+                  <span title={s.prompt}>
+                    {s.prompt.length > 80 ? `${s.prompt.slice(0, 80)}...` : s.prompt}
+                  </span>
+                </td>
+                <td>
+                  <Form.Check
+                    type="switch"
+                    checked={s.active}
+                    onChange={() => handleToggle(s)}
+                  />
+                </td>
+                <td>
+                  <ActionBtn
+                    onClick={() => {
+                      setEditing(s);
+                      setEditorOpen(true);
+                    }}
+                    title="Editar"
+                  >
+                    <Icon icon={faPenToSquare} />
+                  </ActionBtn>
+                  <ActionBtn className="danger" onClick={() => handleDelete(s)} title="Eliminar">
+                    <Icon icon={faTrash} />
+                  </ActionBtn>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableWrap>
+
+      <SuggestionEditorModal
+        show={editorOpen}
+        suggestion={editing}
+        onClose={() => setEditorOpen(false)}
+      />
+    </>
+  );
+}

--- a/src/pages/admin/agent/index.tsx
+++ b/src/pages/admin/agent/index.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import React, { useState } from 'react';
+import { CoreLayout } from '@layout';
+import { Container, Tab, Tabs } from 'react-bootstrap';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import { faRobot } from '@fortawesome/free-solid-svg-icons';
+import PageTitle from '@components/PageTitle';
+import RoleGuard from 'src/components/RoleGuard';
+import SkillsTab from './_SkillsTab';
+import SuggestionsTab from './_SuggestionsTab';
+
+export default function AgentAdminPage() {
+  const [activeTab, setActiveTab] = useState<string>('skills');
+
+  return (
+    <CoreLayout>
+      <RoleGuard requiredRole="super_admin">
+        <Container fluid className="px-4 pb-4">
+          <PageTitle>
+            <Icon icon={faRobot} />
+            <h4>Configuracion del Agente IA</h4>
+          </PageTitle>
+
+          <Tabs
+            activeKey={activeTab}
+            onSelect={(k) => setActiveTab(k || 'skills')}
+            className="mb-3"
+          >
+            <Tab eventKey="skills" title="Skills">
+              <SkillsTab />
+            </Tab>
+            <Tab eventKey="suggestions" title="Sugerencias">
+              <SuggestionsTab />
+            </Tab>
+          </Tabs>
+        </Container>
+      </RoleGuard>
+    </CoreLayout>
+  );
+}

--- a/src/pages/api/chat/index.ts
+++ b/src/pages/api/chat/index.ts
@@ -122,7 +122,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
   const userName = session.user.user_metadata?.full_name || session.user.email;
-  const systemPrompt = buildSystemPrompt(userName);
+  const systemPrompt = await buildSystemPrompt(userName, supabase);
 
   const anthropicMessages: Anthropic.MessageParam[] = clientMessages.map((m) => ({
     role: m.role,

--- a/src/pages/api/chat/suggestions.ts
+++ b/src/pages/api/chat/suggestions.ts
@@ -1,0 +1,27 @@
+import { createPagesServerClient } from '@supabase/auth-helpers-nextjs';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const supabase = createPagesServerClient({ req, res });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return res.status(401).json({ error: 'No autenticado' });
+  }
+
+  const { data, error } = await supabase
+    .schema('xerenity')
+    .rpc('get_active_agent_suggestions');
+
+  if (error) {
+    return res.status(500).json({ error: error.message });
+  }
+
+  return res.status(200).json({ suggestions: data || [] });
+}

--- a/src/pages/api/chat/system-prompt.ts
+++ b/src/pages/api/chat/system-prompt.ts
@@ -1,312 +1,57 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// In-memory cache to avoid hitting DB on every chat message
+const CACHE_TTL_MS = 60_000; // 60 seconds
+let cache: { at: number; skills: Array<{ name: string; content: string }> } | null = null;
+
+export function invalidateSkillsCache(): void {
+  cache = null;
+}
+
+async function loadActiveSkills(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient | any,
+): Promise<Array<{ name: string; content: string }>> {
+  const now = Date.now();
+  if (cache && now - cache.at < CACHE_TTL_MS) {
+    return cache.skills;
+  }
+
+  try {
+    const { data, error } = await supabase.schema('xerenity').rpc('get_active_agent_skills');
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error loading agent skills:', error.message);
+      return cache?.skills || [];
+    }
+    const skills = (data as Array<{ name: string; content: string }>) || [];
+    cache = { at: now, skills };
+    return skills;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Exception loading agent skills:', err);
+    return cache?.skills || [];
+  }
+}
+
 // eslint-disable-next-line import/prefer-default-export
-export function buildSystemPrompt(userName?: string): string {
+export async function buildSystemPrompt(
+  userName?: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase?: SupabaseClient | any,
+): Promise<string> {
   const greeting = userName ? `El usuario actual es ${userName}.` : '';
+  const header = `${greeting}`.trim();
 
-  return `Eres el asistente de IA de Xerenity, una plataforma de datos financieros para mercados colombianos y latinoamericanos. ${greeting}
+  if (!supabase) {
+    return header || 'Eres el asistente de IA de Xerenity.';
+  }
 
-Responde siempre en español a menos que el usuario escriba en otro idioma.
-Se conciso y directo. Usa formato markdown cuando sea util.
+  const skills = await loadActiveSkills(supabase);
 
-## Contexto del Grafico
-El primer mensaje del usuario puede incluir un bloque [CONTEXTO DEL GRAFICO ACTUAL: ...] que te dice que series estan cargadas en el graficador y el periodo seleccionado. Usa esta informacion para:
-- Referirte a las series que el usuario ya esta viendo ("Veo que tienes la TRM cargada...")
-- Sugerir agregar series complementarias ("Podrias agregar la tasa de politica monetaria para comparar")
-- Advertir sobre incompatibilidades de periodicidad con las series ya cargadas
-- Ajustar tus recomendaciones de periodo basandote en lo que ya esta seleccionado
-Si no hay contexto del grafico, el usuario no tiene series cargadas.
+  const body = skills
+    .map((s) => s.content.trim())
+    .join('\n\n');
 
-## Base de Datos Disponible (Supabase, schema "xerenity")
-
-### Tablas Principales
-
-**xerenity.tes** — Bonos del tesoro colombiano (TES)
-Columnas: name (PK, TEXT), type, country, memo, isin, emision (DATE), maduracion (DATE), periocidad, cupon (float), l_minimo (float), moneda, displayname
-
-**xerenity.tes_operation** — Operaciones de TES
-Columnas: tes (FK->xerenity.tes), collector, date (timestamp), price (float), yield (float), volume (float)
-
-**xerenity.ibr_swaps** — Datos DTCC de swaps IBR
-Columnas: dissemination_identifier (PK), action_type, event_timestamp, product_name, execution_timestamp, effective_date (DATE), expiration_date (DATE), notional_amount_leg_1, notional_amount_leg_2, fixed_rate_leg_1, fixed_rate_leg_2, underlier_id_leg_1, underlier_id_leg_2
-
-**xerenity.cop_ndf** — Forwards NDF COP
-Columnas: dissemination_identifier (PK), action_type, product_name, event_timestamp, execution_timestamp, effective_date (DATE), expiration_date (DATE), exchange_rate (float), notional_amount_leg_1, notional_amount_leg_2, notional_currency_leg_1, notional_currency_leg_2
-
-**xerenity.currency** — Tasas de cambio (FX)
-Columnas: time (TIMESTAMP), value (float), volume (float), currency (TEXT, formato "XXX:YYY" ej: "USD:COP")
-
-**xerenity.currency_hour** — FX agregado por hora
-Columnas: time (TIMESTAMP), value (float), volume (float), currency (TEXT)
-
-**xerenity.banrep_serie_v2** — Catalogo de series Banco de la Republica
-Columnas: id (PK, INT), nombre, description, fuente, sub_group, grupo
-
-**xerenity.banrep_series_value_v2** — Valores de series Banrep
-Columnas: id_serie (INT), fecha (TIMESTAMP), valor (FLOAT)
-
-**xerenity.camacol_serie** — Catalogo de series Camacol (sector construccion)
-Columnas: id (PK, INT), nombre, description, fuente, sub_group, grupo
-
-**xerenity.camacol_series_value** — Valores series Camacol
-Columnas: id_serie (INT), fecha (TIMESTAMP), valor (FLOAT)
-
-**xerenity.ust_yield_curve** — Curva de rendimiento bonos del tesoro USA
-Columnas: fecha (DATE), tenor_months (INT: 1,2,3,4,6,12,24,36,60,84,120,240,360), yield_value (FLOAT), curve_type (TEXT: 'NOMINAL' o 'TIPS')
-
-**xerenity.us_reference_rates** — Tasas de referencia USA (SOFR, EFFR, etc.)
-Columnas: fecha (DATE), rate_type (TEXT: 'SOFR','EFFR','OBFR','SOFR_AVG_30D','SOFR_AVG_90D','SOFR_AVG_180D'), rate (FLOAT), volume_billions (FLOAT)
-
-**xerenity.politica_monetaria** — Tasa de politica monetaria Colombia
-Columnas: fecha (DATE), tasa (float)
-
-**xerenity.canasta** — Componentes canasta IPC
-Columnas: id (PK, INT), nombre (TEXT), peso (float)
-
-**xerenity.canasta_values** — Valores canasta IPC por fecha
-Columnas: id_canasta (INT), fecha (TIMESTAMP), valorcontribucion, indice, valor, valormensual (float)
-
-**xerenity.public_series** — Catalogo de series publicas para busqueda
-
-**xerenity.ibr_quotes_curve** — Curva IBR por plazo (vista materializada)
-Columnas: fecha (DATE), ibr_1d, ibr_1m, ibr_3m, ibr_6m, ibr_12m, ibr_2y, ibr_5y, ibr_10y, ibr_15y, ibr_20y (float)
-
-**xerenity.fic** — Datos de fondos de inversion colectiva
-
-**xerenity.bcrp_series_value** — Series del Banco Central del Peru
-Columnas: id_serie (INT), fecha (DATE), valor (FLOAT)
-
-### Schema "loans"
-
-**loans.loan** — Prestamos del usuario
-Columnas: id (uuid, PK), owner (uuid), type (ENUM: 'fija','ibr','uvr'), start_date (DATE), number_of_payments (INT), original_balance (float), periodicity (TEXT), interest_rate (float), days_count, grace_type, loan_identifier (TEXT), grace_period (INT), min_period_rate (float), bank (TEXT)
-
-### Schema "trading"
-
-**trading.company** — Empresas
-Columnas: id (uuid, PK), name (TEXT), nit (TEXT)
-
-**trading.xccy_position** — Posiciones Cross-Currency Swap
-Columnas: id (uuid, PK), owner (uuid), company_id (uuid), label, counterparty, notional_usd (float), start_date (DATE), maturity_date (DATE), usd_spread_bps, cop_spread_bps (float), pay_usd (boolean), fx_initial (float), payment_frequency (TEXT, default '3M'), amortization_type (TEXT, default 'bullet')
-
-**trading.ndf_position** — Posiciones NDF
-Columnas: id (uuid, PK), owner (uuid), company_id (uuid), label, counterparty, notional_usd (float), strike (float), maturity_date (DATE), direction (TEXT, default 'buy')
-
-**trading.ibr_swap_position** — Posiciones IBR Swap
-Columnas: id (uuid, PK), owner (uuid), company_id (uuid), label, counterparty, notional (float), start_date (DATE), maturity_date (DATE), fixed_rate (float), pay_fixed (boolean), spread_bps (float), payment_frequency (TEXT, default '3M')
-
-### Vistas Materializadas (formato OHLCV: day, close, open, high, low, volume)
-- TES: tes_24, tes_25, tes_26, tes_27, tes_28, tes_30, tes_31, tes_32, tes_33, tes_34, tes_36, tes_42, tes_50
-- TES UVR: uvr_25, uvr_27, uvr_29, uvr_33, uvr_35, uvr_37, uvr_49
-- IBR por plazo: ibr_1m, ibr_2m, ibr_3m, ibr_4m, ibr_5m, ibr_6m, ibr_7m, ibr_8m, ibr_9m, ibr_10m, ibr_11m, ibr_1y, ibr_18m, ibr_2y, ibr_3y, ibr_4y, ibr_5y, ibr_6y, ibr_7y, ibr_8y, ibr_9y, ibr_10y
-
-## Reglas de Uso de Tools
-
-### query_database
-- SOLO queries SELECT. Nunca INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, TRUNCATE.
-- Siempre incluye LIMIT (max 500 filas) para evitar resultados enormes.
-- Usa el schema correcto: xerenity.tabla, loans.tabla, trading.tabla.
-- Para la TRM (tasa representativa del mercado), consulta: SELECT value, time FROM xerenity.currency WHERE currency = 'USD:COP' ORDER BY time DESC LIMIT 1
-
-### generate_chart
-- NO uses este tool. Usa view_series en su lugar para TODAS las graficas.
-- generate_chart esta deprecado. Solo usalo si view_series falla por algun motivo.
-
-### view_series (OBLIGATORIO para cualquier grafica)
-- SIEMPRE usa este tool cuando el usuario quiera ver, graficar, o visualizar cualquier dato.
-- Esto incluye: TRM, USDCOP, IBR, TES, inflacion, PIB, base monetaria, politica monetaria, FIC, o CUALQUIER serie.
-- Este tool carga las series directamente en el graficador profesional de Xerenity SIN recargar la pagina.
-- Las series se agregan al grafico actual — las series existentes se preservan.
-
-**FLUJO OBLIGATORIO (maximo 2 pasos, NO mas):**
-1. UNA SOLA query para buscar todos los tickers que necesitas:
-   SELECT ticker, display_name FROM xerenity.search_mv WHERE display_name ILIKE '%termino1%' OR display_name ILIKE '%termino2%' LIMIT 10
-2. Inmediatamente llama view_series con los tickers y nombres encontrados. NO hagas mas queries.
-
-**REGLAS CRITICAS:**
-- NUNCA hagas mas de 1 query de busqueda antes de llamar view_series.
-- Si la primera query no encuentra resultados exactos, usa los resultados mas cercanos. NO intentes refinar con mas queries.
-- Si buscas multiples series, usa OR en una sola query, NO queries separadas.
-- Maximo 5 series por visualizacion.
-
-**SERIES COMUNES (usa estos terminos de busqueda):**
-- TRM/USDCOP: WHERE display_name ILIKE '%Tasa Representativa%' (DIARIA, ~250 pts/año)
-- IBR plazos: WHERE grupo = 'IBR' (DIARIA)
-- Inflacion mensual: WHERE display_name ILIKE '%Inflaci%n sin alimentos%' OR display_name ILIKE '%Inflaci%n de servicio%' (MENSUAL, 12 pts/año)
-- Inflacion total: WHERE display_name ILIKE '%Inflaci%n total%anual%' (ANUAL, 1 pt/año — solo usar con periodo 10Y)
-- Meta de inflacion: WHERE display_name ILIKE '%Meta de inflaci%n%' (MENSUAL)
-- Politica monetaria: WHERE display_name ILIKE '%pol%tica monetaria%' (DIARIA)
-- PIB trimestral: WHERE display_name ILIKE '%PIB Trimestral%Total%' AND grupo = 'Cuentas Nacionales' (TRIMESTRAL, 4 pts/año — usar con periodo 5Y o 10Y)
-- PIB Construccion: WHERE display_name = 'PIB Total Colombia' AND grupo = 'Construccion' (TRIMESTRAL)
-- Base monetaria: WHERE display_name ILIKE '%base monetaria%' (MENSUAL)
-- FIC/Fondos: WHERE grupo = 'FIC' AND display_name ILIKE '%renta fija%' (DIARIA)
-- TES tasas: WHERE grupo = 'TES TASAS' (DIARIA)
-- Empleo/Desempleo: WHERE grupo = 'EMPLEO' (MENSUAL)
-- Tasa de cambio: WHERE grupo = 'Divisas' (DIARIA)
-
-## Inteligencia Economica — Reglas de Comparacion
-
-ANTES de cargar series en el graficador, evalua la compatibilidad:
-
-### Periodicidad
-Cada serie tiene una frecuencia de datos. Si el usuario pide comparar series de diferentes frecuencias, ADVIERTE y sugiere alternativas:
-- **DIARIA** (~250 pts/año): TRM, IBR, politica monetaria, TES tasas, FIC
-- **MENSUAL** (~12 pts/año): Inflacion (componentes), empleo, base monetaria, IPC
-- **TRIMESTRAL** (~4 pts/año): PIB, cuentas nacionales
-- **ANUAL** (~1 pt/año): Inflacion total anual, crecimiento PIB anual
-
-**Regla:** Si comparas una serie DIARIA con una TRIMESTRAL, la grafica se vera mal (ej: TRM diaria vs PIB trimestral). En ese caso:
-- Sugiere usar series de frecuencia similar
-- O advierte: "El PIB es trimestral (4 datos/año) y la TRM es diaria. La comparacion se vera mejor con periodo 5Y o 10Y."
-- Para PIB, SIEMPRE sugiere periodo minimo 3Y o 5Y (con 1Y solo hay 4 puntos)
-
-### Series con pocos datos
-- Si una serie tiene menos de 5 datos en el periodo seleccionado, ADVIERTE al usuario
-- Sugiere ampliar el periodo o usar una serie alternativa con mas datos
-- Ejemplo: "La inflacion total anual solo tiene ~1 dato por año. Para ver la tendencia, usa 'Inflacion sin alimentos ni regulados' que es mensual."
-
-### Comparaciones economicas validas
-Cuando el usuario pide comparar, sugiere las combinaciones que tienen sentido economico:
-- **Inflacion vs Tasa de politica monetaria** → ambas son variables que el Banco de la Republica relaciona directamente. Usar inflacion mensual (no anual) con politica monetaria diaria. Periodo: 3Y-5Y.
-- **PIB vs Inflacion** → Usar PIB trimestral con inflacion mensual. Periodo: 5Y-10Y. NORMALIZAR para comparar escalas diferentes.
-- **TRM vs Tasa de politica monetaria** → ambas diarias, buena comparacion. Periodo: 1Y-3Y.
-- **IBR vs politica monetaria** → ambas diarias, excelente comparacion directa.
-- **FIC fondos** → todos diarios, buena comparacion. NORMALIZAR para ver rendimiento relativo.
-
-### Normalizacion
-Cuando compares series con escalas muy diferentes (ej: PIB en billones vs inflacion en porcentaje), usa control_chart con action=normalize para activar la normalizacion automaticamente. No le digas al usuario que lo haga manualmente — hazlo tu.
-
-### control_chart (controlar el graficador)
-- Usa este tool para ajustar el grafico que el usuario ya tiene abierto.
-- Acciones disponibles:
-  - **set_period**: Cambiar el rango de tiempo. Periodos: 1D, 5D, 1M, 3M, 6M, YTD, 1Y, 3Y, 5Y, 10Y.
-  - **normalize**: Activar/desactivar normalizacion para comparar escalas diferentes.
-  - **clear**: Limpiar todas las series del grafico.
-  - **remove_series**: Quitar una serie especifica (necesita ticker del contexto del grafico).
-- Usa esto DESPUES de cargar series con view_series para ajustar la visualizacion.
-- Flujo tipico: view_series → control_chart(set_period) → control_chart(normalize)
-- Ejemplos:
-  - "Muestrame 5 anos" → control_chart(set_period, period="5Y")
-  - "Normaliza para comparar" → control_chart(normalize, normalize=true)
-  - "Limpia el grafico" → control_chart(clear)
-  - "Quita la TRM" → control_chart(remove_series, ticker=ticker_de_trm)
-  - Cargar PIB + inflacion → automaticamente: control_chart(normalize) + control_chart(set_period, "5Y")
-
-### navigate_to
-- Usa este tool cuando el usuario pida ir a una seccion especifica.
-- Solo paths validos (ver mapa abajo).
-
-### create_position / create_loan
-- SIEMPRE pide confirmacion EXPLICITA al usuario antes de ejecutar.
-- Muestra un resumen de los parametros antes de crear.
-- Ejemplo: "Voy a crear una posicion NDF con estos parametros: ... Confirmas?"
-
-## Mapa de Navegacion
-
-| Path | Seccion |
-|---|---|
-| /dashboard | Dashboard principal |
-| /suameca | Dashboard SUAMECA |
-| /loans | Prestamos |
-| /xccy-swap | Posiciones Cross-Currency Swap |
-| /ibr-swap | Posiciones IBR Swap |
-| /ndf-pricer | Pricer NDF |
-| /tes | TES (bonos colombianos) |
-| /tes-portfolio | Portafolio TES |
-| /coltes-calculator | Calculadora COLTES |
-| /series | Series de tiempo |
-| /inflation | Inflacion e IPC |
-| /us-rates | Tasas USA (SOFR, Treasury) |
-| /portfolio | Portafolio de derivados |
-| /risk-management | Gestion de riesgo |
-| /risk-resumen | Resumen de riesgo |
-| /marks | Marks de mercado |
-| /monedas-dashboard | Dashboard de monedas |
-| /par-monedas | Pares de monedas |
-| /tasas | Tasas de interes |
-| /copndf | COP NDF historico |
-| /fic | Fondos de Inversion Colectiva |
-| /peru | Datos Peru (BCRP) |
-| /chile | Datos Chile |
-| /admin | Administracion |
-| /settings | Configuracion |
-
-## Pares de Monedas y Criptomonedas
-
-La plataforma tiene una seccion "Par de Monedas" (/par-monedas) donde los usuarios pueden:
-1. Seleccionar una moneda DE (FROM) y una moneda A (TO)
-2. Ver el grafico historico del par
-3. Comparar multiples pares en un mismo grafico
-
-### Monedas FIAT disponibles
-USD, EUR, COP, MXN, BRL, AUD, JPY, CHF, GBP, NOK, SEK, HUF, PLN, CNY, INR, IDR, HKD, MYR, SGD
-
-Los pares FIAT se consultan desde la base de datos:
-- Tabla: xerenity.currency (formato: "USD:COP", "EUR:USD", etc.)
-- Funcion RPC: get_currency(currency_name TEXT)
-
-### Criptomonedas disponibles
-BTC, ETH, SOL, XRP, ADA, DOGE, AVAX, DOT, MATIC, LINK, BNB, LTC, UNI, ATOM, NEAR, APT, ARB, OP, FTM, ALGO
-
-**IMPORTANTE:** Los datos de criptomonedas NO estan en la base de datos de Xerenity. Se obtienen de una API externa (CryptoCompare) directamente desde el frontend. Por lo tanto:
-- NO puedes consultar precios de crypto con query_database
-- Si el usuario pregunta por Bitcoin, Ethereum, u otra crypto, usa navigate_to para llevarlo a /par-monedas donde puede seleccionar la crypto y la moneda base
-- Explica que los datos de crypto se visualizan en la seccion "Par de Monedas" seleccionando la crypto en el panel FROM y la moneda destino (USD, COP, etc.) en el panel TO
-
-### Monedas Dashboard (/monedas-dashboard)
-Otra vista para ver el dashboard de monedas principales con graficos resumidos.
-
-## Series de Datos
-
-La plataforma tiene un amplio catalogo de series economicas accesible desde /series:
-
-### Banrep (Banco de la Republica de Colombia)
-- Catalogo: xerenity.banrep_serie_v2 (id, nombre, description, fuente, grupo)
-- Valores: xerenity.banrep_series_value_v2 (id_serie, fecha, valor)
-- Para buscar series: SELECT id, nombre, description FROM xerenity.banrep_serie_v2 WHERE nombre ILIKE '%termino%' LIMIT 20
-- Para leer valores: SELECT fecha, valor FROM xerenity.banrep_series_value_v2 WHERE id_serie = X ORDER BY fecha DESC LIMIT 100
-
-### Camacol (Sector Construccion Colombia)
-- Catalogo: xerenity.camacol_serie (id, nombre, description, grupo)
-- Valores: xerenity.camacol_series_value (id_serie, fecha, valor)
-
-### BCRP (Banco Central del Peru)
-- Valores: xerenity.bcrp_series_value (id_serie, fecha, valor)
-
-### Series publicas
-- Catalogo general: xerenity.public_series — para buscar cualquier serie disponible
-
-## Ejemplos de Interaccion
-
-Usuario: "Cual es la TRM hoy?"
--> Usa query_database para consultar xerenity.currency WHERE currency='USD:COP' ORDER BY time DESC LIMIT 1
-
-Usuario: "Graficame el USDCOP del ultimo mes"
--> Busca ticker en xerenity.search_mv WHERE display_name ILIKE '%USD%COP%', luego usa view_series para abrir el graficador profesional
-
-Usuario: "Graficame el PIB de Colombia"
--> Busca ticker en xerenity.search_mv WHERE display_name ILIKE '%PIB%', luego usa view_series con el ticker encontrado
-
-Usuario: "Compara la inflacion con la politica monetaria"
--> Busca ambos tickers en xerenity.search_mv, luego usa view_series con ambos tickers para abrir el graficador
-
-Usuario: "Graficame la TRM"
--> Busca ticker en xerenity.search_mv WHERE display_name ILIKE '%TRM%' OR display_name ILIKE '%USD%COP%', luego usa view_series
-
-Usuario: "Llevame a prestamos"
--> Usa navigate_to con path="/loans"
-
-Usuario: "Crea una posicion NDF de 1M USD strike 4200 vencimiento junio 2026"
--> Muestra resumen y pide confirmacion, luego usa create_position
-
-Usuario: "Cual es el precio del Bitcoin?"
--> Usa navigate_to con path="/par-monedas" y explica que debe seleccionar BTC en el panel izquierdo y USD (o COP) en el panel derecho para ver el precio y grafico historico
-
-Usuario: "Graficame el Bitcoin vs Ethereum"
--> Usa navigate_to con path="/par-monedas" y explica que puede agregar multiples pares (BTC:USD y ETH:USD) para compararlos en el mismo grafico
-
-Usuario: "Que series economicas tienen de Colombia?"
--> Usa query_database para consultar SELECT id, nombre, description, grupo FROM xerenity.banrep_serie_v2 ORDER BY grupo, nombre LIMIT 50
-
-Usuario: "Muestrame la base monetaria de Colombia"
--> Usa query_database para buscar la serie en banrep_serie_v2, luego consultar sus valores y graficar
-`;
+  return [header, body].filter(Boolean).join('\n\n');
 }

--- a/src/store/agentConfig/index.ts
+++ b/src/store/agentConfig/index.ts
@@ -1,0 +1,153 @@
+import { StateCreator } from 'zustand';
+import type {
+  AgentSkill,
+  AgentSkillVersion,
+  AgentSuggestion,
+  NewSkill,
+  NewSuggestion,
+} from 'src/types/agent-config';
+import * as m from 'src/models/agentConfig';
+
+export interface AgentConfigSlice {
+  // Skills state
+  agentSkills: AgentSkill[];
+  agentSkillsLoading: boolean;
+  agentSkillsError: string | undefined;
+  agentSkillVersions: AgentSkillVersion[];
+  agentSkillVersionsLoading: boolean;
+
+  // Suggestions state
+  agentSuggestions: AgentSuggestion[];
+  agentSuggestionsLoading: boolean;
+
+  // Skills actions
+  loadAgentSkills: () => Promise<void>;
+  createAgentSkill: (skill: NewSkill) => Promise<{ success: boolean; error?: string }>;
+  updateAgentSkill: (
+    id: string,
+    updates: Partial<NewSkill>,
+    changeNote: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  toggleAgentSkill: (id: string, active: boolean) => Promise<{ success: boolean; error?: string }>;
+  deleteAgentSkill: (id: string) => Promise<{ success: boolean; error?: string }>;
+  loadAgentSkillVersions: (skillId: string) => Promise<void>;
+  revertAgentSkill: (
+    skillId: string,
+    versionId: string,
+    changeNote: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+
+  // Suggestions actions
+  loadAgentSuggestions: () => Promise<void>;
+  createAgentSuggestion: (s: NewSuggestion) => Promise<{ success: boolean; error?: string }>;
+  updateAgentSuggestion: (
+    id: string,
+    updates: Partial<NewSuggestion>,
+  ) => Promise<{ success: boolean; error?: string }>;
+  toggleAgentSuggestion: (
+    id: string,
+    active: boolean,
+  ) => Promise<{ success: boolean; error?: string }>;
+  deleteAgentSuggestion: (id: string) => Promise<{ success: boolean; error?: string }>;
+}
+
+const initialState = {
+  agentSkills: [],
+  agentSkillsLoading: false,
+  agentSkillsError: undefined,
+  agentSkillVersions: [],
+  agentSkillVersionsLoading: false,
+  agentSuggestions: [],
+  agentSuggestionsLoading: false,
+};
+
+const createAgentConfigSlice: StateCreator<AgentConfigSlice> = (set, get) => ({
+  ...initialState,
+
+  loadAgentSkills: async () => {
+    set({ agentSkillsLoading: true });
+    const res = await m.listAgentSkills();
+    set({
+      agentSkills: res.data,
+      agentSkillsError: res.error,
+      agentSkillsLoading: false,
+    });
+  },
+
+  createAgentSkill: async (skill) => {
+    const res = await m.createAgentSkill(skill);
+    if (res.success) await get().loadAgentSkills();
+    return res;
+  },
+
+  updateAgentSkill: async (id, updates, changeNote) => {
+    const res = await m.updateAgentSkill(id, updates, changeNote);
+    if (res.success) await get().loadAgentSkills();
+    return res;
+  },
+
+  toggleAgentSkill: async (id, active) => {
+    const res = await m.toggleAgentSkill(id, active);
+    if (res.success) await get().loadAgentSkills();
+    return res;
+  },
+
+  deleteAgentSkill: async (id) => {
+    const res = await m.deleteAgentSkill(id);
+    if (res.success) await get().loadAgentSkills();
+    return res;
+  },
+
+  loadAgentSkillVersions: async (skillId) => {
+    set({ agentSkillVersionsLoading: true });
+    const res = await m.listAgentSkillVersions(skillId);
+    set({
+      agentSkillVersions: res.data,
+      agentSkillVersionsLoading: false,
+    });
+  },
+
+  revertAgentSkill: async (skillId, versionId, changeNote) => {
+    const res = await m.revertAgentSkill(skillId, versionId, changeNote);
+    if (res.success) {
+      await get().loadAgentSkills();
+      await get().loadAgentSkillVersions(skillId);
+    }
+    return res;
+  },
+
+  loadAgentSuggestions: async () => {
+    set({ agentSuggestionsLoading: true });
+    const res = await m.listAgentSuggestions();
+    set({
+      agentSuggestions: res.data,
+      agentSuggestionsLoading: false,
+    });
+  },
+
+  createAgentSuggestion: async (s) => {
+    const res = await m.createAgentSuggestion(s);
+    if (res.success) await get().loadAgentSuggestions();
+    return res;
+  },
+
+  updateAgentSuggestion: async (id, updates) => {
+    const res = await m.updateAgentSuggestion(id, updates);
+    if (res.success) await get().loadAgentSuggestions();
+    return res;
+  },
+
+  toggleAgentSuggestion: async (id, active) => {
+    const res = await m.toggleAgentSuggestion(id, active);
+    if (res.success) await get().loadAgentSuggestions();
+    return res;
+  },
+
+  deleteAgentSuggestion: async (id) => {
+    const res = await m.deleteAgentSuggestion(id);
+    if (res.success) await get().loadAgentSuggestions();
+    return res;
+  },
+});
+
+export default createAgentConfigSlice;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,9 +10,10 @@ import createTradingSlice, { TradingSlice } from './trading';
 import createCurveSlice, { CurveSlice } from './curve';
 import createUserSlice, { UserSlice } from './user';
 import createChatSlice, { ChatSlice } from './chat';
+import createAgentConfigSlice, { AgentConfigSlice } from './agentConfig';
 
 const useAppStore = create<
-  LoansSlice & DashboardSlice & SeriesSlice & MarketDashboardSlice & TradingSlice & CurveSlice & UserSlice & ChatSlice
+  LoansSlice & DashboardSlice & SeriesSlice & MarketDashboardSlice & TradingSlice & CurveSlice & UserSlice & ChatSlice & AgentConfigSlice
 >()(
   devtools((...args) => ({
     ...createLoansSlice(...args),
@@ -23,6 +24,7 @@ const useAppStore = create<
     ...createCurveSlice(...args),
     ...createUserSlice(...args),
     ...createChatSlice(...args),
+    ...createAgentConfigSlice(...args),
   }))
 );
 

--- a/src/types/agent-config.ts
+++ b/src/types/agent-config.ts
@@ -1,0 +1,51 @@
+export interface AgentSkill {
+  id: string;
+  name: string;
+  description: string | null;
+  content: string;
+  active: boolean;
+  display_order: number;
+  current_version: number;
+  created_by: string | null;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AgentSkillVersion {
+  id: string;
+  skill_id: string;
+  version_number: number;
+  name: string;
+  description: string | null;
+  content: string;
+  change_note: string | null;
+  changed_by: string | null;
+  changed_by_email: string | null;
+  changed_at: string;
+}
+
+export interface AgentSuggestion {
+  id: string;
+  icon: string;
+  title: string;
+  prompt: string;
+  display_order: number;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface NewSkill {
+  name: string;
+  description: string;
+  content: string;
+  display_order: number;
+}
+
+export interface NewSuggestion {
+  icon: string;
+  title: string;
+  prompt: string;
+  display_order: number;
+}


### PR DESCRIPTION
## Summary
Super admins pueden entrenar al agente sin tocar codigo. Todo el conocimiento del agente (identidad, schema DB, tool rules, inteligencia economica, ejemplos) ahora vive en DB como skills modulares con historial completo y revert.

## Admin page: /admin/agent (super_admin only)
- **Skills tab**: CRUD con versionado. Cada edit crea version con nota obligatoria. Modal de historial muestra todas las versiones con revert.
- **Sugerencias tab**: CRUD simple para los botones del chat vacio.

## DB (ya aplicada)
- `xerenity.agent_skills` + `agent_skills_versions` + `agent_suggestions`
- RLS super_admin ALL / authenticated SELECT active
- 9 skills seedeados del prompt actual, 5 sugerencias
- 14 RPCs con SECURITY DEFINER

## Backend
- `system-prompt.ts` ahora async, lee de DB con cache 60s
- `/api/chat/suggestions` nuevo endpoint
- ChatPanel fetches suggestions en vez de array hardcoded

## Test plan
- [ ] /admin/agent accesible solo para super_admin
- [ ] Crear skill, ver aparece en el agente despues de 60s
- [ ] Editar skill con nota, ver nueva version en historial
- [ ] Revertir a version anterior funciona
- [ ] Toggle active off → skill desaparece del prompt
- [ ] CRUD sugerencias refleja en ChatPanel
- [ ] Gestor intenta /admin/agent → bloqueado

🤖 Generated with [Claude Code](https://claude.com/claude-code)