### PR TITLE
feat(pricing): #300 Fase 3.3 — leer pricing_status del backend (cierra epic)

### DIFF
--- a/src/__tests__/integration/reprice-concurrency.test.tsx
+++ b/src/__tests__/integration/reprice-concurrency.test.tsx
@@ -180,4 +180,73 @@ describe('useRepricePortfolio — null NPV handling', () => {
     expect(row.error).toBeTruthy();
     expect(row.error).toMatch(/npv_cop/);
   });
+
+  it('Phase 3.3: pricing_status="degraded" surfaces error + missing_fields passthrough', async () => {
+    server.use(
+      http.post(`${PYSDK_URL}/pricing/portfolio/reprice`, () =>
+        HttpResponse.json({
+          xccy_results: [{
+            id: 'p1',
+            npv_cop: null,
+            npv_usd: null,
+            pricing_status: 'degraded',
+            missing_fields: ['npv_cop', 'npv_usd', 'carry_cop'],
+          }],
+          ndf_results: [],
+          ibr_swap_results: [],
+          summary: { total_npv_cop: 0, total_npv_usd: 0, total_carry_cop: 0, total_carry_usd: 0, total_pnl_rate_cop: 0, total_pnl_fx_cop: 0 },
+        }),
+      ),
+    );
+
+    const { result } = renderHookWithClient(() =>
+      useRepricePortfolio({
+        xccy: [mkXccy('p1')], ndf: [], ibr: [],
+        valuationDate: '2026-04-25',
+      }),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const row = result.current.data!.xccy_results[0];
+    // Error message comes from the new explicit path and lists missing fields.
+    expect(row.error).toContain('npv_cop');
+    expect(row.error).toContain('carry_cop');
+    expect(row.pricing_status).toBe('degraded');
+    expect(row.missing_fields).toEqual(['npv_cop', 'npv_usd', 'carry_cop']);
+  });
+
+  it('Phase 3.3: pricing_status="partial" passes through without surfacing an error', async () => {
+    server.use(
+      http.post(`${PYSDK_URL}/pricing/portfolio/reprice`, () =>
+        HttpResponse.json({
+          xccy_results: [{
+            id: 'p1',
+            npv_cop: 1000,  // NPV is fine
+            npv_usd: 0.25,
+            carry_cop: null,  // auxiliary missing
+            pricing_status: 'partial',
+            missing_fields: ['carry_cop'],
+          }],
+          ndf_results: [],
+          ibr_swap_results: [],
+          summary: { total_npv_cop: 1000, total_npv_usd: 0.25, total_carry_cop: 0, total_carry_usd: 0, total_pnl_rate_cop: 0, total_pnl_fx_cop: 0 },
+        }),
+      ),
+    );
+
+    const { result } = renderHookWithClient(() =>
+      useRepricePortfolio({
+        xccy: [mkXccy('p1')], ndf: [], ibr: [],
+        valuationDate: '2026-04-25',
+      }),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const row = result.current.data!.xccy_results[0];
+    // Partial: NPV is usable so we do NOT mark as error. Status passes through.
+    expect(row.error).toBeUndefined();
+    expect(row.pricing_status).toBe('partial');
+    expect(row.missing_fields).toEqual(['carry_cop']);
+    expect(row.npv_cop).toBe(1000);
+  });
 });

