### PR TITLE
feat(queries): #312 hooks read-only de pricing (TanStack Query)

### DIFF
--- a/src/pages/coltes-calculator/index.tsx
+++ b/src/pages/coltes-calculator/index.tsx
@@ -28,10 +28,10 @@ import {
 } from 'recharts';
 import {
   priceTesBond,
-  getTesCatalog,
   getTesYieldCurve,
   type TesBondRequest,
 } from 'src/models/pricing/pricingApi';
+import { useTesCatalog } from 'src/queries/pricing';
 import type {
   TesBondResult,
   TesBondCashflow,
@@ -140,7 +140,8 @@ function ColTesCalculator() {
   const [loading, setLoading] = useState(false);
 
   // Catalog
-  const [catalog, setCatalog] = useState<TesCatalogItem[]>([]);
+  const { data: catalogData } = useTesCatalog();
+  const catalog: TesCatalogItem[] = catalogData?.length ? catalogData : MOCK_CATALOG;
   const [catalogMode, setCatalogMode] = useState(true);
   const [selectedBond, setSelectedBond] = useState<string>('');
 
@@ -169,13 +170,6 @@ function ColTesCalculator() {
   const [result, setResult] = useState<TesBondResult | null>(null);
   const [cashflows, setCashflows] = useState<TesBondCashflow[]>([]);
   const [yieldCurve, setYieldCurve] = useState<TesYieldCurvePoint[]>([]);
-
-  // Load catalog on mount
-  useEffect(() => {
-    getTesCatalog()
-      .then((data) => setCatalog(data?.length ? data : MOCK_CATALOG))
-      .catch(() => setCatalog(MOCK_CATALOG));
-  }, []);
 
   // When a bond is selected from catalog, prefill params
   useEffect(() => {

--- a/src/pages/marks/index.tsx
+++ b/src/pages/marks/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { CoreLayout } from '@layout';
 import Container from 'react-bootstrap/Container';
 import PageTitle from '@components/PageTitle';
@@ -9,7 +9,8 @@ import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip,
   ResponsiveContainer, ReferenceLine,
 } from 'recharts';
-import { getMarks, type MarketMarkRow } from 'src/models/pricing/pricingApi';
+import { type MarketMarkRow } from 'src/models/pricing/pricingApi';
+import { useMarks } from 'src/queries/pricing';
 import styles from './marks.module.css';
 
 const PAGE_TITLE = 'Marcas de Mercado';
@@ -150,9 +151,6 @@ export function MarksContent({
   selectedDate?: string | null;
   onSelectDate?: (fecha: string) => void;
 } = {}) {
-  const [rows, setRows]       = useState<MarketMarkRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError]     = useState<string | null>(null);
   const [internalSelected, setInternalSelected] = useState<string | null>(null);
 
   const selected = selectedDate !== undefined ? selectedDate : internalSelected;
@@ -161,12 +159,8 @@ export function MarksContent({
     onSelectDate?.(ymd);
   };
 
-  useEffect(() => {
-    getMarks()
-      .then((res) => { setRows(res.marks); })
-      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Error'))
-      .finally(() => setLoading(false));
-  }, []);
+  const { data: marksData, isLoading: loading, error } = useMarks();
+  const rows: MarketMarkRow[] = marksData?.marks ?? [];
 
   const byDate = Object.fromEntries(rows.map((r) => [r.fecha, r]));
   const detail = selected ? byDate[selected] : null;
@@ -186,7 +180,7 @@ export function MarksContent({
   }
 
   if (loading) return <p className={styles.muted}>Cargando marcas...</p>;
-  if (error)   return <p className={styles.danger}>Error: {error}</p>;
+  if (error)   return <p className={styles.danger}>Error: {error instanceof Error ? error.message : String(error)}</p>;
 
   return (
     <div>

--- a/src/pages/tes-portfolio/index.tsx
+++ b/src/pages/tes-portfolio/index.tsx
@@ -27,7 +27,8 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
-import { getTesCatalog, getTesYieldCurve } from 'src/models/pricing/pricingApi';
+import { getTesYieldCurve } from 'src/models/pricing/pricingApi';
+import { useTesCatalog } from 'src/queries/pricing';
 import type { TesCatalogItem, TesYieldCurvePoint } from 'src/types/pricing';
 import type { PricedTesBond, NewTesPosition } from 'src/types/trading';
 import useAppStore from 'src/store';
@@ -836,8 +837,8 @@ function TesPortfolioPage() {
   const [viewTab, setViewTab] = useState<'posiciones' | 'curva'>('posiciones');
   const [showAdd, setShowAdd] = useState(false);
   const [selectedBond, setSelectedBond] = useState<PricedTesBond | null>(null);
-  const [catalog, setCatalog] = useState<TesCatalogItem[]>([]);
-  const [catalogLoading, setCatalogLoading] = useState(false);
+  const { data: catalogQueryData, isLoading: catalogLoading } = useTesCatalog();
+  const catalog: TesCatalogItem[] = catalogQueryData ?? [];
 
   const {
     tesPositions,
@@ -854,15 +855,10 @@ function TesPortfolioPage() {
     selectedCompanyId,
   } = useAppStore();
 
-  // Mount: load positions + role + catalog
+  // Mount: load positions + role (catalog now comes from useTesCatalog)
   useEffect(() => {
     loadTesPositions(activeCompanyId());
     loadUserRole();
-    setCatalogLoading(true);
-    getTesCatalog()
-      .then(setCatalog)
-      .catch(() => {})
-      .finally(() => setCatalogLoading(false));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadTesPositions, loadUserRole, selectedCompanyId]);
 

--- a/src/queries/pricing.ts
+++ b/src/queries/pricing.ts
@@ -1,0 +1,101 @@
+/**
+ * TanStack Query hooks for pricing endpoints.
+ *
+ * Phase 2 (#299) sub-issue #312 — read-only queries with stable keys. These
+ * replace ad-hoc `useEffect` + `useState` + `await getXxx()` patterns
+ * throughout the app, giving us automatic dedupe (multiple components asking
+ * for the same data → single fetch), cache, and AbortSignal cancellation.
+ *
+ * Convention: every hook returns the standard `useQuery` result. `signal`
+ * from the query lifecycle flows into the underlying fetcher (#292) so
+ * unmounting or invalidating cancels the in-flight request.
+ *
+ * Stale times are tuned per endpoint:
+ * - Curves change when marks are loaded — 30s is fine.
+ * - Catalogs and historical marks change rarely — 10 min.
+ */
+import { useQuery } from '@tanstack/react-query';
+import {
+  getCurveStatus,
+  getNdfImpliedCurve,
+  getIbrParCurve,
+  getTesCatalog,
+  getMarksDates,
+  getMarks,
+  getMarkByDate,
+} from 'src/models/pricing/pricingApi';
+
+export const pricingKeys = {
+  curveStatus: ['pricing', 'curveStatus'] as const,
+  ndfImpliedCurve: ['pricing', 'ndfImpliedCurve'] as const,
+  ibrParCurve: ['pricing', 'ibrParCurve'] as const,
+  tesCatalog: ['pricing', 'tesCatalog'] as const,
+  marksDates: ['pricing', 'marksDates'] as const,
+  marks: ['pricing', 'marks'] as const,
+  markByDate: (fecha: string) => ['pricing', 'marks', fecha] as const,
+};
+
+export function useCurveStatus(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: pricingKeys.curveStatus,
+    queryFn: ({ signal }) => getCurveStatus({ signal }),
+    enabled: options?.enabled ?? true,
+    staleTime: 30_000,
+  });
+}
+
+export function useNdfImpliedCurve(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: pricingKeys.ndfImpliedCurve,
+    queryFn: ({ signal }) => getNdfImpliedCurve({ signal }),
+    enabled: options?.enabled ?? true,
+    staleTime: 30_000,
+  });
+}
+
+export function useIbrParCurve(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: pricingKeys.ibrParCurve,
+    queryFn: ({ signal }) => getIbrParCurve({ signal }),
+    enabled: options?.enabled ?? true,
+    staleTime: 30_000,
+  });
+}
+
+export function useTesCatalog(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: pricingKeys.tesCatalog,
+    queryFn: ({ signal }) => getTesCatalog({ signal }),
+    enabled: options?.enabled ?? true,
+    // Catalog rarely changes — keep it warm for 10 min.
+    staleTime: 10 * 60_000,
+  });
+}
+
+export function useMarksDates(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: pricingKeys.marksDates,
+    queryFn: ({ signal }) => getMarksDates({ signal }),
+    enabled: options?.enabled ?? true,
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useMarks(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: pricingKeys.marks,
+    queryFn: ({ signal }) => getMarks({ signal }),
+    enabled: options?.enabled ?? true,
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useMarkByDate(fecha: string | null | undefined) {
+  return useQuery({
+    queryKey: pricingKeys.markByDate(fecha ?? ''),
+    queryFn: ({ signal }) => getMarkByDate(fecha as string, { signal }),
+    // Don't fire when no date is selected.
+    enabled: !!fecha,
+    staleTime: 5 * 60_000,
+  });
+}


### PR DESCRIPTION
## Summary

- Sub-issue #312 — primera migración real de Fase 2 (#299).
- Crea `src/queries/pricing.ts` con 7 hooks de TanStack Query.
- Migra 3 consumidores que usaban patrón `useEffect + useState + await getXxx()` a `useXxx()`.
- **No toca portfolio ni los button-handlers imperativos** — eso queda para sub-issues siguientes.

## Hooks creados ([src/queries/pricing.ts](src/queries/pricing.ts))

- `useCurveStatus()` — staleTime 30s
- `useNdfImpliedCurve()` — staleTime 30s
- `useIbrParCurve()` — staleTime 30s
- `useTesCatalog()` — staleTime 10min (rara vez cambia)
- `useMarksDates()` — staleTime 5min
- `useMarks()` — staleTime 5min
- `useMarkByDate(fecha)` — staleTime 5min, `enabled: !!fecha`

Cada hook respeta el `AbortSignal` de la query lifecycle (enchufado a `pricingApi` via #292).

## Consumidores migrados

| Archivo | Antes | Después |
|---|---|---|
| `pages/marks/index.tsx` | `useState<MarketMarkRow[]>([])` + `useEffect(() => getMarks().then(setRows))` | `const { data, isLoading, error } = useMarks()` |
| `pages/coltes-calculator/index.tsx` | `useState<TesCatalogItem[]>([])` + `useEffect` con fallback a MOCK | `useTesCatalog()` + selector |
| `pages/tes-portfolio/index.tsx` | `setCatalogLoading(true)` + manual fetch | `const { isLoading: catalogLoading } = useTesCatalog()` |

## Beneficios automáticos

1. **Dedupe**: si dos componentes piden el mismo catalog en la misma vista, solo se hace 1 fetch.
2. **Cache compartido**: navegar entre `/coltes-calculator` y `/tes-portfolio` no refetcha el catalog.
3. **AbortSignal**: desmontar el componente antes que termine la query cancela el fetch.
4. **`staleTime` tuneado**: catalogs frescos 10 min, curves 30s.

## Sin migrar (scope futuro)

- **Button-handler imperative usages** en `ndf-pricer`, `copndf`, `ibr-swap` — llaman `getXxx()` en click. Se migran con `useQuery({enabled:false}) + refetch()` en sub-issue follow-up.
- **`portfolio/index.tsx` getCurveStatus** — acoplado con local state + `buildCurves`. Lo migra #313 que ya toca portfolio extensivamente.
- **`store/curve`, `models/trading/fetchHistoricalMark`** — wrappers con acoplamientos. Scope #318 cleanup.

## Test plan

- [x] `npx tsc --noEmit` limpio
- [x] `npm run build` con dummy env vars: 70/70 static pages generadas, sin errors
- [ ] Manual: abrir `/marks` — devtools panel debe mostrar query `[pricing, marks]` activa
- [ ] Manual: navegar `/coltes-calculator` → `/tes-portfolio` → ver query `[pricing, tesCatalog]` cacheada (no se refetcha)

## Siguiente

- #313 — useRepricePortfolio (la migración grande)

Closes #312
Refs #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
