### PR TITLE
chore(deps): #311 setup TanStack Query v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@popperjs/core": "^2.11.8",
         "@supabase/auth-helpers-nextjs": "^0.8.1",
         "@supabase/supabase-js": "^2.38.0",
+        "@tanstack/react-query": "^5.100.5",
         "@tanstack/react-table": "^8.21.3",
         "@types/react-bootstrap": "^0.32.36",
         "@uiw/react-color-circle": "^2.0.3",
@@ -50,6 +51,7 @@
         "zustand": "^4.5.4"
       },
       "devDependencies": {
+        "@tanstack/react-query-devtools": "^5.100.5",
         "@types/node": "25.3.3",
         "@types/nprogress": "^0.2.0",
         "@types/react": "18.3.28",
@@ -2087,6 +2089,62 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.5.tgz",
+      "integrity": "sha512-t20KrhKkf0HXzqQkPbJ5erhFesup68BAbwFgYmTrS7bxMF7O5MdmL8jUkik4thsG7Hg00fblz30h6yF1d5TxGg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.100.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.5.tgz",
+      "integrity": "sha512-SuCkVCqqliRYJvm+LEL2U/TcFv92zTnHj6OGrJFHp1v/RsiwamI+ZDgQzbeUrLsJb8/Nj/52aIw0NyDMcVHl4A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.5.tgz",
+      "integrity": "sha512-aNwj1mi2v2bQ9IxkyR1grLOUkv3BYWoykHy9KDyLNbjC3tsahbOHJibK+Wjtr1wRhG59/AvJhiJG5OlthaCgJA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/query-core": "5.100.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.100.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.5.tgz",
+      "integrity": "sha512-bItQERx7dJoiI0WEoS4tIrvNnmk4kUYsaQLdIpm4o9Kttmsi5B6xlY6JBDkavstR3hH/R2+VT5dr3L5LBFPW4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.100.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.100.5",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-table": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@supabase/auth-helpers-nextjs": "^0.8.1",
         "@supabase/supabase-js": "^2.38.0",
         "@tanstack/react-query": "^5.100.5",
+        "@tanstack/react-query-devtools": "^5.100.5",
         "@tanstack/react-table": "^8.21.3",
         "@types/react-bootstrap": "^0.32.36",
         "@uiw/react-color-circle": "^2.0.3",
@@ -51,7 +52,6 @@
         "zustand": "^4.5.4"
       },
       "devDependencies": {
-        "@tanstack/react-query-devtools": "^5.100.5",
         "@types/node": "25.3.3",
         "@types/nprogress": "^0.2.0",
         "@types/react": "18.3.28",
@@ -2105,7 +2105,6 @@
       "version": "5.100.5",
       "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.5.tgz",
       "integrity": "sha512-SuCkVCqqliRYJvm+LEL2U/TcFv92zTnHj6OGrJFHp1v/RsiwamI+ZDgQzbeUrLsJb8/Nj/52aIw0NyDMcVHl4A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2133,7 +2132,6 @@
       "version": "5.100.5",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.5.tgz",
       "integrity": "sha512-bItQERx7dJoiI0WEoS4tIrvNnmk4kUYsaQLdIpm4o9Kttmsi5B6xlY6JBDkavstR3hH/R2+VT5dr3L5LBFPW4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-devtools": "5.100.5"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@popperjs/core": "^2.11.8",
     "@supabase/auth-helpers-nextjs": "^0.8.1",
     "@supabase/supabase-js": "^2.38.0",
+    "@tanstack/react-query": "^5.100.5",
     "@tanstack/react-table": "^8.21.3",
     "@types/react-bootstrap": "^0.32.36",
     "@uiw/react-color-circle": "^2.0.3",
@@ -58,6 +59,7 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
+    "@tanstack/react-query-devtools": "^5.100.5",
     "@types/node": "25.3.3",
     "@types/nprogress": "^0.2.0",
     "@types/react": "18.3.28",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@supabase/auth-helpers-nextjs": "^0.8.1",
     "@supabase/supabase-js": "^2.38.0",
     "@tanstack/react-query": "^5.100.5",
+    "@tanstack/react-query-devtools": "^5.100.5",
     "@tanstack/react-table": "^8.21.3",
     "@types/react-bootstrap": "^0.32.36",
     "@uiw/react-color-circle": "^2.0.3",
@@ -59,7 +60,6 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
-    "@tanstack/react-query-devtools": "^5.100.5",
     "@types/node": "25.3.3",
     "@types/nprogress": "^0.2.0",
     "@types/react": "18.3.28",

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,31 @@
+/**
+ * TanStack Query client configuration for xerenity-fe.
+ *
+ * Defaults are tuned for a financial dashboard:
+ * - `staleTime: 30s` — most pricing/loans data is fresh enough to show without
+ *   refetching on every mount; individual hooks override when they need
+ *   shorter (live reprice) or longer (catalogs, marks).
+ * - `retry: 1` — pricing endpoints fail fast on bad input; one retry is enough
+ *   to recover from transient network issues without blocking the UI.
+ * - `refetchOnWindowFocus: false` — re-running a 30-position reprice every
+ *   time the user tabs back is wasteful and surprising.
+ * - `gcTime: 5min` — keep responses around so navigating between pages reuses
+ *   cache (vs. the previous Zustand store which dropped data on unmount).
+ *
+ * Tracked in epic #299, sub-issue #311 (Fase 2 — TanStack Query setup).
+ */
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 5 * 60_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+});

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -16,7 +16,7 @@
  */
 import { QueryClient } from '@tanstack/react-query';
 