--- a/src/models/trading/repricePortfolio.ts
+++ b/src/models/trading/repricePortfolio.ts
@@ -6,6 +6,7 @@ import type {
   PricedNdf,
   PricedIbrSwap,
   PortfolioRepriceResponse,
+  PricingStatus,
 } from 'src/types/trading';
 import {
   telemetry,
@@ -142,15 +143,49 @@ async function repriceImpl(
   // "Err" when `error` is set, so promote null-NPV to an error status here so
   // the user sees "Err" instead of a fake zero. Preserves any existing backend
   // error message so real failure reasons still surface.
+  //
+  // Phase 3.3 (epic #300): pysdk now sets `pricing_status` and `missing_fields`
+  // explicitly. Prefer those when present; fall back to the legacy null-NPV
+  // heuristic for backwards-compat with older deploys.
   const promoteNullNpvToError = (
     r: Record<string, unknown>,
     criticalFields: string[],
   ): string | undefined => {
     if (r.error) return r.error as string;
+
+    // Server-reported status (preferred path).
+    const status = r.pricing_status as string | undefined;
+    if (status === 'degraded' || status === 'partial') {
+      const missing = Array.isArray(r.missing_fields) ? r.missing_fields as string[] : [];
+      // Only treat 'partial' as an error if NPV itself is missing — partial
+      // typically means an auxiliary field (carry/dv01) is None, which is
+      // displayable. Show explicit missing-field detail when degraded.
+      if (status === 'degraded') {
+        return missing.length > 0
+          ? `NPV incompleto (${missing.join(', ')})`
+          : 'NPV incompleto';
+      }
+      // partial: do not surface as error; charts/NPV still render.
+      return undefined;
+    }
+    if (status === 'complete') {
+      return undefined;
+    }
+
+    // Legacy fallback when `pricing_status` is absent (older pysdk deploys).
     const missing = criticalFields.filter((f) => r[f] === null || r[f] === undefined);
     if (missing.length === 0) return undefined;
     return `NPV incompleto (${missing.join(', ')})`;
   };
+
+  /** Pluck through the pricing_status / missing_fields onto each result row
+   *  so consumers (UI tooltips, dev panels, future logic) can read them. */
+  const passthroughStatus = (r: Record<string, unknown>) => ({
+    pricing_status: r.pricing_status as PricingStatus | undefined,
+    missing_fields: Array.isArray(r.missing_fields)
+      ? r.missing_fields as string[]
+      : undefined,
+  });
 
   const xccyResults: PricedXccy[] = (raw.xccy_results ?? []).map((r) => {
     const pos = xccyById[r.id as string];
@@ -173,6 +208,7 @@ async function repriceImpl(
       notional_cop: g('notional_cop'), fx_spot: g('fx_spot'), n_periods: g('n_periods'),
       cashflows: (r.cashflows as PricedXccy['cashflows']) ?? [],
       error: promoteNullNpvToError(r, ['npv_cop', 'npv_usd']),
+      ...passthroughStatus(r),
     };
   });
 
@@ -193,6 +229,7 @@ async function repriceImpl(
       days_open: g('days_open'),
       accrued_cop: g('accrued_cop'),
       error: promoteNullNpvToError(r, ['npv_cop', 'npv_usd']),
+      ...passthroughStatus(r),
     };
   });
 
@@ -212,6 +249,7 @@ async function repriceImpl(
       carry_period_cop: g('carry_period_cop'),
       carry_period_diff_bps: g('carry_period_diff_bps'),
       error: promoteNullNpvToError(r, ['npv']),
+      ...passthroughStatus(r),
     };
   });
 

--- a/src/types/trading.ts
+++ b/src/types/trading.ts
@@ -97,6 +97,24 @@ export interface XccyCashflow {
   diff_bps: number;
 }
 
