### PR TITLE
feat(loans): #300 Fase 3.1 — bulk summary (1 round-trip en vez de 68)

### DIFF
--- a/src/__tests__/integration/loans-failure-isolation.test.tsx
+++ b/src/__tests__/integration/loans-failure-isolation.test.tsx
@@ -22,6 +22,17 @@ vi.mock('src/models/loans/fetchCashFlows', () => ({
   fetchCashFlows: vi.fn(),
 }));
 
+// The bulk RPC isn't relevant to these failure-isolation tests, but the hook
+// chain calls it. Stub with a permanent reject so it doesn't make real
+// network calls; the FE-computed fallback in `useLoanPortfolioSummary` then
+// drives the assertions below.
+vi.mock('src/models/loans/fetchBulkSummary', () => ({
+  fetchBulkLoanSummary: vi.fn().mockResolvedValue({
+    data: [],
+    error: 'mocked-out',
+  }),
+}));
+
 const mockedFetch = fetchCashFlows as unknown as ReturnType<typeof vi.fn>;
 
 const mkLoan = (id: string, type = 'ibr', bank = 'Bancolombia'): Loan => ({

--- a/src/models/loans/fetchBulkSummary.ts
+++ b/src/models/loans/fetchBulkSummary.ts
@@ -1,0 +1,120 @@
+/**
+ * Bulk loan summary fetcher — Phase 3.1 (epic #300).
+ *
+ * Calls the existing Supabase RPC `xerenity.ibr_cash_flow_by_loans` (despite
+ * the name, this function handles ALL loan types: fija, ibr, uvr — `loan_get_data`
+ * inside it queries `loans.loan` without filtering by type). The RPC delegates
+ * to pysdk's `/all_loans` endpoint, which runs the full
+ * `LoanPortfolioAnalyzer` server-side and returns:
+ *
+ *   1. One row per bank with weighted IRR/tenor/duration aggregates.
+ *   2. One "totals" row with `bank = 0` and global aggregates (sum across banks).
+ *
+ * The shape matches `LoanData` in `src/types/loans.ts` exactly, so the
+ * frontend `buildPortfolioSummary` becomes redundant for this call path.
+ *
+ * Why this matters for production latency:
+ * - Today the FE makes N (e.g. 68) round-trips to compute the same summary.
+ * - This RPC reduces it to ONE round-trip.
+ * - User reports a "ratico" before the dashboard fills in — that latency
+ *   is exactly N × (network RTT + Postgres compute). Bulk drops the multiplier.
+ */
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { LoanData } from 'src/types/loans';
+import {
+  telemetry,
+  combineAbortSignals,
+  DEFAULT_FETCH_TIMEOUT_MS,
+  isAbortError,
+} from 'src/lib/telemetry';
+
+const SCHEMA = 'xerenity';
+const RPC_KEY = 'ibr_cash_flow_by_loans';
+const supabase = createClientComponentClient();
+
+export type BulkLoanSummaryResponse = {
+  /** Per-bank rows; the row with `bank === '0'` is the global totals. */
+  data: LoanData[];
+  error: string | undefined;
+};
+
+export interface FetchBulkLoanSummaryOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+/** Server can return `bank` as the integer 0 (totals row, from a positional
+ *  index) or a real bank-name string. Normalize both into `LoanData`. */
+const normalizeRow = (raw: Record<string, unknown>): LoanData => {
+  const bank = raw.bank;
+  return {
+    bank: bank === 0 ? '0' : String(bank ?? ''),
+    loan_ids: Array.isArray(raw.loan_ids) ? (raw.loan_ids as string[]) : [],
+    loan_count: Number(raw.loan_count ?? 0),
+    total_value: Number(raw.total_value ?? 0),
+    accrued_interest: Number(raw.accrued_interest ?? 0),
+    average_irr: Number(raw.average_irr ?? 0),
+    average_tenor: Number(raw.average_tenor ?? 0),
+    average_duration: Number(raw.average_duration ?? 0),
+    total_value_fija: Number(raw.total_value_fija ?? 0),
+    total_value_ibr: Number(raw.total_value_ibr ?? 0),
+    total_value_uvr: Number(raw.total_value_uvr ?? 0),
+    average_irr_fija: Number(raw.average_irr_fija ?? 0),
+    average_irr_ibr: Number(raw.average_irr_ibr ?? 0),
+    average_irr_uvr: Number(raw.average_irr_uvr ?? 0),
+    outdated_loan_count: Number(raw.outdated_loan_count ?? 0),
+    not_calculated_loan_count: Number(raw.not_calculated_loan_count ?? 0),
+  };
+};
+
+export const fetchBulkLoanSummary = async (
+  loanIds: string[],
+  filterDate: string,
+  opts?: FetchBulkLoanSummaryOptions,
+): Promise<BulkLoanSummaryResponse> => {
+  const response: BulkLoanSummaryResponse = { data: [], error: undefined };
+  if (loanIds.length === 0) return response;
+
+  const signal = combineAbortSignals(
+    opts?.signal,
+    opts?.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS,
+  );
+
+  return telemetry.time(
+    'loans',
+    RPC_KEY,
+    async () => {
+      try {
+        const { data, error } = await supabase
+          .schema(SCHEMA)
+          .rpc(RPC_KEY, { filter_date: filterDate, loans: loanIds })
+          .abortSignal(signal);
+
+        if (error) {
+          telemetry.warn('loans', `${RPC_KEY} rpc error`, {
+            count: loanIds.length,
+            rpcMessage: error.message,
+            code: error.code,
+          });
+          response.error = error.message ?? 'Bulk loan summary failed';
+          return response;
+        }
+
+        const rows = Array.isArray(data) ? data : [];
+        response.data = rows
+          .filter((r): r is Record<string, unknown> => r != null && typeof r === 'object')
+          .map(normalizeRow);
+        return response;
+      } catch (e) {
+        if (isAbortError(e)) throw e;
+        telemetry.warn('loans', `${RPC_KEY} threw`, {
+          count: loanIds.length,
+          message: e instanceof Error ? e.message : String(e),
+        });
+        response.error = 'Bulk loan summary failed';
+        return response;
+      }
+    },
+    { count: loanIds.length, filterDate },
+  );
+};

--- a/src/models/loans/fetchBulkSummary.ts
+++ b/src/models/loans/fetchBulkSummary.ts
@@ -46,7 +46,7 @@ export interface FetchBulkLoanSummaryOptions {
 /** Server can return `bank` as the integer 0 (totals row, from a positional
  *  index) or a real bank-name string. Normalize both into `LoanData`. */
 const normalizeRow = (raw: Record<string, unknown>): LoanData => {
-  const bank = raw.bank;
+  const { bank } = raw;
   return {
     bank: bank === 0 ? '0' : String(bank ?? ''),
     loan_ids: Array.isArray(raw.loan_ids) ? (raw.loan_ids as string[]) : [],

--- a/src/models/loans/index.ts
+++ b/src/models/loans/index.ts
@@ -1,6 +1,7 @@
 import { fetchLoans, LoanResponse } from './fetchLoans';
 import { fetchBanks, BankResponse } from './fetchBanks';
 import { fetchCashFlows, CashflowResponse } from './fetchCashFlows';
+import { fetchBulkLoanSummary, BulkLoanSummaryResponse } from './fetchBulkSummary';
 import { deleteLoan, DeleteLoanResponse } from './deleteLoan';
 import { createNewLoan, CreateLoanResponse } from './createLoan';
 import { fetchLoansIbrs } from './fetchIbrLoans';
@@ -10,6 +11,7 @@ export type {
   LoanResponse,
   BankResponse,
   CashflowResponse,
+  BulkLoanSummaryResponse,
   DeleteLoanResponse,
   CreateLoanResponse,
 };
@@ -18,6 +20,7 @@ export {
   fetchLoans,
   fetchBanks,
   fetchCashFlows,
+  fetchBulkLoanSummary,
   deleteLoan,
   createNewLoan,
   fetchLoansIbrs,

--- a/src/queries/loans.ts
+++ b/src/queries/loans.ts
@@ -24,7 +24,7 @@
  * compound hook vs. inline at the end of the store action).
  */
 import { useMemo } from 'react';
-import { useQueries, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
 import {
   Loan,
   LoanCashFlowIbr,
@@ -33,12 +33,15 @@ import {
 } from 'src/types/loans';
 import { LightSerieValue } from 'src/types/lightserie';
 import { fetchCashFlows } from 'src/models/loans/fetchCashFlows';
+import { fetchBulkLoanSummary } from 'src/models/loans/fetchBulkSummary';
 import { telemetry } from 'src/lib/telemetry';
 
 export const loanKeys = {
   cashflow: (loanId: string, type: string, filterDate: string) =>
     ['loans', 'cashflow', loanId, type, filterDate] as const,
   cashflowAll: ['loans', 'cashflow'] as const,
+  bulkSummary: (loanIds: string[], filterDate: string) =>
+    ['loans', 'bulkSummary', [...loanIds].sort(), filterDate] as const,
 };
 
 const STALE_MS = 5 * 60_000;
@@ -230,14 +233,72 @@ export interface UseLoanPortfolioSummaryResult {
 }
 
 /**
+ * #300 (Phase 3.1) — Bulk loan summary query.
+ *
+ * Calls `xerenity.ibr_cash_flow_by_loans` (the misnamed bulk RPC that
+ * actually handles all loan types) which delegates to pysdk's `/all_loans`.
+ * Returns the same `LoanData[]` shape that `buildPortfolioSummary` produces
+ * locally — so consumers can read `fullLoan` and `loanDebtData` from a single
+ * round-trip instead of waiting for N per-loan queries to settle.
+ *
+ * Stale time matches per-loan queries (5 min): same underlying data, same
+ * cache horizon.
+ */
+export function useLoansBulkSummary(
+  loanIds: string[],
+  filterDate: string,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: loanKeys.bulkSummary(loanIds, filterDate),
+    queryFn: async ({ signal }) => {
+      const res = await fetchBulkLoanSummary(loanIds, filterDate, { signal });
+      if (res.error) throw new Error(res.error);
+      return res.data;
+    },
+    enabled: (options?.enabled ?? true) && loanIds.length > 0,
+    staleTime: STALE_MS,
+    retry: 0 as const,
+  });
+}
+
+/** Split the bulk response into `fullLoan` (the totals row, `bank === '0'`)
+ *  and `loanDebtData` (the per-bank rows). */
+function splitBulkSummary(rows: LoanData[] | undefined): {
+  fullLoan: LoanData | undefined;
+  loanDebtData: LoanData[];
+} {
+  if (!rows || rows.length === 0) return { fullLoan: undefined, loanDebtData: [] };
+  const fullLoan = rows.find((r) => r.bank === '0' || r.bank === '');
+  const loanDebtData = rows.filter((r) => r !== fullLoan)
+    .sort((a, b) => b.total_value - a.total_value);
+  return { fullLoan, loanDebtData };
+}
+
+/**
  * Compound hook: fans out N per-loan queries via `useQueries`, then derives
  * the merged series + portfolio summary + progress from their results.
+ *
+ * Phase 3.1 (#300) hybrid strategy: the headline summary (`fullLoan`,
+ * `loanDebtData`) is sourced from the **bulk** RPC (one round-trip) so the
+ * user sees Deuda Total / CPD / Tenor / Duración as soon as it lands. The
+ * per-loan queries still feed `cashFlows` / `mergedCashFlows` / `chartData`
+ * for charts and the per-loan modal — those fill in progressively.
+ *
+ * If the bulk call hasn't settled yet, fall back to the FE-computed summary
+ * from whatever per-loan queries have completed so far. The math is
+ * identical (pysdk uses the same formulas), so the swap is transparent.
  */
 export function useLoanPortfolioSummary(
   selectedLoans: Loan[],
   filterDate: string,
 ): UseLoanPortfolioSummaryResult {
   const queryClient = useQueryClient();
+
+  const bulk = useLoansBulkSummary(
+    selectedLoans.map((l) => l.id),
+    filterDate,
+  );
 
   const queries = useQueries({
     queries: selectedLoans.map((loan) => ({
@@ -283,7 +344,16 @@ export function useLoanPortfolioSummary(
       time: v.date.split(' ')[0],
       value: v.payment,
     }));
-    const { fullLoan, loanDebtData } = buildPortfolioSummary(cashFlows, selectedLoans);
+
+    // Server-side summary from the bulk RPC (preferred). If it hasn't loaded
+    // yet, derive from whatever per-loan queries have completed so we still
+    // show *something*.
+    const bulkSplit = splitBulkSummary(bulk.data);
+    const fallback = buildPortfolioSummary(cashFlows, selectedLoans);
+    const fullLoan = bulkSplit.fullLoan ?? fallback.fullLoan;
+    const loanDebtData = bulkSplit.loanDebtData.length > 0
+      ? bulkSplit.loanDebtData
+      : fallback.loanDebtData;
 
     const progress: LoanCalcProgress = {
       total: selectedLoans.length,
@@ -305,6 +375,11 @@ export function useLoanPortfolioSummary(
           queryKey: loanKeys.cashflow(loan.id, loan.type, filterDate),
         });
       });
+      // Also invalidate the bulk summary since its results may shift when
+      // previously-failed loans succeed on retry.
+      queryClient.invalidateQueries({
+        queryKey: loanKeys.bulkSummary(selectedLoans.map((l) => l.id), filterDate),
+      });
     };
 
     return {
@@ -319,6 +394,7 @@ export function useLoanPortfolioSummary(
     };
     // queries is recomputed by useQueries on every render; including it as a
     // dep correctly triggers re-aggregation when any query state changes.
+    // bulk.data is the bulk summary (Phase 3.1) — re-derive when it lands.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [queries, selectedLoans, filterDate]);
+  }, [queries, selectedLoans, filterDate, bulk.data]);
 }


### PR DESCRIPTION
## Summary

- **Fase 3.1 (#300)** — primer cambio del backend contract.
- **Reduce N round-trips a 1** para los headline numbers de `/loans` (Deuda Total, CPD, Tenor, Duración).
- Estrategia híbrida: bulk para summary, per-loan para charts/modal/CSV.
- **FE-only PR** — la infra backend ya existía (la encontramos al explorar).

## Lo que descubrimos

El endpoint bulk **ya existe** en el stack:

| Componente | Estado |
|---|---|
| Supabase RPC `xerenity.ibr_cash_flow_by_loans(filter_date, uuid[])` | ✅ existe (mal nombrado: acepta cualquier tipo de loan) |
| pysdk endpoint `/all_loans` | ✅ existe |
| pysdk `LoanPortfolioAnalyzer.calculate_weighted_averages` | ✅ existe, devuelve mismo shape `LoanData[]` que `buildPortfolioSummary` del FE |
| FE lo usaba | ❌ — hacía 68 RPCs individuales |

Por eso el "ratico" que sentías al cargar `/loans`: 68 × (network RTT + Postgres compute). Bulk lo colapsa a 1.

## Cambios

### Nuevo: [src/models/loans/fetchBulkSummary.ts](src/models/loans/fetchBulkSummary.ts)

- `fetchBulkLoanSummary(loanIds, filterDate)` llama `supabase.rpc('ibr_cash_flow_by_loans', { filter_date, loans })`.
- `normalizeRow` convierte server → `LoanData` typesafe (incluyendo el `bank: 0` del row de totales que pandas serializa como integer).
- AbortSignal + timeout via `combineAbortSignals` (#292).
- Telemetría via `telemetry.time` (#297).

### [src/queries/loans.ts](src/queries/loans.ts)

- `loanKeys.bulkSummary(loanIds, filterDate)` — nueva key con IDs ordenados.
- `useLoansBulkSummary(loanIds, filterDate)` — hook con `staleTime: 5min`.
- `splitBulkSummary(rows)` helper: separa el row `bank: '0'` (totals → `fullLoan`) de los per-bank rows (`loanDebtData`).
- **`useLoanPortfolioSummary` actualizado:** ahora consume bulk para `fullLoan` + `loanDebtData` cuando llega, **fall back** a `buildPortfolioSummary` de los per-loan queries mientras tanto.
- `retryFailed` también invalida la bulk query.

### Sin cambios en

- API pública del hook `useLoanPortfolioSummary` — el page no necesita modificaciones, sigue leyendo `fullLoan` / `loanDebtData` igual.
- Per-loan queries siguen existiendo para `cashFlows`, `mergedCashFlows`, `chartData` (charts + modal + CSV).

## UX esperada

| Antes | Después |
|---|---|
| 68 round-trips → headline numbers tras 5-10s | 1 round-trip → headline numbers en ~500ms-2s |
| Charts vacíos hasta que todos los loans completen | Charts llenan progresivamente como hoy (per-loan parallel) |
| Una RPC lenta retrasaba todo | Bulk + per-loan independientes, fallback FE si bulk falla |

## Backwards compatibility

Si la RPC bulk falla (e.g. backend down), `useLoanPortfolioSummary` cae automáticamente al `buildPortfolioSummary` FE-computed con datos parciales de las queries per-loan. **El user nunca pierde funcionalidad** — solo gana velocidad cuando bulk responde.

## Test plan

- [x] `npm run test:run`: 19 passed (incluye mock para `fetchBulkLoanSummary` en los tests de failure-isolation, elimina el ENOTFOUND noise).
- [x] `npx tsc --noEmit`: limpio.
- [x] `npm run build`: 72/72 páginas.
- [ ] Manual en preview: usuario con 68 créditos → CPD/Tenor/Duración aparecen en <2s.
- [ ] DevTools de TanStack: ver una query nueva `[loans, bulkSummary, ids, fecha]` activa.
- [ ] Si bulk falla: la página sigue funcionando con datos progresivos de per-loan queries.

## Lo que NO se toca (scope futuro)

- **Fase 3.3** — `pysdk /pricing/portfolio/reprice/v2` con `pricing_status: complete|partial|degraded` por posición. Requiere cambios en pysdk.
- Los per-loan queries (`xx_cash_flow`) siguen existiendo. Si quisieras eliminarlos completamente, habría que extender pysdk `/all_loans` para que ALSO devuelva cashflows por loan (no solo aggregates). Más invasivo, scope aparte.

Refs #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