-export const queryClient = new QueryClient({
+const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 30_000,
@@ -29,3 +29,5 @@ export const queryClient = new QueryClient({
     },
   },
 });
+
+export default queryClient;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,8 +7,16 @@ import { config } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import { ProgressBar } from '@components/ProgressBar';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import dynamic from 'next/dynamic';
 import { queryClient } from 'src/lib/queryClient';
+
+// Devtools is a devDependency — Vercel production builds skip dev deps, so
+// importing it unconditionally fails the build. Dynamic-import it and keep
+// the chunk out of the production bundle entirely.
+const ReactQueryDevtools = dynamic(
+  () => import('@tanstack/react-query-devtools').then((m) => m.ReactQueryDevtools),
+  { ssr: false },
+);
 
 // You change this configuration value to false so that the Font Awesome core SVG library
 // will not try and insert <style> elements into the <head> of the page.

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,9 @@ import { Inter } from 'next/font/google';
 import { config } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import { ProgressBar } from '@components/ProgressBar';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { queryClient } from 'src/lib/queryClient';
 
 // You change this configuration value to false so that the Font Awesome core SVG library
 // will not try and insert <style> elements into the <head> of the page.
@@ -23,7 +26,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   // to ensure that the auto-generated ids are consistent between the server and client.
   // https://react-bootstrap.github.io/getting-started/server-side-rendering/
   return (
-    <>
+    <QueryClientProvider client={queryClient}>
       <style jsx global>{`
         html {
           font-family: ${inter.style.fontFamily};
@@ -35,7 +38,10 @@ function MyApp({ Component, pageProps }: AppProps) {
       <ProgressBar />
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <Component {...pageProps} />
-    </>
+      {process.env.NODE_ENV !== 'production' && (
+        <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-right" />
+      )}
+    </QueryClientProvider>
   );
 }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,7 +8,7 @@ import '@fortawesome/fontawesome-svg-core/styles.css';
 import { ProgressBar } from '@components/ProgressBar';
 import { QueryClientProvider } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
-import { queryClient } from 'src/lib/queryClient';
+import queryClient from 'src/lib/queryClient';
 
 // Devtools is a devDependency — Vercel production builds skip dev deps, so
 // importing it unconditionally fails the build. Dynamic-import it and keep


### PR DESCRIPTION
## Summary

- Sub-issue #311 — primer paso de Fase 2 (#299).
- **Solo plumbing.** Sin esto los siguientes sub-issues (#312-#318) no compilan, pero por sí solo no cambia ningún componente ni comportamiento.

## Cambios

- `npm install @tanstack/react-query@^5 @tanstack/react-query-devtools@^5`
- [src/lib/queryClient.ts](src/lib/queryClient.ts): nuevo. Defaults tuneados para app financiera:
  - `staleTime: 30s` — pricing/loans frescos sin refetch en cada mount
  - `gcTime: 5min` — navegar entre páginas reusa cache
  - `retry: 1` — recovery transient sin bloquear UI
  - `refetchOnWindowFocus: false` — no re-priceamos al hacer alt-tab
- [src/pages/_app.tsx](src/pages/_app.tsx): `QueryClientProvider` envuelve la app + `ReactQueryDevtools` cuando `NODE_ENV !== 'production'`.

## Test plan

- [x] `npx tsc --noEmit` limpio
- [x] `npm run lint` sin errores nuevos
- [ ] Manual en dev: floating button de devtools visible esquina inferior-derecha
- [ ] Manual: abrir devtools panel — debe estar vacío (ningún hook usa queries todavía)
- [ ] Manual: navegar páginas, comportamiento idéntico al main actual

## Siguiente

- #312 — Migrar read-only queries simples (curveStatus, marks, catalogs). Esto sí va a poblar el devtools.

Closes #311
Refs #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
