### PR TITLE
feat(portfolio): #317 usePositions queries + mutations CRUD para XCCY/NDF/IBR

### DIFF
--- a/src/pages/portfolio/index.tsx
+++ b/src/pages/portfolio/index.tsx
@@ -33,6 +33,17 @@ import {
 } from 'src/models/pricing/pricingApi';
 import type { NdfSettlementResult } from 'src/models/pricing/pricingApi';
 import { useRepricePortfolio, useReferencePrices } from 'src/queries/pricing';
+import {
+  useXccyPositions,
+  useNdfPositions,
+  useIbrSwapPositions,
+  useAddXccyPosition,
+  useAddNdfPosition,
+  useAddIbrSwapPosition,
+  useRemoveXccyPositions,
+  useRemoveNdfPositions,
+  useRemoveIbrSwapPositions,
+} from 'src/queries/trading';
 import { useQueryClient } from '@tanstack/react-query';
 import { fetchHistoricalMark } from 'src/models/trading/fetchHistoricalMark';
 import type { CurveStatus } from 'src/types/pricing';
@@ -1940,17 +1951,7 @@ function PortfolioPage() {
   const [settlementMap, setSettlementMap] = useState<Record<string, NdfSettlementResult | 'error'>>({});
 
   const {
-    xccyPositions,
-    ndfPositions,
-    ibrSwapPositions,
     tradingError,
-    loadPositions,
-    addXccyPosition,
-    addNdfPosition,
-    addIbrSwapPosition,
-    removeXccyPositions,
-    removeNdfPositions,
-    removeIbrSwapPositions,
     canEdit,
     loadUserRole,
     userRole,
@@ -1960,6 +1961,29 @@ function PortfolioPage() {
     activeCompanyId,
     selectedCompanyId,
   } = useAppStore();
+
+  // #317 — Position lists now come from TanStack Query. Their cache key
+  // includes companyId so switching companies invalidates correctly. The
+  // store fields `xccyPositions/ndfPositions/ibrSwapPositions` are still
+  // there for risk-resumen (uses `loadPositions` imperatively); they will
+  // be removed in #318 cleanup.
+  const companyId = activeCompanyId();
+  const xccyPositionsQuery = useXccyPositions(companyId);
+  const ndfPositionsQuery = useNdfPositions(companyId);
+  const ibrSwapPositionsQuery = useIbrSwapPositions(companyId);
+  const xccyPositions = xccyPositionsQuery.data ?? [];
+  const ndfPositions = ndfPositionsQuery.data ?? [];
+  const ibrSwapPositions = ibrSwapPositionsQuery.data ?? [];
+
+  // #317 — Mutations replace the store CRUD actions. `onSuccess` invalidates
+  // the corresponding list query → list refetches → `useRepricePortfolio`
+  // sees a different ID set → reprice fires automatically.
+  const addXccyMutation = useAddXccyPosition();
+  const addNdfMutation = useAddNdfPosition();
+  const addIbrSwapMutation = useAddIbrSwapPosition();
+  const removeXccyMutation = useRemoveXccyPositions();
+  const removeNdfMutation = useRemoveNdfPositions();
+  const removeIbrSwapMutation = useRemoveIbrSwapPositions();
 
   // Track when the user explicitly requested a reprice via the toolbar button
   // — used to surface a toast when the next query lands. Without it, every
@@ -2059,11 +2083,12 @@ function PortfolioPage() {
       }
     };
     initCurves();
-    loadPositions(activeCompanyId());
+    // Positions are now fetched by useXccy/Ndf/IbrSwapPositions hooks
+    // (#317). They auto-fetch on mount; no manual loadPositions needed here.
     loadUserRole();
     loadMarketDataConfig();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [handleBuild, loadPositions, loadUserRole, loadMarketDataConfig, selectedCompanyId]);
+  }, [handleBuild, loadUserRole, loadMarketDataConfig, selectedCompanyId]);
 
 
   // Sync markFecha to curveStatus valuation_date once it loads
