### PR TITLE
feat(portfolio): #314 useReferencePrices — reemplazar loadReferencePrices

### DIFF
--- a/src/pages/portfolio/index.tsx
+++ b/src/pages/portfolio/index.tsx
@@ -32,7 +32,7 @@ import {
   getNdfSettlement,
 } from 'src/models/pricing/pricingApi';
 import type { NdfSettlementResult } from 'src/models/pricing/pricingApi';
-import { useRepricePortfolio } from 'src/queries/pricing';
+import { useRepricePortfolio, useReferencePrices } from 'src/queries/pricing';
 import { useQueryClient } from '@tanstack/react-query';
 import { fetchHistoricalMark } from 'src/models/trading/fetchHistoricalMark';
 import type { CurveStatus } from 'src/types/pricing';
@@ -1957,8 +1957,6 @@ function PortfolioPage() {
     marketDataConfig,
     loadMarketDataConfig,
     updateMarketDataConfig,
-    refPrices,
-    loadReferencePrices,
     activeCompanyId,
     selectedCompanyId,
   } = useAppStore();
@@ -2005,6 +2003,17 @@ function PortfolioPage() {
       })
     : undefined;
 
+  // #314 — Reference prices (daily/MTD/YTD snapshots) for P&L derivation.
+  // The hook auto-fans into 3 sub-queries with own cache keys; aborts stale
+  // ones when fechaMarca or position list changes.
+  const { refPrices } = useReferencePrices({
+    xccy: xccyPositions,
+    ndf: ndfPositions,
+    ibr: ibrSwapPositions,
+    fechaMarca: markFecha,
+    enabled: !!(curveStatus?.ibr.built && curveStatus?.sofr.built),
+  });
+
   // Toast only when the user explicitly hit "Repricear" — automatic refetches
   // (date change, position added) should be silent. The dual-toast bug from
   // the legacy code path was caused by aborted reprices firing toast.success.
@@ -2015,7 +2024,6 @@ function PortfolioPage() {
     if (reprice.isFetching) return;
     if (reprice.isSuccess) {
       toast.success(`Portafolio valorado con marca ${markFecha}`);
-      loadReferencePrices(markFecha).catch(() => {});
       reprintRequestedRef.current = false;
     } else if (reprice.isError) {
       const msg = reprice.error instanceof Error ? reprice.error.message : String(reprice.error);
@@ -2025,14 +2033,8 @@ function PortfolioPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reprice.isFetching, reprice.isSuccess, reprice.isError, reprice.dataUpdatedAt]);
 