+/**
+ * Server-reported pricing completeness for a single position result.
+ *
+ * Phase 3.3 of epic #300 — pysdk now annotates each result row with one of
+ * these statuses so the FE doesn't have to infer from null coalescing.
+ *
+ * - `complete`: every required + auxiliary field is present and finite.
+ * - `partial`:  NPV is present (so the row is usable), but some auxiliary
+ *               fields (carry, DV01, par_basis, etc.) are missing — typically
+ *               because a curve isn't available for the position's tenor.
+ * - `degraded`: NPV itself is missing or pricing raised — the row is not
+ *               usable for valuation.
+ *
+ * Optional because older pysdk deploys don't send it; the FE falls back to
+ * the legacy null-NPV heuristic when missing.
+ */
+export type PricingStatus = 'complete' | 'partial' | 'degraded';
+
 export interface PricedXccy extends XccyPosition {
   npv_cop: number;
   npv_usd: number;
@@ -126,6 +144,8 @@ export interface PricedXccy extends XccyPosition {
   days_open?: number;
   cashflows: XccyCashflow[];
   error?: string;
+  pricing_status?: PricingStatus;
+  missing_fields?: string[];
 }
 
 export interface PricedNdf extends NdfPosition {
@@ -148,6 +168,8 @@ export interface PricedNdf extends NdfPosition {
   days_open?: number;
   accrued_cop?: number;
   error?: string;
+  pricing_status?: PricingStatus;
+  missing_fields?: string[];
 }
 
 export interface IbrSwapCashflow {
@@ -181,6 +203,8 @@ export interface PricedIbrSwap extends IbrSwapPosition {
   accrued_carry_cop?: number;
   cashflows?: IbrSwapCashflow[];
   error?: string;
+  pricing_status?: PricingStatus;
+  missing_fields?: string[];
 }
 
 // ── Portfolio summary ──


### PR DESCRIPTION
## Summary

- Phase 3.3 of epic #300 — companion PR para [xerenity-backend#117](https://github.com/avelezX/xerenity-backend/pull/117).
- Adopta los nuevos campos explícitos `pricing_status` + `missing_fields` que pysdk emite por row.
- **Backwards-compatible** — fallback al heurístico legacy (`promoteNullNpvToError`) cuando pysdk no envía los campos (deploys viejos).
- **Cierra el último sub-issue de Fase 3 → cierra epic #300.**

## Cambios

### [src/types/trading.ts](src/types/trading.ts)

- Nuevo type:
  ```ts
  export type PricingStatus = 'complete' | 'partial' | 'degraded';
  ```
- `pricing_status?: PricingStatus` + `missing_fields?: string[]` opcionales en `PricedXccy`, `PricedNdf`, `PricedIbrSwap`.

### [src/models/trading/repricePortfolio.ts](src/models/trading/repricePortfolio.ts)

- `promoteNullNpvToError` ahora prefiere el status del servidor si viene:
  - `complete` → sin error.
  - `partial` → sin error (NPV usable; solo aux fields como carry/DV01 missing).
  - `degraded` → error explícito con la lista exacta de missing_fields (mejor mensaje que el legacy genérico).
- Si `pricing_status` no viene → cae a la heurística null-NPV legacy. Comportamiento idéntico al de hoy.
- Nuevo `passthroughStatus(r)` que copia los campos al row final para que la UI / DevTools / tooltips los puedan leer.

### Tests

[src/__tests__/integration/reprice-concurrency.test.tsx](src/__tests__/integration/reprice-concurrency.test.tsx) +2 tests nuevos:

| Test | Valida |
|---|---|
| `pricing_status="degraded" surfaces error + missing_fields passthrough` | Path nuevo: backend dice "degraded" → row con error detallado + missing_fields presentes |
| `pricing_status="partial" passes through without surfacing an error` | NPV ok pero carry missing → row SIN error, status pasa al row |

El test legacy de `null npv_cop` sigue pasando, validando el fallback path.

## Test plan

- [x] `npm run test:run`: **21 passed** (incluye 2 nuevos para Phase 3.3).
- [x] `npx tsc --noEmit`: limpio.
- [x] `npm run build`: 72/72 páginas.
- [ ] Después de mergear xerenity-backend#117 + redesplegar pysdk: ver `pricing_status` en los response payloads (DevTools).
- [ ] Manual: posición con curva incompleta → ver tooltip con missing_fields específicos en lugar de "NPV incompleto" genérico.

## Orden de despliegue

1. **xerenity-backend#117** primero (manda a Fly).
2. Después este PR (FE).

Si el FE merge va antes que el backend, no rompe nada — el FE espera `pricing_status` opcional y cae al path legacy. Pero se pierde el beneficio hasta que el backend esté actualizado.

## Estado del épico #300 (Fase 3) tras este merge

| Sub-issue | Estado |
|---|---|
| 3.1 — Bulk loan summary | ✅ merged (PR #331) |
| 3.2 — Server-side aggregation | ✅ ya existía |
| **3.3 — pricing_status** | **este PR + xerenity-backend#117** |

**Después del merge → epic #300 se cierra → todas las Fases 0/1/2/3/4 completas.**

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