@@ -2082,12 +2107,12 @@ function PortfolioPage() {
 
   const handleDelete = useCallback(
     (id: string, type: string) => {
-      if (type === 'XCCY') removeXccyPositions([id]);
-      else if (type === 'NDF') removeNdfPositions([id]);
-      else if (type === 'IBR') removeIbrSwapPositions([id]);
+      if (type === 'XCCY') removeXccyMutation.mutate([id]);
+      else if (type === 'NDF') removeNdfMutation.mutate([id]);
+      else if (type === 'IBR') removeIbrSwapMutation.mutate([id]);
       toast.info('Posicion eliminada');
     },
-    [removeXccyPositions, removeNdfPositions, removeIbrSwapPositions]
+    [removeXccyMutation, removeNdfMutation, removeIbrSwapMutation]
   );
 
   const onSelectXccy = useCallback((pos: PricedXccy) => {
@@ -2331,7 +2356,7 @@ function PortfolioPage() {
           show={addType === 'xccy'}
           onHide={() => setAddType(null)}
           onSave={async (v) => {
-            await addXccyPosition(v);
+            await addXccyMutation.mutateAsync(v);
             toast.success('Posicion XCCY creada');
           }}
         />
@@ -2339,7 +2364,7 @@ function PortfolioPage() {
           show={addType === 'ndf'}
           onHide={() => setAddType(null)}
           onSave={async (v) => {
-            await addNdfPosition(v);
+            await addNdfMutation.mutateAsync(v);
             toast.success('Posicion NDF creada');
           }}
         />
@@ -2347,7 +2372,7 @@ function PortfolioPage() {
           show={addType === 'ibr'}
           onHide={() => setAddType(null)}
           onSave={async (v) => {
-            await addIbrSwapPosition(v);
+            await addIbrSwapMutation.mutateAsync(v);
             toast.success('Posicion IBR Swap creada');
           }}
         />

--- a/src/queries/trading.ts
+++ b/src/queries/trading.ts
@@ -1,0 +1,161 @@
+/**
+ * TanStack Query hooks for derivatives positions (xccy, ndf, ibr swaps).
+ *
+ * Phase 2 (#299) sub-issue #317 — replaces the position-list state and CRUD
+ * actions in `src/store/trading/index.ts` for the **derivatives** flow.
+ *
+ * TES queda fuera del scope de Fase 2 — se maneja por separado.
+ *
+ * Pattern:
+ * - `useXxxPositions(companyId)` → list query, key includes companyId so
+ *   switching company invalidates correctly.
+ * - `useAddXxxPosition()` / `useRemoveXxxPositions()` → mutations that
+ *   invalidate the list on success.
+ *
+ * Why this matters for the user-visible bugs:
+ * - Adding a position no longer needs the `repriceTrigger` counter from #295.
+ *   When the mutation invalidates `['positions', 'xccy', companyId]`, the
+ *   list refetches with the new position, then `useRepricePortfolio` sees
+ *   a different ID set in its key and refetches automatically.
+ * - The store's manual `xccyPositions: [...state.xccyPositions, localPos]`
+ *   optimistic update is replaced by query invalidation. No more "where did
+ *   my position go after a refresh?" desync.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchXccyPositions,
+  fetchNdfPositions,
+  fetchIbrSwapPositions,
+  createXccyPosition,
+  createNdfPosition,
+  createIbrSwapPosition,
+  deleteXccyPositions,
+  deleteNdfPositions,
+  deleteIbrSwapPositions,
+} from 'src/models/trading';
+import type {
+  XccyPosition,
+  NdfPosition,
+  IbrSwapPosition,
+  NewXccyPosition,
+  NewNdfPosition,
+  NewIbrSwapPosition,
+} from 'src/types/trading';
+
+export const tradingKeys = {
+  xccyPositions: (companyId?: string) =>
+    ['positions', 'xccy', companyId ?? null] as const,
+  ndfPositions: (companyId?: string) =>
+    ['positions', 'ndf', companyId ?? null] as const,
+  ibrSwapPositions: (companyId?: string) =>
+    ['positions', 'ibrSwap', companyId ?? null] as const,
+  /** All position lists across all companies — used for invalidation broadcast. */
+  allPositions: ['positions'] as const,
+};
+
+const POSITIONS_STALE_MS = 60_000;
+
+// ── List queries ──
+
+export function useXccyPositions(companyId?: string, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: tradingKeys.xccyPositions(companyId),
+    queryFn: async () => {
+      const res = await fetchXccyPositions(companyId);
+      if (res.error) throw new Error(res.error);
+      return res.data as XccyPosition[];
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: POSITIONS_STALE_MS,
+  });
+}
+
+export function useNdfPositions(companyId?: string, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: tradingKeys.ndfPositions(companyId),
+    queryFn: async () => {
+      const res = await fetchNdfPositions(companyId);
+      if (res.error) throw new Error(res.error);
+      return res.data as NdfPosition[];
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: POSITIONS_STALE_MS,
+  });
+}
+
+export function useIbrSwapPositions(companyId?: string, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: tradingKeys.ibrSwapPositions(companyId),
+    queryFn: async () => {
+      const res = await fetchIbrSwapPositions(companyId);
+      if (res.error) throw new Error(res.error);
+      return res.data as IbrSwapPosition[];
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: POSITIONS_STALE_MS,
+  });
+}
+
+// ── Mutations: create ──
+
+export function useAddXccyPosition() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: createXccyPosition as (v: NewXccyPosition) => Promise<unknown>,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['positions', 'xccy'] });
+    },
+  });
+}
+
+export function useAddNdfPosition() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: createNdfPosition as (v: NewNdfPosition) => Promise<unknown>,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['positions', 'ndf'] });
+    },
+  });
+}
+
+export function useAddIbrSwapPosition() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: createIbrSwapPosition as (v: NewIbrSwapPosition) => Promise<unknown>,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['positions', 'ibrSwap'] });
+    },
+  });
+}
+
+// ── Mutations: delete ──
+
+export function useRemoveXccyPositions() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (ids: string[]) => deleteXccyPositions(ids),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['positions', 'xccy'] });
+    },
+  });
+}
+
+export function useRemoveNdfPositions() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (ids: string[]) => deleteNdfPositions(ids),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['positions', 'ndf'] });
+    },
+  });
+}
+
+export function useRemoveIbrSwapPositions() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (ids: string[]) => deleteIbrSwapPositions(ids),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['positions', 'ibrSwap'] });
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Sub-issue #317 — migración de las queries CRUD de positions (XCCY/NDF/IBR) a TanStack Query.
- TES queda fuera de scope (excluido de Fase 2).
- Crea cadena de invalidación automática: `agregar posición → mutation → invalidate list → refetch list → useRepricePortfolio detecta nueva ID set → reprice`.

