### PR TITLE
feat(portfolio): #313 useRepricePortfolio — matar dual-toast y reprice flicker

### DIFF
--- a/src/pages/portfolio/index.tsx
+++ b/src/pages/portfolio/index.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable no-nested-ternary, no-underscore-dangle, no-restricted-syntax, prefer-template, jsx-a11y/control-has-associated-label */
 import { CoreLayout } from '@layout';
 import { Row, Col, Form, Modal } from 'react-bootstrap';
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import Container from 'react-bootstrap/Container';
 import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import {
@@ -32,6 +32,8 @@ import {
   getNdfSettlement,
 } from 'src/models/pricing/pricingApi';
 import type { NdfSettlementResult } from 'src/models/pricing/pricingApi';
+import { useRepricePortfolio } from 'src/queries/pricing';
+import { useQueryClient } from '@tanstack/react-query';
 import { fetchHistoricalMark } from 'src/models/trading/fetchHistoricalMark';
 import type { CurveStatus } from 'src/types/pricing';
 import type {
@@ -1927,10 +1929,8 @@ function PortfolioPage() {
   const [markFecha, setMarkFecha] = useState<string>(defaultMarkFecha());
   const [curveStatus, setCurveStatus] = useState<CurveStatus | null>(null);
   const [addType, setAddType] = useState<string | null>(null); // 'xccy' | 'ndf' | 'ibr' | null
-  // #295: bump this counter whenever positions change and we want a reprice.
-  // Keeps the reprice trigger in ONE place (the useEffect below) — callbacks
-  // just bump this instead of calling repriceAllWithMark directly.
-  const [repriceTrigger, setRepriceTrigger] = useState(0);
+  // (#313 removed repriceTrigger — useRepricePortfolio's key includes position
+  //  IDs, so adding/removing a position triggers refetch automatically.)
   const { prefs: blotterPrefs, setPrefs: setBlotterPrefs } = useBlotterPreferences();
   const [selectedXccy, setSelectedXccy] = useState<PricedXccy | null>(null);
   const [selectedNdf, setSelectedNdf] = useState<PricedNdf | null>(null);
@@ -1943,15 +1943,8 @@ function PortfolioPage() {
     xccyPositions,
     ndfPositions,
     ibrSwapPositions,
-    pricedXccy,
-    pricedNdf,
-    pricedIbrSwap,
-    summary,
-    pricedAt,
-    tradingLoading,
     tradingError,
     loadPositions,
-    repriceAllWithMark,
     addXccyPosition,
     addNdfPosition,
     addIbrSwapPosition,
@@ -1970,6 +1963,12 @@ function PortfolioPage() {
     selectedCompanyId,
   } = useAppStore();
 
+  // Track when the user explicitly requested a reprice via the toolbar button
+  // — used to surface a toast when the next query lands. Without it, every
+  // automatic refetch (e.g. when a position is added) would also pop a toast.
+  const reprintRequestedRef = useRef(false);
+  const queryClient = useQueryClient();
+
   const handleBuild = useCallback(async (silent = false) => {
     setLoading(true);
     try {
@@ -1984,23 +1983,64 @@ function PortfolioPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleRepriceWithMark = useCallback(async (fecha: string) => {
-    setMarkRepricing(true);
-    try {
-      await repriceAllWithMark(fecha);
-      toast.success(`Portafolio valorado con marca ${fecha}`);
-      // Cargar precios de referencia en segundo plano (no bloquea la UI)
-      loadReferencePrices(fecha).catch(() => {});
-    } catch (e) {
-      toast.error(`Error al valorar: ${e instanceof Error ? e.message : String(e)}`);
-    } finally {
-      setMarkRepricing(false);
-    }
-  }, [repriceAllWithMark, loadReferencePrices]);
+  // #313 — `useRepricePortfolio` replaces the old `repriceAllWithMark` action.
+  // The query key includes `markFecha` and the sorted position IDs, so any
+  // change (date pick, add/remove position) triggers a fresh query and aborts
+  // the previous in-flight one automatically.
+  const reprice = useRepricePortfolio({
+    xccy: xccyPositions,
+    ndf: ndfPositions,
+    ibr: ibrSwapPositions,
+    valuationDate: markFecha,
+    enabled: !!(curveStatus?.ibr.built && curveStatus?.sofr.built),
+  });
+  const pricedXccy = reprice.data?.xccy_results ?? [];
+  const pricedNdf = reprice.data?.ndf_results ?? [];
+  const pricedIbrSwap = reprice.data?.ibr_swap_results ?? [];
+  const summary = reprice.data?.summary ?? null;
+  const tradingLoading = reprice.isFetching;
+  const pricedAt = reprice.dataUpdatedAt
+    ? new Date(reprice.dataUpdatedAt).toLocaleTimeString('es-CO', {
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+      })
+    : undefined;
 
-  const handleReprice = useCallback(async () => {
-    await handleRepriceWithMark(markFecha);
-  }, [handleRepriceWithMark, markFecha]);
+  // Toast only when the user explicitly hit "Repricear" — automatic refetches
+  // (date change, position added) should be silent. The dual-toast bug from
+  // the legacy code path was caused by aborted reprices firing toast.success.
+  // With useQuery, `dataUpdatedAt` only advances when the *current* query
+  // resolved successfully — aborted queries never touch this clock.
+  useEffect(() => {
+    if (!reprintRequestedRef.current) return;
+    if (reprice.isFetching) return;
+    if (reprice.isSuccess) {
+      toast.success(`Portafolio valorado con marca ${markFecha}`);
+      loadReferencePrices(markFecha).catch(() => {});
+      reprintRequestedRef.current = false;
+    } else if (reprice.isError) {
+      const msg = reprice.error instanceof Error ? reprice.error.message : String(reprice.error);
+      toast.error(`Error al valorar: ${msg}`);
+      reprintRequestedRef.current = false;
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reprice.isFetching, reprice.isSuccess, reprice.isError, reprice.dataUpdatedAt]);
+
+  // Background-load reference prices whenever the date or set of positions
+  // changes (the store de-dupes by date internally, so this is cheap).
+  useEffect(() => {
+    if (!(curveStatus?.ibr.built && curveStatus?.sofr.built)) return;
+    if (!markFecha) return;
+    loadReferencePrices(markFecha).catch(() => {});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [markFecha, curveStatus?.ibr.built, curveStatus?.sofr.built, xccyPositions.length, ndfPositions.length, ibrSwapPositions.length]);
+
+  const handleReprice = useCallback(() => {
+    reprintRequestedRef.current = true;
+    setMarkRepricing(true);
+    queryClient
+      .invalidateQueries({ queryKey: ['pricing', 'reprice'] })
+      .finally(() => setMarkRepricing(false));
+  }, [queryClient]);
 
   // Auto-load on mount: init curves + load positions + role + market data config
   useEffect(() => {
@@ -2034,17 +2074,9 @@ function PortfolioPage() {
   const curvesReady =
     curveStatus?.ibr.built && curveStatus?.sofr.built;
 
-  // #295 — SINGLE trigger for reprice. Inputs:
-  //   - curvesReady flips true after mount
-  //   - markFecha changes (user picked new date)
-  //   - repriceTrigger bumps (position added/removed, manual "Repricear" button)
-  // Everyone else that used to call repriceAllWithMark directly now just bumps
-  // repriceTrigger. The store's token + AbortController (#293) serializes.
-  useEffect(() => {
-    if (!curvesReady) return;
-    handleRepriceWithMark(markFecha);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [curvesReady, markFecha, repriceTrigger]);
+  // (#313 removed the manual reprice trigger useEffect — useRepricePortfolio
+  //  reacts automatically to curveStatus, markFecha and position changes via
+  //  its query key. The repriceTrigger counter from #295 is also obsolete.)
 
   const handleDelete = useCallback(
     (id: string, type: string) => {
@@ -2289,14 +2321,16 @@ function PortfolioPage() {
           <MarksContent selectedDate={markFecha} onSelectDate={setMarkFecha} />
         )}
 
-        {/* Add Modals */}
+        {/* Add Modals — adding a position changes xccyPositions/ndfPositions/
+            ibrSwapPositions; useRepricePortfolio sees the new position list in
+            its query key and refetches automatically. No manual reprice trigger
+            needed (#313). */}
         <AddXccyModal
           show={addType === 'xccy'}
           onHide={() => setAddType(null)}
           onSave={async (v) => {
             await addXccyPosition(v);
             toast.success('Posicion XCCY creada');
-            setRepriceTrigger((n) => n + 1);
           }}
         />
         <AddNdfModal
@@ -2305,7 +2339,6 @@ function PortfolioPage() {
           onSave={async (v) => {
             await addNdfPosition(v);
             toast.success('Posicion NDF creada');
-            setRepriceTrigger((n) => n + 1);
           }}
         />
         <AddIbrSwapModal
@@ -2314,7 +2347,6 @@ function PortfolioPage() {
           onSave={async (v) => {
             await addIbrSwapPosition(v);
             toast.success('Posicion IBR Swap creada');
-            setRepriceTrigger((n) => n + 1);
           }}
         />
         {/* Detail Modals */}

--- a/src/queries/pricing.ts
+++ b/src/queries/pricing.ts
@@ -24,6 +24,12 @@ import {
   getMarks,
   getMarkByDate,
 } from 'src/models/pricing/pricingApi';
+import { repricePortfolio } from 'src/models/trading/repricePortfolio';
+import type {
+  XccyPosition,
+  NdfPosition,
+  IbrSwapPosition,
+} from 'src/types/trading';
 
 export const pricingKeys = {
   curveStatus: ['pricing', 'curveStatus'] as const,
@@ -33,6 +39,15 @@ export const pricingKeys = {
   marksDates: ['pricing', 'marksDates'] as const,
   marks: ['pricing', 'marks'] as const,
   markByDate: (fecha: string) => ['pricing', 'marks', fecha] as const,
+  reprice: (
+    valuationDate: string,
+    xccyIds: string[],
+    ndfIds: string[],
+    ibrIds: string[],
+  ) => [
+    'pricing', 'reprice', valuationDate,
+    [...xccyIds].sort(), [...ndfIds].sort(), [...ibrIds].sort(),
+  ] as const,
 };
 
 export function useCurveStatus(options?: { enabled?: boolean }) {
@@ -99,3 +114,67 @@ export function useMarkByDate(fecha: string | null | undefined) {
     staleTime: 5 * 60_000,
   });
 }
+
+/**
+ * #313 — Reprice the entire derivatives portfolio (xccy + ndf + ibr swaps)
+ * for a given valuation date.
+ *
+ * Replaces `repriceAllWithMark` from `src/store/trading/index.ts`. The store
+ * version manually managed a token + AbortController to drop stale results
+ * (NPV flicker fix from #293); TanStack does it natively via the queryKey
+ * (changing date or position list = new query, old one is cancelled).
+ *
+ * Why the key includes sorted IDs (not the full positions array):
+ * - Object identity changes on every render even when content is the same,
+ *   which would cause infinite refetches.
+ * - Sorting makes `[a,b,c]` and `[c,a,b]` (same set, different order) hit
+ *   the same cache entry.
+ * - When the user adds/removes a position, the ID set changes → new key →
+ *   automatic refetch. This replaces the `repriceTrigger` counter from #295.
+ *
+ * Why this is a fix for the dual-toast bug the user reported:
+ * - Old flow: `await repriceAllWithMark(A); toast.success(A);`. When A was
+ *   aborted by a newer call B, the store returned silently and the page
+ *   thought A succeeded → fired toast.success(A). User saw two toasts.
+ * - New flow: TanStack's `onSuccess` only fires when the query for the
+ *   *current* key resolves successfully. Aborted previous queries simply
+ *   never trigger any side-effect callback.
+ */
+export interface UseRepricePortfolioInput {
+  xccy: XccyPosition[];
+  ndf: NdfPosition[];
+  ibr: IbrSwapPosition[];
+  /** Valuation date in YYYY-MM-DD. */
+  valuationDate: string;
+  enabled?: boolean;
+}
+
+export function useRepricePortfolio(input: UseRepricePortfolioInput) {
+  const { xccy, ndf, ibr, valuationDate, enabled = true } = input;
+
+  // Filter positions whose start/trade date is after the valuation date —
+  // those instruments did not exist as of `valuationDate` and pysdk would
+  // either error or produce nonsense for them. Same logic as the legacy
+  // `repriceAllWithMark` action in the store.
+  const filteredXccy = xccy.filter((p) => p.start_date <= valuationDate);
+  const filteredNdf = ndf.filter((p) => !p.trade_date || p.trade_date <= valuationDate);
+  const filteredIbr = ibr.filter((p) => p.start_date <= valuationDate);
+
+  return useQuery({
+    queryKey: pricingKeys.reprice(
+      valuationDate,
+      filteredXccy.map((p) => p.id),
+      filteredNdf.map((p) => p.id),
+      filteredIbr.map((p) => p.id),
+    ),
+    queryFn: ({ signal }) =>
+      repricePortfolio(filteredXccy, filteredNdf, filteredIbr, {
+        valuation_date: valuationDate,
+        signal,
+      }),
+    // No data to reprice — return an empty result rather than fetching.
+    enabled: enabled && (filteredXccy.length + filteredNdf.length + filteredIbr.length) > 0,
+    staleTime: 30_000,
+  });
+}
+


### PR DESCRIPTION
## Summary

- Sub-issue #313 — la migración análoga a #316 pero del lado **derivados**.
- **Mata el bug reportado por el usuario:** "aparecían dos NPVs / dos toasts uno tras otro" al cambiar fechas en portfolio.
- Reemplaza el callsite de `pages/portfolio/index.tsx` que usaba `repriceAllWithMark` del store por `useRepricePortfolio` (TanStack Query).

## Por qué fallaba antes (root cause del dual-toast)

```ts
// Antes en pages/portfolio/index.tsx:
const handleRepriceWithMark = async (fecha: string) => {
  try {
    await repriceAllWithMark(fecha);
    toast.success(`valorado con marca ${fecha}`);  // ← acá se equivoca
  } catch (e) { ... }
};
```

Flujo problemático:
1. `handleRepriceWithMark(A)` en vuelo. 
2. Usuario cambia fecha a B. 
3. `repriceAllWithMark(B)` aborta A vía AbortController.
4. `repriceAllWithMark` del store hace `if (isAbortError(e)) return;` — **retorna silenciosamente**.
5. La promesa de `handleRepriceWithMark(A)` resuelve sin throw. El page cree que A funcionó → `toast.success(A)`.
6. B completa → `toast.success(B)`.
7. **Usuario ve dos toasts con dos fechas, NPV se ve como si hubiera dos marcas en juego.**

## Cómo lo arregla TanStack

- `useRepricePortfolio` con key `[valuationDate, sortedXccyIds, sortedNdfIds, sortedIbrIds]`.
- Cambiar fecha o lista de posiciones = nueva key = nueva query. La vieja se aborta.
- **TanStack no llama `onSuccess` / `dataUpdatedAt` para queries abortadas.** Solo la query de la fecha actual puede disparar side-effects.
- Adicional: un `reprintRequestedRef` guarda toast solo cuando el usuario apretó "Repricear" — los refetch automáticos (cambio de fecha, posición agregada) son silenciosos como deben ser.

## Cambios

### Nuevo en [src/queries/pricing.ts](src/queries/pricing.ts)

- `pricingKeys.reprice(valuationDate, xccyIds, ndfIds, ibrIds)` — sorts ids para que orden no afecte cache.
- `useRepricePortfolio({xccy, ndf, ibr, valuationDate, enabled})`:
  - Filtra posiciones cuya `start_date`/`trade_date` sea posterior a `valuationDate` (misma lógica que el store legacy).
  - `enabled` flag para no fetchear hasta que las curvas estén construidas.
  - `staleTime: 30s`.

### [src/pages/portfolio/index.tsx](src/pages/portfolio/index.tsx)

**Removido del destructure de `useAppStore`:**
- `pricedXccy, pricedNdf, pricedIbrSwap, summary, pricedAt, tradingLoading, repriceAllWithMark`

**Esos valores ahora derivan del hook:**
```ts
const reprice = useRepricePortfolio({ xccy, ndf, ibr, valuationDate: markFecha, enabled: curvesReady });
const pricedXccy = reprice.data?.xccy_results ?? [];
// ... etc
```

**Eliminado:**
- `handleRepriceWithMark` (función con el toast bug)
- `handleReprice` (versión vieja que llamaba al primero)
- `useEffect([curvesReady, markFecha, repriceTrigger])` (el manual trigger)
- `repriceTrigger` / `setRepriceTrigger` state (el counter de #295 ya no necesario)
- `setRepriceTrigger((n) => n + 1)` en los 3 onSave de modales (XCCY/NDF/IBR)

**Nuevo:**
- `handleReprice` simple: `queryClient.invalidateQueries({queryKey: ['pricing', 'reprice']})`
- `useEffect` que dispara toast solo cuando `reprintRequestedRef.current === true` y la query terminó.
- `loadReferencePrices` sigue siendo del store (lo migra #314 después).

## Qué NO se toca (scope futuro)

- **`repriceAllWithMark` en el store** sigue existiendo — `risk-resumen/index.tsx` lo usa imperativo. Se elimina en #318 (cleanup final).
- **`loadReferencePrices`** sigue siendo del store. Lo migra #314.
- El sentinel "Pendiente de valoración" en xccyRows/ndfRows/ibrRows (líneas 2102-2108) sigue ahí — funciona bien con el hook ahora que `pricedXccy = reprice.data?.xccy_results ?? []`.

## Test plan

- [x] `npx tsc --noEmit` limpio
- [x] `npm run build` Vercel-style: 70/70 páginas
- [ ] Manual: cambiar markFecha 5 veces seguidas en <1s → un solo toast al final, no varios
- [ ] Manual: agregar XCCY/NDF/IBR → reprice automático sin toast (silent), nueva posición aparece
- [ ] Manual: botón "Repricear" → 1 toast al completar
- [ ] DevTools: ver una sola query `['pricing', 'reprice', ...]` activa por fecha+posiciones

Closes #313
Refs #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