-  // Background-load reference prices whenever the date or set of positions
-  // changes (the store de-dupes by date internally, so this is cheap).
-  useEffect(() => {
-    if (!(curveStatus?.ibr.built && curveStatus?.sofr.built)) return;
-    if (!markFecha) return;
-    loadReferencePrices(markFecha).catch(() => {});
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [markFecha, curveStatus?.ibr.built, curveStatus?.sofr.built, xccyPositions.length, ndfPositions.length, ibrSwapPositions.length]);
+  // (#314 removed the explicit loadReferencePrices background effect —
+  //  useReferencePrices reacts natively to fechaMarca + position changes.)
 
   const handleReprice = useCallback(() => {
     reprintRequestedRef.current = true;

--- a/src/queries/pricing.ts
+++ b/src/queries/pricing.ts
@@ -14,7 +14,7 @@
  * - Curves change when marks are loaded — 30s is fine.
  * - Catalogs and historical marks change rarely — 10 min.
  */
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueries } from '@tanstack/react-query';
 import {
   getCurveStatus,
   getNdfImpliedCurve,
@@ -25,10 +25,12 @@ import {
   getMarkByDate,
 } from 'src/models/pricing/pricingApi';
 import { repricePortfolio } from 'src/models/trading/repricePortfolio';
+import { computePnlRefDates } from 'src/utils/pnlDates';
 import type {
   XccyPosition,
   NdfPosition,
   IbrSwapPosition,
+  PortfolioRepriceResponse,
 } from 'src/types/trading';
 
 export const pricingKeys = {
@@ -46,6 +48,17 @@ export const pricingKeys = {
     ibrIds: string[],
   ) => [
     'pricing', 'reprice', valuationDate,
+    [...xccyIds].sort(), [...ndfIds].sort(), [...ibrIds].sort(),
+  ] as const,
+  refDates: (fechaMarca: string) => ['pricing', 'refDates', fechaMarca] as const,
+  refPrice: (
+    period: 'daily' | 'mtd' | 'ytd',
+    fecha: string,
+    xccyIds: string[],
+    ndfIds: string[],
+    ibrIds: string[],
+  ) => [
+    'pricing', 'refPrice', period, fecha,
     [...xccyIds].sort(), [...ndfIds].sort(), [...ibrIds].sort(),
   ] as const,
 };
@@ -177,4 +190,105 @@ export function useRepricePortfolio(input: UseRepricePortfolioInput) {
     staleTime: 30_000,
   });
 }
+
+/**
+ * #314 — Compute reference prices (daily, MTD, YTD) needed to derive P&L
+ * columns in the portfolio blotter.
+ *
+ * Replaces `loadReferencePrices` from `src/store/trading/index.ts`. The
+ * legacy version:
+ *   1. Awaited `computePnlRefDates(fechaMarca)` to get the 3 reference dates.
+ *   2. Fired 3 `repricePortfolio` calls in parallel with `Promise.allSettled`.
+ *   3. Stored results in `state.refPrices.{daily, mtd, ytd}`.
+ *
+ * The hook does the same in two stages:
+ *   - One `useQuery` for `refDates` keyed on `fechaMarca`.
+ *   - `useQueries` for the 3 sub-reprices, gated by `refDates` being
+ *     resolved. Each sub-query has its own key so partial failures don't
+ *     cascade and TanStack dedupes if another component asks for the same
+ *     period+date combo.
+ */
+export type RefPricePeriod = 'daily' | 'mtd' | 'ytd';
+
+export interface UseReferencePricesInput {
+  xccy: XccyPosition[];
+  ndf: NdfPosition[];
+  ibr: IbrSwapPosition[];
+  fechaMarca: string;
+  enabled?: boolean;
+}
+
+export interface UseReferencePricesResult {
+  refPrices: {
+    daily: PortfolioRepriceResponse | null;
+    mtd: PortfolioRepriceResponse | null;
+    ytd: PortfolioRepriceResponse | null;
+  };
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function useReferencePrices(input: UseReferencePricesInput): UseReferencePricesResult {
+  const { xccy, ndf, ibr, fechaMarca, enabled = true } = input;
+
+  const refDatesQuery = useQuery({
+    queryKey: pricingKeys.refDates(fechaMarca),
+    queryFn: () => computePnlRefDates(fechaMarca),
+    enabled: enabled && !!fechaMarca,
+    // The 3 reference dates depend only on calendar logic for `fechaMarca`,
+    // not on market data — keep them cached for an hour.
+    staleTime: 60 * 60_000,
+  });
+  const refDates = refDatesQuery.data;
+
+  const periods: RefPricePeriod[] = ['daily', 'mtd', 'ytd'];
+
+  const subQueries = useQueries({
+    queries: periods.map((period) => {
+      const fecha = refDates?.[period];
+      const filteredXccy = fecha ? xccy.filter((p) => p.start_date <= fecha) : [];
+      const filteredNdf = fecha
+        ? ndf.filter((p) => !p.trade_date || p.trade_date <= fecha)
+        : [];
+      const filteredIbr = fecha ? ibr.filter((p) => p.start_date <= fecha) : [];
+      return {
+        queryKey: pricingKeys.refPrice(
+          period,
+          fecha ?? '',
+          filteredXccy.map((p) => p.id),
+          filteredNdf.map((p) => p.id),
+          filteredIbr.map((p) => p.id),
+        ),
+        queryFn: ({ signal }: { signal: AbortSignal }) =>
+          repricePortfolio(filteredXccy, filteredNdf, filteredIbr, {
+            valuation_date: fecha as string,
+            signal,
+          }),
+        enabled: enabled
+          && !!fecha
+          && (filteredXccy.length + filteredNdf.length + filteredIbr.length) > 0,
+        // Reference prices for past dates are immutable for that snapshot of
+        // positions — keep them warm for 5 min so navigating between pages or
+        // re-rendering doesn't refetch.
+        staleTime: 5 * 60_000,
+      };
+    }),
+  });
+
+  const [daily, mtd, ytd] = subQueries;
+  const isLoading = refDatesQuery.isLoading || subQueries.some((q) => q.isLoading);
+  const isError = refDatesQuery.isError || subQueries.some((q) => q.isError);
+
+  return {
+    refPrices: {
+      daily: daily?.data ?? null,
+      mtd: mtd?.data ?? null,
+      ytd: ytd?.data ?? null,
+    },
+    isLoading,
+    isError,
+  };
+}
+
+
 


### PR DESCRIPTION
## Summary

- Sub-issue #314 — completa la migración del lado pricing-derivados a TanStack Query.
- Reemplaza `loadReferencePrices` del store en `pages/portfolio/index.tsx` por un hook compuesto.

## Cómo funciona

### Nuevo en [src/queries/pricing.ts](src/queries/pricing.ts)

`useReferencePrices({xccy, ndf, ibr, fechaMarca, enabled})` hace dos fases:

**Fase 1 — `useQuery` interno** para los 3 ref dates:
```ts
queryKey: ['pricing', 'refDates', fechaMarca]
queryFn: () => computePnlRefDates(fechaMarca)
staleTime: 1h  // las fechas de calendario no dependen de market data
```

**Fase 2 — `useQueries`** dispara los 3 reprices:
```ts
periods.map((period) => ({
  queryKey: ['pricing', 'refPrice', period, refDates[period], xccyIds, ndfIds, ibrIds],
  queryFn: ({signal}) => repricePortfolio(filteredPositions, {valuation_date, signal}),
  enabled: !!refDates[period] && positions > 0,
  staleTime: 5 * 60_000,
}))
```

Cada sub-query tiene su propia key, así una falla no afecta las otras y TanStack dedupea entre páginas que pidan el mismo periodo+fecha.

### [src/pages/portfolio/index.tsx](src/pages/portfolio/index.tsx)

**Removido:**
- `refPrices` del destructure de `useAppStore`
- `loadReferencePrices` del destructure
- El `useEffect([markFecha, curveStatus..., positions...])` que disparaba `loadReferencePrices` manual
- El `loadReferencePrices(markFecha).catch(...)` dentro del toast useEffect

**Reemplazado por:**
```ts
const { refPrices } = useReferencePrices({
  xccy, ndf, ibr, fechaMarca: markFecha,
  enabled: !!(curveStatus?.ibr.built && curveStatus?.sofr.built),
});
```

## Qué NO se toca (scope futuro)

- `loadReferencePrices` en el store sigue ahí — `pages/risk-resumen/index.tsx` lo usa imperativo. Cleanup en #318.
- `state.refPrices`, `state.refPricesForDate`, `state.refPricesLoading` siguen en el store por la misma razón.
- Tokens del store (`refPricesToken`, `refPricesAbort`) aún protegen a risk-resumen.

## Beneficios

- **Dedupe automático.** Si dos páginas piden el mismo periodo+fecha+positions, solo 1 fetch. (Antes el store disparaba siempre 3.)
- **Cancelación natural.** Cambiar `markFecha` o agregar/quitar posición = nueva key = aborta en vuelo automáticamente.
- **Cache 5 min.** Snapshots históricos son inmutables — no se refetchean al re-renderizar.
- **Failure aislada.** Si la curva de YTD no existe, `daily` y `mtd` resuelven igual.

## Test plan

- [x] `npx tsc --noEmit` limpio
- [x] `npm run build` Vercel-style: 70/70 páginas, sin errors
- [ ] Manual: en `/portfolio`, los P&L 1D/MTD/YTD aparecen tras unos segundos del reprice principal (los 3 sub-fetches resuelven independientes).
- [ ] DevTools: ver 3 queries `['pricing', 'refPrice', daily|mtd|ytd, ...]` activas + 1 `['pricing', 'refDates', <fecha>]`.
- [ ] Cambiar fecha rápido: las 3 viejas se cancelan, las 3 nuevas arrancan.

## Estado Fase 2

| Issue | Status |
|---|---|
| #311 Setup | ✅ |
| #312 Read-only queries | ✅ |
| #313 useRepricePortfolio | ✅ |
| #314 useReferencePrices | **este PR** |
| #316 useLoanCashflow | ✅ |
| #317 usePositions + CRUD | pendiente |
| #318 Cleanup final (incluye risk-resumen) | pendiente |

Después de este merge, **portfolio/index.tsx ya no usa nada de pricing/refPrices del store**. Solo queda el lado de positions (#317) y el cleanup global (#318).

Closes #314
Refs #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