## Cambios

### Nuevo: [src/queries/trading.ts](src/queries/trading.ts)

- `tradingKeys.{xccyPositions, ndfPositions, ibrSwapPositions}` keyed con companyId.
- 3 list queries: `useXccyPositions`, `useNdfPositions`, `useIbrSwapPositions` con `staleTime: 60s`.
- 6 mutations:
  - `useAddXccyPosition`, `useAddNdfPosition`, `useAddIbrSwapPosition` (create)
  - `useRemoveXccyPositions`, `useRemoveNdfPositions`, `useRemoveIbrSwapPositions` (delete)
  - Todas invalidan `['positions', '<tipo>']` en `onSuccess`.

### [src/pages/portfolio/index.tsx](src/pages/portfolio/index.tsx)

**Quitado del destructure de `useAppStore`:**
```diff
-xccyPositions, ndfPositions, ibrSwapPositions,
-loadPositions,
-addXccyPosition, addNdfPosition, addIbrSwapPosition,
-removeXccyPositions, removeNdfPositions, removeIbrSwapPositions,
```

**Reemplazado por:**
```ts
const xccyPositionsQuery = useXccyPositions(companyId);
const xccyPositions = xccyPositionsQuery.data ?? [];
// ... idem ndf, ibr

const addXccyMutation = useAddXccyPosition();
// ... etc

// handleDelete: removeXccyMutation.mutate([id]) en vez de removeXccyPositions([id])
// onSave de modales: await addXccyMutation.mutateAsync(v)
```

**Eliminado:**
- `loadPositions(activeCompanyId())` del initCurves useEffect — los hooks auto-fetchean.

## Cadena automática de invalidación

```
Usuario agrega XCCY
  → useAddXccyPosition.mutate(v)
    → POST a Supabase
    → onSuccess: invalidateQueries(['positions', 'xccy'])
      → useXccyPositions refetcha
        → nueva lista con la posición
          → useRepricePortfolio ve nueva sorted ID set en su key
            → reprice automático
              → NPV de la nueva posición aparece
```

Sin código glue. Sin `repriceTrigger` counter. Sin manual `setRepriceTrigger`.

## Lo que NO se toca (scope #318)

- Store sigue exponiendo `xccyPositions/ndfPositions/ibrSwapPositions` y `loadPositions` — `risk-resumen/index.tsx` los usa imperativo.
- Store sigue exponiendo `addXxxPosition/removeXxxPositions` (a verificar si más callers en #318).
- Las dos fuentes (store + query) coexisten temporalmente: portfolio lee solo de queries, risk-resumen solo de store. Sin conflicto.

## Test plan

- [x] `npx tsc --noEmit` limpio
- [x] `npm run build`: 72/72 páginas, sin errors
- [ ] Manual: agregar XCCY → aparece en la tabla con NPV calculado en pocos segundos (sin recargar la página)
- [ ] Manual: borrar posición → desaparece de la tabla
- [ ] DevTools: ver `['positions', 'xccy', companyId]`, `['positions', 'ndf', companyId]`, `['positions', 'ibrSwap', companyId]` activas
- [ ] Switch de empresa → todas las queries invalidan + refetcha automáticamente

## Estado Fase 2

| Issue | Status |
|---|---|
| #311 Setup | ✅ |
| #312 Read-only queries | ✅ |
| #313 useRepricePortfolio | ✅ |
| #314 useReferencePrices | ✅ |
| **#317 usePositions + CRUD** | **este PR** |
| #316 useLoanCashflow | ✅ |
| #318 Cleanup final | siguiente |

**Después de mergear este PR**, `pages/portfolio/index.tsx` ya no lee/escribe NADA de pricing/positions/refPrices del store de derivados. Solo `marketDataConfig`, `userRole`, `tradingError`, y los flags UI.

#318 puede limpiar el store completo (eliminar pricedXccy, pricedNdf, pricedIbrSwap, summary, refPrices, xccyPositions, etc.) y migrar `risk-resumen/index.tsx`.

Closes #317
Refs #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
