### PR TITLE
feat(monitor): add Catálogo tab to collector detail page

### DIFF
--- a/src/models/catalog/index.ts
+++ b/src/models/catalog/index.ts
@@ -1,0 +1,181 @@
+// Thin RPC wrappers for the data catalog (sources, tables, consumers,
+// per-pair review). All endpoints super_admin-gated server-side.
+// Errors are normalised to { ok: false, error } so callers don't have
+// to know about Supabase's error shape.
+
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import type {
+  CollectorFullDetail,
+  DataConsumer,
+  DataSource,
+  DataTableMeta,
+  ReviewStatus,
+} from 'src/types/catalog';
+
+const supabase = createClientComponentClient();
+const SCHEMA = 'xerenity';
+
+export interface ActionResponse {
+  ok: boolean;
+  error?: string;
+}
+
+export interface DataResponse<T> {
+  data: T | null;
+  error?: string;
+}
+
+
+// ── reads ─────────────────────────────────────────────────────
+
+export async function getCollectorFullDetail(
+  collectorName: string,
+): Promise<DataResponse<CollectorFullDetail>> {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('get_collector_full_detail', { p_collector: collectorName });
+    if (error) return { data: null, error: error.message };
+    return { data: data as CollectorFullDetail, error: undefined };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function listDataSources(): Promise<DataResponse<DataSource[]>> {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('list_data_sources');
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as DataSource[] };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function listDataTables(): Promise<DataResponse<DataTableMeta[]>> {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('list_data_tables');
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as DataTableMeta[] };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function listDataConsumers(): Promise<DataResponse<DataConsumer[]>> {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('list_data_consumers');
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as DataConsumer[] };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function listDistinctClassification(
+  entity: 'data_sources' | 'data_tables_meta',
+  field: 'country' | 'category' | 'source_type' | 'consumer_type',
+): Promise<DataResponse<string[]>> {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('list_distinct_classification', { p_entity: entity, p_field: field });
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as string[] };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+
+// ── writes (super_admin only) ─────────────────────────────────
+
+export async function updateCollectorMetadata(
+  name: string,
+  sourceName: string | null,
+  notes: string | null,
+): Promise<ActionResponse> {
+  try {
+    const { error } = await supabase
+      .schema(SCHEMA)
+      .rpc('update_collector_metadata', {
+        p_name: name,
+        p_source_name: sourceName,
+        p_notes: notes,
+      });
+    if (error) return { ok: false, error: error.message };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function updateCollectorTableReview(
+  collectorName: string,
+  tableName: string,
+  status: ReviewStatus,
+  notes: string | null,
+): Promise<ActionResponse> {
+  try {
+    const { error } = await supabase
+      .schema(SCHEMA)
+      .rpc('update_collector_table_review', {
+        p_collector: collectorName,
+        p_table: tableName,
+        p_status: status,
+        p_notes: notes,
+      });
+    if (error) return { ok: false, error: error.message };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function updateDataSource(
+  source: Partial<DataSource> & { name: string; label: string },
+): Promise<ActionResponse> {
+  try {
+    const { error } = await supabase
+      .schema(SCHEMA)
+      .rpc('update_data_source', { p_payload: source });
+    if (error) return { ok: false, error: error.message };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function updateDataTable(
+  table: Partial<DataTableMeta> & { table_name: string; date_column: string },
+): Promise<ActionResponse> {
+  try {
+    const { error } = await supabase
+      .schema(SCHEMA)
+      .rpc('update_data_table', { p_payload: table });
+    if (error) return { ok: false, error: error.message };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function updateDataConsumer(
+  consumer: Partial<DataConsumer> & { name: string; consumer_type: string; label: string },
+): Promise<ActionResponse> {
+  try {
+    const { error } = await supabase
+      .schema(SCHEMA)
+      .rpc('update_data_consumer', { p_payload: consumer });
+    if (error) return { ok: false, error: error.message };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Error' };
+  }
+}

--- a/src/pages/admin/monitor/[name].tsx
+++ b/src/pages/admin/monitor/[name].tsx
@@ -15,6 +15,8 @@ import {
   faArrowLeft,
   faChevronDown,
   faChevronRight,
+  faGauge,
+  faBookOpen,
 } from '@fortawesome/free-solid-svg-icons';
 import styled from 'styled-components';
 import PageTitle from '@components/PageTitle';
@@ -22,6 +24,7 @@ import RoleGuard from 'src/components/RoleGuard';
 import useAppStore from 'src/store';
 import type { CollectorRun, CollectorOverview, RunStatus, Severity } from 'src/types/monitor';
 import { getCollectorDefinition } from 'src/models/monitor';
+import CatalogTab from './_CatalogTab';
 
 const SEV_BADGE: Record<Severity, string> = {
   critical: '#dc3545',
@@ -75,6 +78,36 @@ const BackLink = styled(Link)`
   &:hover { text-decoration: underline; }
 `;
 
+const TabBar = styled.div`
+  display: flex;
+  gap: 4px;
+  border-bottom: 2px solid #e5e5ec;
+  margin-bottom: 16px;
+`;
+
+const TabButton = styled.button<{ $active: boolean }>`
+  background: ${(p) => (p.$active ? '#fff' : 'transparent')};
+  border: none;
+  border-bottom: 3px solid ${(p) => (p.$active ? '#302b63' : 'transparent')};
+  color: ${(p) => (p.$active ? '#302b63' : '#777')};
+  font-weight: ${(p) => (p.$active ? 700 : 500)};
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 10px 18px;
+  margin-bottom: -2px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+
+  &:hover {
+    color: #302b63;
+    background: rgba(48, 43, 99, 0.04);
+  }
+`;
+
 const statusBadge = (status: RunStatus) => {
   const cfg: Record<RunStatus, { bg: string; icon: typeof faCircleCheck }> = {
     success: { bg: '#28a745', icon: faCircleCheck },
@@ -111,6 +144,7 @@ const CollectorDetailPage = () => {
 
   const [definition, setDefinition] = useState<CollectorOverview | null>(null);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [activeTab, setActiveTab] = useState<'estado' | 'catalogo'>('estado');
 
   const {
     collectorRuns,
@@ -147,101 +181,130 @@ const CollectorDetailPage = () => {
           </BackLink>
           <PageTitle>{name ?? 'Collector'}</PageTitle>
 
-          <Container fluid>
-            <Row>
-              <Col md={4}>
-                <InfoCard>
-                  <h4>Catálogo</h4>
-                  {definition ? (
-                    <dl>
-                      <dt>Severity</dt>
-                      <dd><Badge style={{ background: SEV_BADGE[definition.severity_default] }}>{definition.severity_default}</Badge></dd>
-                      <dt>Enabled</dt>
-                      <dd>{definition.enabled ? 'Sí' : 'No'}</dd>
-                      <dt>Cron</dt>
-                      <dd>{definition.schedule_cron ? <code>{definition.schedule_cron}</code> : <em>no-schedule</em>}</dd>
-                      <dt>Tablas</dt>
-                      <dd>{definition.target_tables.length > 0 ? definition.target_tables.join(', ') : <em>—</em>}</dd>
-                      <dt>Alertas</dt>
-                      <dd>{definition.open_alerts}</dd>
-                    </dl>
-                  ) : (
-                    <em style={{ color: '#888' }}>Cargando…</em>
-                  )}
-                </InfoCard>
-              </Col>
-              <Col md={8}>
-                <TimelineCard>
-                  <h4>Últimos runs ({runs.length})</h4>
-                  <table>
-                    <thead>
-                      <tr>
-                        <th aria-label="expand traceback" />
-                        <th>Inicio</th>
-                        <th>Status</th>
-                        <th>Duración</th>
-                        <th>Filas</th>
-                        <th>Exit</th>
-                        <th>Error</th>
-                        <th aria-label="external link" />
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {runs.map((run) => {
-                        const isExpanded = expanded[run.id] ?? false;
-                        const hasTraceback = Boolean(run.error_traceback);
-                        return (
-                          <React.Fragment key={run.id}>
-                            <tr className={run.status === 'failed' || run.status === 'timeout' ? 'failed' : ''}>
-                              <td
-                                className={hasTraceback ? 'expander' : ''}
-                                onClick={hasTraceback ? () => toggle(run.id) : undefined}
-                              >
-                                {hasTraceback && (
-                                  <Icon icon={isExpanded ? faChevronDown : faChevronRight} />
-                                )}
-                              </td>
-                              <td>{formatDate(run.started_at)}</td>
-                              <td>{statusBadge(run.status)}</td>
-                              <td>{formatDuration(run.duration_seconds)}</td>
-                              <td>{run.rows_inserted ?? '—'}</td>
-                              <td>{run.exit_code ?? '—'}</td>
-                              <td style={{ color: '#888', maxWidth: 280 }}>
-                                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                  {run.error_message ?? ''}
-                                </div>
-                              </td>
-                              <td>
-                                {run.gh_run_url && (
-                                  <a href={run.gh_run_url} target="_blank" rel="noreferrer" style={{ fontSize: 12 }}>
-                                    GH <Icon icon={faArrowUpRightFromSquare} />
-                                  </a>
-                                )}
-                              </td>
-                            </tr>
-                            {isExpanded && hasTraceback && (
-                              <tr>
-                                <td colSpan={8}>
-                                  <div className="traceback">{run.error_traceback}</div>
+          <TabBar role="tablist" aria-label="Vistas del collector">
+            <TabButton
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'estado'}
+              $active={activeTab === 'estado'}
+              onClick={() => setActiveTab('estado')}
+            >
+              <Icon icon={faGauge} /> Estado actual
+            </TabButton>
+            <TabButton
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'catalogo'}
+              $active={activeTab === 'catalogo'}
+              onClick={() => setActiveTab('catalogo')}
+            >
+              <Icon icon={faBookOpen} /> Catálogo
+            </TabButton>
+          </TabBar>
+
+          {activeTab === 'estado' && (
+            <Container fluid>
+              <Row>
+                <Col md={4}>
+                  <InfoCard>
+                    <h4>Catálogo</h4>
+                    {definition ? (
+                      <dl>
+                        <dt>Severity</dt>
+                        <dd><Badge style={{ background: SEV_BADGE[definition.severity_default] }}>{definition.severity_default}</Badge></dd>
+                        <dt>Enabled</dt>
+                        <dd>{definition.enabled ? 'Sí' : 'No'}</dd>
+                        <dt>Cron</dt>
+                        <dd>{definition.schedule_cron ? <code>{definition.schedule_cron}</code> : <em>no-schedule</em>}</dd>
+                        <dt>Tablas</dt>
+                        <dd>{definition.target_tables.length > 0 ? definition.target_tables.join(', ') : <em>—</em>}</dd>
+                        <dt>Alertas</dt>
+                        <dd>{definition.open_alerts}</dd>
+                      </dl>
+                    ) : (
+                      <em style={{ color: '#888' }}>Cargando…</em>
+                    )}
+                  </InfoCard>
+                </Col>
+                <Col md={8}>
+                  <TimelineCard>
+                    <h4>Últimos runs ({runs.length})</h4>
+                    <table>
+                      <thead>
+                        <tr>
+                          <th aria-label="expand traceback" />
+                          <th>Inicio</th>
+                          <th>Status</th>
+                          <th>Duración</th>
+                          <th>Filas</th>
+                          <th>Exit</th>
+                          <th>Error</th>
+                          <th aria-label="external link" />
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {runs.map((run) => {
+                          const isExpanded = expanded[run.id] ?? false;
+                          const hasTraceback = Boolean(run.error_traceback);
+                          return (
+                            <React.Fragment key={run.id}>
+                              <tr className={run.status === 'failed' || run.status === 'timeout' ? 'failed' : ''}>
+                                <td
+                                  className={hasTraceback ? 'expander' : ''}
+                                  onClick={hasTraceback ? () => toggle(run.id) : undefined}
+                                >
+                                  {hasTraceback && (
+                                    <Icon icon={isExpanded ? faChevronDown : faChevronRight} />
+                                  )}
+                                </td>
+                                <td>{formatDate(run.started_at)}</td>
+                                <td>{statusBadge(run.status)}</td>
+                                <td>{formatDuration(run.duration_seconds)}</td>
+                                <td>{run.rows_inserted ?? '—'}</td>
+                                <td>{run.exit_code ?? '—'}</td>
+                                <td style={{ color: '#888', maxWidth: 280 }}>
+                                  <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                    {run.error_message ?? ''}
+                                  </div>
+                                </td>
+                                <td>
+                                  {run.gh_run_url && (
+                                    <a href={run.gh_run_url} target="_blank" rel="noreferrer" style={{ fontSize: 12 }}>
+                                      GH <Icon icon={faArrowUpRightFromSquare} />
+                                    </a>
+                                  )}
                                 </td>
                               </tr>
-                            )}
-                          </React.Fragment>
-                        );
-                      })}
-                      {runs.length === 0 && (
-                        <tr>
-                          <td colSpan={8} style={{ textAlign: 'center', color: '#999', padding: 24 }}>
-                            Sin runs registrados aún.
-                          </td>
-                        </tr>
-                      )}
-                    </tbody>
-                  </table>
-                </TimelineCard>
-              </Col>
-            </Row>
-          </Container>
+                              {isExpanded && hasTraceback && (
+                                <tr>
+                                  <td colSpan={8}>
+                                    <div className="traceback">{run.error_traceback}</div>
+                                  </td>
+                                </tr>
+                              )}
+                            </React.Fragment>
+                          );
+                        })}
+                        {runs.length === 0 && (
+                          <tr>
+                            <td colSpan={8} style={{ textAlign: 'center', color: '#999', padding: 24 }}>
+                              Sin runs registrados aún.
+                            </td>
+                          </tr>
+                        )}
+                      </tbody>
+                    </table>
+                  </TimelineCard>
+                </Col>
+              </Row>
+            </Container>
+          )}
+
+          {activeTab === 'catalogo' && name && (
+            <Container fluid>
+              <CatalogTab collectorName={name} />
+            </Container>
+          )}
         </PageWrap>
       </RoleGuard>
     </CoreLayout>

--- a/src/pages/admin/monitor/_CatalogTab.tsx
+++ b/src/pages/admin/monitor/_CatalogTab.tsx
@@ -104,17 +104,18 @@ const TableBlock = styled.div`
   .table-meta { font-size: 11px; color: #888; }
 `;
 
-const Notes = styled.div`
-  font-size: 13px;
-  color: #444;
-  white-space: pre-wrap;
-  background: #fafaff;
-  border: 1px dashed #d8d8e6;
-  border-radius: 4px;
-  padding: 10px 12px;
-  min-height: 38px;
-  &.empty { color: #aaa; font-style: italic; }
-`;
+const HEALTH_BG: Record<HealthStatus, string> = {
+  healthy: '#d4edda',
+  degraded: '#fff3cd',
+  down: '#f8d7da',
+  unknown: '#e9ecef',
+};
+const HEALTH_FG: Record<HealthStatus, string> = {
+  healthy: '#155724',
+  degraded: '#856404',
+  down: '#721c24',
+  unknown: '#495057',
+};
 
 const HealthBadge = styled.span<{ $status: HealthStatus }>`
   display: inline-flex;
@@ -128,19 +129,6 @@ const HealthBadge = styled.span<{ $status: HealthStatus }>`
   background: ${(p) => HEALTH_BG[p.$status]};
   color: ${(p) => HEALTH_FG[p.$status]};
 `;
-
-const HEALTH_BG: Record<HealthStatus, string> = {
-  healthy: '#d4edda',
-  degraded: '#fff3cd',
-  down: '#f8d7da',
-  unknown: '#e9ecef',
-};
-const HEALTH_FG: Record<HealthStatus, string> = {
-  healthy: '#155724',
-  degraded: '#856404',
-  down: '#721c24',
-  unknown: '#495057',
-};
 
 const REVIEW_LABELS: Record<ReviewStatus, string> = {
   pendiente: 'Pendiente',
@@ -219,6 +207,87 @@ function useDebouncedSave<TArgs extends unknown[]>(
 // ─────────────────────────────────────────────────────────────────
 // Sub-sections
 // ─────────────────────────────────────────────────────────────────
+
+const SaveStatus: React.FC<{
+  savingState: 'idle' | 'saving' | 'saved' | 'error';
+  savedAt: number | null;
+}> = ({ savingState, savedAt }) => {
+  if (savingState === 'idle') return null;
+  return (
+    <div style={{ fontSize: 11, color: '#888', marginTop: 4, display: 'flex', alignItems: 'center', gap: 4 }}>
+      {savingState === 'saving' && (
+        <><Spinner animation="border" size="sm" style={{ width: 10, height: 10 }} /> Guardando…</>
+      )}
+      {savingState === 'saved' && savedAt && (
+        <><Icon icon={faCircleCheck} style={{ color: '#28a745' }} /> Guardado {formatRelative(new Date(savedAt).toISOString())}</>
+      )}
+      {savingState === 'error' && (
+        <><Icon icon={faCircleXmark} style={{ color: '#dc3545' }} /> Error al guardar</>
+      )}
+    </div>
+  );
+};
+
+const ReviewBlock: React.FC<{
+  collectorName: string;
+  tableName: string;
+  review: { review_status: ReviewStatus; notes: string | null; reviewed_at: string | null; reviewed_by_email: string | null } | undefined;
+  save: (collectorName: string, tableName: string, status: ReviewStatus, notes: string | null) => Promise<{ ok: boolean; error?: string }>;
+}> = ({ collectorName, tableName, review, save }) => {
+  const [statusDraft, setStatusDraft] = useState<ReviewStatus>(review?.review_status ?? 'pendiente');
+  const [notesDraft, setNotesDraft] = useState(review?.notes ?? '');
+
+  useEffect(() => {
+    setStatusDraft(review?.review_status ?? 'pendiente');
+    setNotesDraft(review?.notes ?? '');
+  }, [review?.review_status, review?.notes]);
+
+  const { schedule, savingState, savedAt } = useDebouncedSave(
+    (s: ReviewStatus, n: string | null) => save(collectorName, tableName, s, n),
+  );
+
+  return (
+    <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px dashed #ddd' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8, flexWrap: 'wrap' }}>
+        <span style={{ fontSize: 11, fontWeight: 600, color: '#555', textTransform: 'uppercase' }}>Estado de revisión:</span>
+        <Form.Select
+          size="sm"
+          value={statusDraft}
+          onChange={(e) => {
+            const v = e.target.value as ReviewStatus;
+            setStatusDraft(v);
+            schedule(v, notesDraft || null);
+          }}
+          style={{ maxWidth: 180, display: 'inline-block' }}
+        >
+          {(Object.keys(REVIEW_LABELS) as ReviewStatus[]).map((k) => (
+            <option key={k} value={k}>{REVIEW_LABELS[k]}</option>
+          ))}
+        </Form.Select>
+        <Badge style={{ background: REVIEW_BG[statusDraft] }}>
+          {REVIEW_LABELS[statusDraft]}
+        </Badge>
+        {review?.reviewed_at && review.reviewed_by_email && (
+          <span style={{ fontSize: 11, color: '#888' }}>
+            Última: {formatRelative(review.reviewed_at)} por {review.reviewed_by_email}
+          </span>
+        )}
+      </div>
+      <Form.Control
+        as="textarea"
+        rows={2}
+        placeholder="Notas sobre esta tabla específica (selectores, filtros, decisiones)…"
+        value={notesDraft}
+        onChange={(e) => {
+          setNotesDraft(e.target.value);
+          schedule(statusDraft, e.target.value || null);
+        }}
+        style={{ fontSize: 12 }}
+      />
+      <SaveStatus savingState={savingState} savedAt={savedAt} />
+    </div>
+  );
+};
 
 const OrigenSection: React.FC<{ collectorName: string }> = ({ collectorName }) => {
   const { detail, sources, save, loadRegistries } = useAppStore((s) => ({
@@ -302,26 +371,6 @@ const OrigenSection: React.FC<{ collectorName: string }> = ({ collectorName }) =
         <SaveStatus savingState={savingState} savedAt={savedAt} />
       </div>
     </Section>
-  );
-};
-
-const SaveStatus: React.FC<{
-  savingState: 'idle' | 'saving' | 'saved' | 'error';
-  savedAt: number | null;
-}> = ({ savingState, savedAt }) => {
-  if (savingState === 'idle') return null;
-  return (
-    <div style={{ fontSize: 11, color: '#888', marginTop: 4, display: 'flex', alignItems: 'center', gap: 4 }}>
-      {savingState === 'saving' && (
-        <><Spinner animation="border" size="sm" style={{ width: 10, height: 10 }} /> Guardando…</>
-      )}
-      {savingState === 'saved' && savedAt && (
-        <><Icon icon={faCircleCheck} style={{ color: '#28a745' }} /> Guardado {formatRelative(new Date(savedAt).toISOString())}</>
-      )}
-      {savingState === 'error' && (
-        <><Icon icon={faCircleXmark} style={{ color: '#dc3545' }} /> Error al guardar</>
-      )}
-    </div>
   );
 };
 
@@ -434,67 +483,6 @@ const SeriesSection: React.FC<{
         </TableBlock>
       ))}
     </Section>
-  );
-};
-
-const ReviewBlock: React.FC<{
-  collectorName: string;
-  tableName: string;
-  review: { review_status: ReviewStatus; notes: string | null; reviewed_at: string | null; reviewed_by_email: string | null } | undefined;
-  save: (collectorName: string, tableName: string, status: ReviewStatus, notes: string | null) => Promise<{ ok: boolean; error?: string }>;
-}> = ({ collectorName, tableName, review, save }) => {
-  const [statusDraft, setStatusDraft] = useState<ReviewStatus>(review?.review_status ?? 'pendiente');
-  const [notesDraft, setNotesDraft] = useState(review?.notes ?? '');
-
-  useEffect(() => {
-    setStatusDraft(review?.review_status ?? 'pendiente');
-    setNotesDraft(review?.notes ?? '');
-  }, [review?.review_status, review?.notes]);
-
-  const { schedule, savingState, savedAt } = useDebouncedSave(
-    (s: ReviewStatus, n: string | null) => save(collectorName, tableName, s, n),
-  );
-
-  return (
-    <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px dashed #ddd' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8, flexWrap: 'wrap' }}>
-        <span style={{ fontSize: 11, fontWeight: 600, color: '#555', textTransform: 'uppercase' }}>Estado de revisión:</span>
-        <Form.Select
-          size="sm"
-          value={statusDraft}
-          onChange={(e) => {
-            const v = e.target.value as ReviewStatus;
-            setStatusDraft(v);
-            schedule(v, notesDraft || null);
-          }}
-          style={{ maxWidth: 180, display: 'inline-block' }}
-        >
-          {(Object.keys(REVIEW_LABELS) as ReviewStatus[]).map((k) => (
-            <option key={k} value={k}>{REVIEW_LABELS[k]}</option>
-          ))}
-        </Form.Select>
-        <Badge style={{ background: REVIEW_BG[statusDraft] }}>
-          {REVIEW_LABELS[statusDraft]}
-        </Badge>
-        {review?.reviewed_at && review.reviewed_by_email && (
-          <span style={{ fontSize: 11, color: '#888' }}>
-            Última: {formatRelative(review.reviewed_at)} por {review.reviewed_by_email}
-          </span>
-        )}
-      </div>
-      <Form.Control
-        as="textarea"
-        rows={2}
-        placeholder="Notas sobre esta tabla específica (selectores, filtros, decisiones)…"
-        value={notesDraft}
-        onChange={(e) => {
-          setNotesDraft(e.target.value);
-          schedule(statusDraft, e.target.value || null);
-        }}
-        style={{ fontSize: 12 }}
-      />
-      <SaveStatus savingState={savingState} savedAt={savedAt} />
-    </div>
   );
 };
 

--- a/src/pages/admin/monitor/_CatalogTab.tsx
+++ b/src/pages/admin/monitor/_CatalogTab.tsx
@@ -1,0 +1,585 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { Badge, Form, Spinner } from 'react-bootstrap';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import {
+  faGlobe,
+  faDatabase,
+  faPeopleArrows,
+  faPenToSquare,
+  faStar,
+  faCircleCheck,
+  faCircleExclamation,
+  faCircleXmark,
+} from '@fortawesome/free-solid-svg-icons';
+import { toast } from 'react-toastify';
+import useAppStore from 'src/store';
+import type {
+  CollectorTableSeries,
+  SliceBreakdown,
+  ReviewStatus,
+  HealthStatus,
+} from 'src/types/catalog';
+
+// ─────────────────────────────────────────────────────────────────
+// Styling
+// ─────────────────────────────────────────────────────────────────
+
+const Section = styled.section`
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px 20px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  margin-bottom: 16px;
+`;
+
+const SectionHeader = styled.h4`
+  font-size: 14px;
+  font-weight: 700;
+  color: #302b63;
+  margin: 0 0 14px 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const KeyValueGrid = styled.dl`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 8px 16px;
+  font-size: 13px;
+  margin: 0;
+  dt { font-weight: 600; color: #555; }
+  dd { margin: 0; word-break: break-word; }
+  code { font-family: monospace; background: #f3f3f7; padding: 2px 6px; border-radius: 3px; font-size: 12px; }
+  a { color: #302b63; }
+`;
+
+const SubTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  margin-top: 8px;
+  thead th {
+    background: #fafaff;
+    text-transform: uppercase;
+    color: #555;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 6px 10px;
+    text-align: left;
+    border-bottom: 1px solid #eee;
+  }
+  tbody td {
+    padding: 6px 10px;
+    border-bottom: 1px solid #f5f5f5;
+    vertical-align: middle;
+  }
+  tbody tr:hover { background: rgba(48, 43, 99, 0.03); }
+`;
+
+const TableBlock = styled.div`
+  border: 1px solid #eee;
+  border-radius: 6px;
+  padding: 12px 14px;
+  margin-bottom: 12px;
+  background: #fcfcff;
+
+  &.is-critical {
+    border-left: 4px solid #dc3545;
+    background: #fff8f8;
+  }
+
+  .header-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 6px;
+  }
+  .table-name code { font-family: monospace; font-weight: 600; }
+  .table-meta { font-size: 11px; color: #888; }
+`;
+
+const Notes = styled.div`
+  font-size: 13px;
+  color: #444;
+  white-space: pre-wrap;
+  background: #fafaff;
+  border: 1px dashed #d8d8e6;
+  border-radius: 4px;
+  padding: 10px 12px;
+  min-height: 38px;
+  &.empty { color: #aaa; font-style: italic; }
+`;
+
+const HealthBadge = styled.span<{ $status: HealthStatus }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  background: ${(p) => HEALTH_BG[p.$status]};
+  color: ${(p) => HEALTH_FG[p.$status]};
+`;
+
+const HEALTH_BG: Record<HealthStatus, string> = {
+  healthy: '#d4edda',
+  degraded: '#fff3cd',
+  down: '#f8d7da',
+  unknown: '#e9ecef',
+};
+const HEALTH_FG: Record<HealthStatus, string> = {
+  healthy: '#155724',
+  degraded: '#856404',
+  down: '#721c24',
+  unknown: '#495057',
+};
+
+const REVIEW_LABELS: Record<ReviewStatus, string> = {
+  pendiente: 'Pendiente',
+  mantener: 'Mantener',
+  arreglar: 'Arreglar',
+  deprecar: 'Deprecar',
+  documentar: 'Documentar',
+};
+
+const REVIEW_BG: Record<ReviewStatus, string> = {
+  pendiente: '#e9ecef',
+  mantener: '#28a745',
+  arreglar: '#f0ad4e',
+  deprecar: '#dc3545',
+  documentar: '#5bc0de',
+};
+
+const formatRelative = (iso: string | null): string => {
+  if (!iso) return 'sin fecha';
+  const ms = Date.now() - new Date(iso).getTime();
+  const days = ms / 86400000;
+  if (days < 1) {
+    const hours = Math.round(ms / 3600000);
+    return `hace ${hours}h`;
+  }
+  if (days < 30) return `hace ${Math.round(days)}d`;
+  const months = days / 30;
+  if (months < 12) return `hace ${months.toFixed(1)} meses`;
+  return `hace ${(months / 12).toFixed(1)} años`;
+};
+
+const formatCadence = (days: number | null): string => {
+  if (days === null || days === undefined) return '—';
+  if (days < 1) return `~${(days * 24).toFixed(1)}h`;
+  if (days < 5) return `~${days.toFixed(1)}d`;
+  if (days < 14) return `~${days.toFixed(0)}d (semanal?)`;
+  if (days < 60) return `~${days.toFixed(0)}d (mensual?)`;
+  return `~${days.toFixed(0)}d`;
+};
+
+const isErrorRow = (row: SliceBreakdown | { error: string }): row is { error: string } =>
+  'error' in row;
+
+
+// ─────────────────────────────────────────────────────────────────
+// Inline-edit helpers
+// ─────────────────────────────────────────────────────────────────
+
+function useDebouncedSave<TArgs extends unknown[]>(
+  fn: (...args: TArgs) => Promise<{ ok: boolean; error?: string }>,
+  delayMs = 800,
+) {
+  const [savingState, setSavingState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+  const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const schedule = (...args: TArgs) => {
+    setSavingState('saving');
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(async () => {
+      const res = await fn(...args);
+      if (res.ok) {
+        setSavingState('saved');
+        setSavedAt(Date.now());
+      } else {
+        setSavingState('error');
+        toast.error(res.error ?? 'Error al guardar');
+      }
+    }, delayMs);
+  };
+
+  return { schedule, savingState, savedAt };
+}
+
+
+// ─────────────────────────────────────────────────────────────────
+// Sub-sections
+// ─────────────────────────────────────────────────────────────────
+
+const OrigenSection: React.FC<{ collectorName: string }> = ({ collectorName }) => {
+  const { detail, sources, save, loadRegistries } = useAppStore((s) => ({
+    detail: s.catalogDetail[collectorName],
+    sources: s.catalogSources,
+    save: s.saveCollectorMetadata,
+    loadRegistries: s.loadCatalogRegistries,
+  }));
+
+  useEffect(() => {
+    if (sources.length === 0) loadRegistries();
+  }, [sources.length, loadRegistries]);
+
+  const [notesDraft, setNotesDraft] = useState(detail?.definition.notes ?? '');
+  const [sourceDraft, setSourceDraft] = useState(detail?.definition.source_name ?? '');
+
+  useEffect(() => {
+    setNotesDraft(detail?.definition.notes ?? '');
+    setSourceDraft(detail?.definition.source_name ?? '');
+  }, [detail?.definition.notes, detail?.definition.source_name]);
+
+  const { schedule, savingState, savedAt } = useDebouncedSave(
+    (newSource: string | null, newNotes: string | null) =>
+      save(collectorName, newSource, newNotes),
+  );
+
+  if (!detail) return null;
+  const src = detail.source;
+
+  return (
+    <Section>
+      <SectionHeader><Icon icon={faGlobe} /> Origen</SectionHeader>
+      <KeyValueGrid>
+        <dt>Fuente:</dt>
+        <dd>
+          <Form.Select
+            size="sm"
+            value={sourceDraft || ''}
+            onChange={(e) => {
+              const v = e.target.value || null;
+              setSourceDraft(v ?? '');
+              schedule(v, notesDraft || null);
+            }}
+            style={{ maxWidth: 360, display: 'inline-block' }}
+          >
+            <option value="">— Sin fuente asignada —</option>
+            {sources.map((s) => (
+              <option key={s.name} value={s.name}>
+                {s.label} ({s.country ?? '?'})
+              </option>
+            ))}
+          </Form.Select>
+        </dd>
+
+        {src && (
+          <>
+            <dt>País:</dt>           <dd>{src.country ?? '—'}</dd>
+            <dt>Tipo de pull:</dt>   <dd><code>{src.source_type ?? '—'}</code></dd>
+            <dt>URL:</dt>            <dd>{src.base_url ? <a href={src.base_url} target="_blank" rel="noreferrer">{src.base_url}</a> : '—'}</dd>
+            <dt>Publish:</dt>        <dd>{src.publish_schedule ?? '—'}</dd>
+            <dt>Health:</dt>         <dd><HealthBadge $status={src.health_status}>{src.health_status}</HealthBadge></dd>
+          </>
+        )}
+      </KeyValueGrid>
+
+      <div style={{ marginTop: 14 }}>
+        <div style={{ fontWeight: 600, fontSize: 12, color: '#555', marginBottom: 4 }}>
+          Notas del collector <Icon icon={faPenToSquare} style={{ fontSize: 10, color: '#bbb' }} />
+        </div>
+        <Form.Control
+          as="textarea"
+          rows={3}
+          placeholder="Notas operativas, gotchas, historial de decisiones (markdown plano)…"
+          value={notesDraft}
+          onChange={(e) => {
+            setNotesDraft(e.target.value);
+            schedule(sourceDraft || null, e.target.value || null);
+          }}
+          style={{ fontSize: 13 }}
+        />
+        <SaveStatus savingState={savingState} savedAt={savedAt} />
+      </div>
+    </Section>
+  );
+};
+
+const SaveStatus: React.FC<{
+  savingState: 'idle' | 'saving' | 'saved' | 'error';
+  savedAt: number | null;
+}> = ({ savingState, savedAt }) => {
+  if (savingState === 'idle') return null;
+  return (
+    <div style={{ fontSize: 11, color: '#888', marginTop: 4, display: 'flex', alignItems: 'center', gap: 4 }}>
+      {savingState === 'saving' && (
+        <><Spinner animation="border" size="sm" style={{ width: 10, height: 10 }} /> Guardando…</>
+      )}
+      {savingState === 'saved' && savedAt && (
+        <><Icon icon={faCircleCheck} style={{ color: '#28a745' }} /> Guardado {formatRelative(new Date(savedAt).toISOString())}</>
+      )}
+      {savingState === 'error' && (
+        <><Icon icon={faCircleXmark} style={{ color: '#dc3545' }} /> Error al guardar</>
+      )}
+    </div>
+  );
+};
+
+const SeriesSection: React.FC<{
+  series: CollectorTableSeries[];
+  collectorName: string;
+}> = ({ series, collectorName }) => {
+  const { detail, save } = useAppStore((s) => ({
+    detail: s.catalogDetail[collectorName],
+    save: s.saveCollectorTableReview,
+  }));
+  const reviewByTable = useMemo(() => {
+    const map: Record<string, typeof detail.reviews[number]> = {};
+    detail?.reviews.forEach((r) => { map[r.table_name] = r; });
+    return map;
+  }, [detail]);
+
+  return (
+    <Section>
+      <SectionHeader><Icon icon={faDatabase} /> Series por tabla destino</SectionHeader>
+      {series.length === 0 && (
+        <div style={{ color: '#888', fontStyle: 'italic', fontSize: 13 }}>
+          Este collector no tiene tablas destino registradas.
+        </div>
+      )}
+      {series.map((s) => (
+        <TableBlock key={s.table_name} className={s.is_critical ? 'is-critical' : ''}>
+          <div className="header-row">
+            <div className="table-name">
+              {s.is_critical && (
+                <Icon icon={faStar} style={{ color: '#dc3545', marginRight: 6 }} />
+              )}
+              <code>{s.table_name}</code>
+              {s.label && <span style={{ marginLeft: 8, color: '#666', fontSize: 12 }}>{s.label}</span>}
+            </div>
+            <div className="table-meta">
+              {s.country && <Badge bg="secondary" style={{ marginRight: 6 }}>{s.country}</Badge>}
+              {s.category && <Badge bg="info">{s.category}</Badge>}
+            </div>
+          </div>
+
+          {!s.meta_present && (
+            <div style={{ color: '#dc3545', fontSize: 12, padding: '8px 0' }}>
+              ⚠ Tabla no registrada en data_tables_meta. Agregar en una migración futura.
+            </div>
+          )}
+
+          {s.meta_present && s.slices.length === 0 && (
+            <div style={{ color: '#888', fontStyle: 'italic', fontSize: 12 }}>
+              Sin filas en la tabla.
+            </div>
+          )}
+
+          {s.meta_present && s.slices.length > 0 && isErrorRow(s.slices[0]) && (
+            <div style={{ color: '#dc3545', fontSize: 12 }}>
+              Error calculando series: {(s.slices[0] as { error: string }).error}
+            </div>
+          )}
+
+          {s.meta_present && s.slices.length > 0 && !isErrorRow(s.slices[0]) && (
+            <SubTable>
+              <thead>
+                <tr>
+                  <th>Slice {s.slice_column ? <code>{s.slice_column}</code> : ''}</th>
+                  <th>Última fecha</th>
+                  <th>Filas</th>
+                  <th>Cadencia obs.</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(s.slices as SliceBreakdown[]).map((slice) => {
+                  const lastDate = slice.last_date;
+                  let statusIcon = <Icon icon={faCircleCheck} style={{ color: '#28a745' }} />;
+                  let statusText = 'fresca';
+                  if (lastDate) {
+                    const ageDays = (Date.now() - new Date(lastDate).getTime()) / 86400000;
+                    if (ageDays > 14) {
+                      statusIcon = <Icon icon={faCircleXmark} style={{ color: '#dc3545' }} />;
+                      statusText = `stale ${Math.round(ageDays)}d`;
+                    } else if (ageDays > 3) {
+                      statusIcon = <Icon icon={faCircleExclamation} style={{ color: '#f0ad4e' }} />;
+                      statusText = `${Math.round(ageDays)}d`;
+                    }
+                  } else {
+                    statusIcon = <Icon icon={faCircleXmark} style={{ color: '#dc3545' }} />;
+                    statusText = 'sin datos';
+                  }
+                  return (
+                    <tr key={slice.slice_value}>
+                      <td><code>{slice.slice_value}</code></td>
+                      <td>{lastDate ?? '—'}</td>
+                      <td>{slice.row_count.toLocaleString()}</td>
+                      <td>{formatCadence(slice.cadence_days)}</td>
+                      <td>{statusIcon} <span style={{ fontSize: 11, color: '#666' }}>{statusText}</span></td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </SubTable>
+          )}
+
+          {/* Per-(collector, table) review */}
+          <ReviewBlock
+            collectorName={collectorName}
+            tableName={s.table_name}
+            review={reviewByTable[s.table_name]}
+            save={save}
+          />
+        </TableBlock>
+      ))}
+    </Section>
+  );
+};
+
+const ReviewBlock: React.FC<{
+  collectorName: string;
+  tableName: string;
+  review: { review_status: ReviewStatus; notes: string | null; reviewed_at: string | null; reviewed_by_email: string | null } | undefined;
+  save: (collectorName: string, tableName: string, status: ReviewStatus, notes: string | null) => Promise<{ ok: boolean; error?: string }>;
+}> = ({ collectorName, tableName, review, save }) => {
+  const [statusDraft, setStatusDraft] = useState<ReviewStatus>(review?.review_status ?? 'pendiente');
+  const [notesDraft, setNotesDraft] = useState(review?.notes ?? '');
+
+  useEffect(() => {
+    setStatusDraft(review?.review_status ?? 'pendiente');
+    setNotesDraft(review?.notes ?? '');
+  }, [review?.review_status, review?.notes]);
+
+  const { schedule, savingState, savedAt } = useDebouncedSave(
+    (s: ReviewStatus, n: string | null) => save(collectorName, tableName, s, n),
+  );
+
+  return (
+    <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px dashed #ddd' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8, flexWrap: 'wrap' }}>
+        <span style={{ fontSize: 11, fontWeight: 600, color: '#555', textTransform: 'uppercase' }}>Estado de revisión:</span>
+        <Form.Select
+          size="sm"
+          value={statusDraft}
+          onChange={(e) => {
+            const v = e.target.value as ReviewStatus;
+            setStatusDraft(v);
+            schedule(v, notesDraft || null);
+          }}
+          style={{ maxWidth: 180, display: 'inline-block' }}
+        >
+          {(Object.keys(REVIEW_LABELS) as ReviewStatus[]).map((k) => (
+            <option key={k} value={k}>{REVIEW_LABELS[k]}</option>
+          ))}
+        </Form.Select>
+        <Badge style={{ background: REVIEW_BG[statusDraft] }}>
+          {REVIEW_LABELS[statusDraft]}
+        </Badge>
+        {review?.reviewed_at && review.reviewed_by_email && (
+          <span style={{ fontSize: 11, color: '#888' }}>
+            Última: {formatRelative(review.reviewed_at)} por {review.reviewed_by_email}
+          </span>
+        )}
+      </div>
+      <Form.Control
+        as="textarea"
+        rows={2}
+        placeholder="Notas sobre esta tabla específica (selectores, filtros, decisiones)…"
+        value={notesDraft}
+        onChange={(e) => {
+          setNotesDraft(e.target.value);
+          schedule(statusDraft, e.target.value || null);
+        }}
+        style={{ fontSize: 12 }}
+      />
+      <SaveStatus savingState={savingState} savedAt={savedAt} />
+    </div>
+  );
+};
+
+const ConsumidoresSection: React.FC<{ consumers: { name: string; consumer_type: string; label: string; path: string | null; reads_tables: string[]; writes_tables: string[] }[] }> = ({ consumers }) => (
+  <Section>
+    <SectionHeader>
+      <Icon icon={faPeopleArrows} /> Consumidores ({consumers.length})
+    </SectionHeader>
+    {consumers.length === 0 ? (
+      <div style={{ color: '#888', fontStyle: 'italic', fontSize: 13 }}>
+        Ningún consumidor registrado leyendo las tablas de este collector. La página /admin/data-catalog (próximamente) permitirá registrarlos.
+      </div>
+    ) : (
+      <SubTable>
+        <thead>
+          <tr>
+            <th>Tipo</th>
+            <th>Nombre</th>
+            <th>Path</th>
+            <th>Lee tablas</th>
+            <th>Escribe tablas</th>
+          </tr>
+        </thead>
+        <tbody>
+          {consumers.map((c) => (
+            <tr key={c.name}>
+              <td><Badge bg="secondary" style={{ fontSize: 10 }}>{c.consumer_type}</Badge></td>
+              <td><strong>{c.label}</strong></td>
+              <td style={{ color: '#666', fontFamily: 'monospace', fontSize: 11 }}>{c.path ?? '—'}</td>
+              <td style={{ fontSize: 11 }}>{c.reads_tables.length > 0 ? c.reads_tables.join(', ') : '—'}</td>
+              <td style={{ fontSize: 11 }}>
+                {c.writes_tables.length > 0 ? (
+                  <Badge bg="warning" text="dark" style={{ fontSize: 10 }}>
+                    ⭐ escribe {c.writes_tables.join(', ')}
+                  </Badge>
+                ) : '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </SubTable>
+    )}
+  </Section>
+);
+
+
+// ─────────────────────────────────────────────────────────────────
+// Top-level CatalogTab
+// ─────────────────────────────────────────────────────────────────
+
+const CatalogTab: React.FC<{ collectorName: string }> = ({ collectorName }) => {
+  const { detail, loading, error, load } = useAppStore((s) => ({
+    detail: s.catalogDetail[collectorName],
+    loading: !!s.catalogDetailLoading[collectorName],
+    error: s.catalogDetailError,
+    load: s.loadCollectorDetail,
+  }));
+
+  useEffect(() => {
+    if (!detail) load(collectorName);
+  }, [collectorName, detail, load]);
+
+  if (error) {
+    return (
+      <Section>
+        <div style={{ color: '#dc3545' }}>Error cargando catálogo: {error}</div>
+      </Section>
+    );
+  }
+
+  if (loading || !detail) {
+    return (
+      <Section>
+        <Spinner animation="border" size="sm" /> Cargando catálogo…
+      </Section>
+    );
+  }
+
+  return (
+    <div>
+      <OrigenSection collectorName={collectorName} />
+      <SeriesSection series={detail.series} collectorName={collectorName} />
+      <ConsumidoresSection consumers={detail.consumers} />
+    </div>
+  );
+};
+
+export default CatalogTab;

--- a/src/store/catalog/index.ts
+++ b/src/store/catalog/index.ts
@@ -1,0 +1,128 @@
+import { StateCreator } from 'zustand';
+import type {
+  CollectorFullDetail,
+  DataSource,
+  DataTableMeta,
+  DataConsumer,
+  ReviewStatus,
+} from 'src/types/catalog';
+import {
+  getCollectorFullDetail,
+  listDataSources,
+  listDataTables,
+  listDataConsumers,
+  listDistinctClassification,
+  updateCollectorMetadata,
+  updateCollectorTableReview,
+  ActionResponse,
+} from 'src/models/catalog';
+
+export interface CatalogSlice {
+  // Per-collector full detail (cached by collector name)
+  catalogDetail: Record<string, CollectorFullDetail>;
+  catalogDetailLoading: Record<string, boolean>;
+  catalogDetailError: string | undefined;
+
+  // Global registries (used for the autocomplete + future catalog tab)
+  catalogSources: DataSource[];
+  catalogTables: DataTableMeta[];
+  catalogConsumers: DataConsumer[];
+
+  // Distinct classification values keyed by `${entity}:${field}` for autocomplete
+  catalogDistinctValues: Record<string, string[]>;
+
+  loadCollectorDetail: (collectorName: string) => Promise<void>;
+  loadCatalogRegistries: () => Promise<void>;
+  loadDistinctValues: (
+    entity: 'data_sources' | 'data_tables_meta',
+    field: 'country' | 'category' | 'source_type' | 'consumer_type',
+  ) => Promise<void>;
+
+  saveCollectorMetadata: (
+    name: string,
+    sourceName: string | null,
+    notes: string | null,
+  ) => Promise<ActionResponse>;
+
+  saveCollectorTableReview: (
+    collectorName: string,
+    tableName: string,
+    status: ReviewStatus,
+    notes: string | null,
+  ) => Promise<ActionResponse>;
+}
+
+const initialState = {
+  catalogDetail: {} as Record<string, CollectorFullDetail>,
+  catalogDetailLoading: {} as Record<string, boolean>,
+  catalogDetailError: undefined as string | undefined,
+  catalogSources: [] as DataSource[],
+  catalogTables: [] as DataTableMeta[],
+  catalogConsumers: [] as DataConsumer[],
+  catalogDistinctValues: {} as Record<string, string[]>,
+};
+
+const createCatalogSlice: StateCreator<CatalogSlice> = (set, get) => ({
+  ...initialState,
+
+  loadCollectorDetail: async (collectorName) => {
+    set((s) => ({
+      catalogDetailLoading: { ...s.catalogDetailLoading, [collectorName]: true },
+      catalogDetailError: undefined,
+    }));
+    const res = await getCollectorFullDetail(collectorName);
+    if (res.error || !res.data) {
+      set((s) => ({
+        catalogDetailLoading: { ...s.catalogDetailLoading, [collectorName]: false },
+        catalogDetailError: res.error,
+      }));
+      return;
+    }
+    set((s) => ({
+      catalogDetail: { ...s.catalogDetail, [collectorName]: res.data! },
+      catalogDetailLoading: { ...s.catalogDetailLoading, [collectorName]: false },
+    }));
+  },
+
+  loadCatalogRegistries: async () => {
+    const [sourcesRes, tablesRes, consumersRes] = await Promise.all([
+      listDataSources(),
+      listDataTables(),
+      listDataConsumers(),
+    ]);
+    set({
+      catalogSources: sourcesRes.data ?? [],
+      catalogTables: tablesRes.data ?? [],
+      catalogConsumers: consumersRes.data ?? [],
+    });
+  },
+
+  loadDistinctValues: async (entity, field) => {
+    const key = `${entity}:${field}`;
+    const res = await listDistinctClassification(entity, field);
+    if (res.data) {
+      set((s) => ({
+        catalogDistinctValues: { ...s.catalogDistinctValues, [key]: res.data! },
+      }));
+    }
+  },
+
+  saveCollectorMetadata: async (name, sourceName, notes) => {
+    const res = await updateCollectorMetadata(name, sourceName, notes);
+    if (res.ok) {
+      // Refresh detail
+      await get().loadCollectorDetail(name);
+    }
+    return res;
+  },
+
+  saveCollectorTableReview: async (collectorName, tableName, status, notes) => {
+    const res = await updateCollectorTableReview(collectorName, tableName, status, notes);
+    if (res.ok) {
+      await get().loadCollectorDetail(collectorName);
+    }
+    return res;
+  },
+});
+
+export default createCatalogSlice;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -12,9 +12,10 @@ import createUserSlice, { UserSlice } from './user';
 import createChatSlice, { ChatSlice } from './chat';
 import createAgentConfigSlice, { AgentConfigSlice } from './agentConfig';
 import createMonitorSlice, { MonitorSlice } from './monitor';
+import createCatalogSlice, { CatalogSlice } from './catalog';
 
 const useAppStore = create<
-  LoansSlice & DashboardSlice & SeriesSlice & MarketDashboardSlice & TradingSlice & CurveSlice & UserSlice & ChatSlice & AgentConfigSlice & MonitorSlice
+  LoansSlice & DashboardSlice & SeriesSlice & MarketDashboardSlice & TradingSlice & CurveSlice & UserSlice & ChatSlice & AgentConfigSlice & MonitorSlice & CatalogSlice
 >()(
   devtools((...args) => ({
     ...createLoansSlice(...args),
@@ -27,6 +28,7 @@ const useAppStore = create<
     ...createChatSlice(...args),
     ...createAgentConfigSlice(...args),
     ...createMonitorSlice(...args),
+    ...createCatalogSlice(...args),
   }))
 );
 

--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -1,0 +1,136 @@
+// Types mirror the data_sources / data_tables_meta / data_consumers /
+// collector_table_review tables added in xerenity-db migrations
+// 20260429_data_catalog_foundation.sql + companion seeds.
+//
+// Field shapes match what the get_collector_full_detail RPC returns
+// (one round-trip; everything the catalog tab needs).
+
+export type SourceType =
+  | 'rest_api'
+  | 'web_scrape'
+  | 'file_download'
+  | 'manual';
+
+export type HealthStatus = 'healthy' | 'degraded' | 'down' | 'unknown';
+
+export type ConsumerType =
+  | 'fe_page'
+  | 'agent_tool'
+  | 'external_api'
+  | 'export'
+  | 'notebook'
+  | 'script'
+  | 'sdk';
+
+export type ReviewStatus =
+  | 'pendiente'
+  | 'mantener'
+  | 'arreglar'
+  | 'deprecar'
+  | 'documentar';
+
+
+export interface DataSource {
+  name: string;
+  label: string;
+  country: string | null;
+  source_type: SourceType | null;
+  base_url: string | null;
+  docs_url: string | null;
+  auth_required: boolean;
+  publish_schedule: string | null;
+  health_status: HealthStatus;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DataTableMeta {
+  table_name: string;
+  schema_name: string;
+  label: string | null;
+  date_column: string;
+  slice_column: string | null;
+  slice_label_sql: string | null;
+  category: string | null;
+  country: string | null;
+  description: string | null;
+  is_critical: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DataConsumer {
+  name: string;
+  consumer_type: ConsumerType;
+  label: string;
+  path: string | null;
+  reads_tables: string[];
+  writes_tables: string[];
+  description: string | null;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CollectorTableReview {
+  collector_name: string;
+  table_name: string;
+  review_status: ReviewStatus;
+  notes: string | null;
+  reviewed_at: string | null;
+  reviewed_by_email: string | null;
+}
+
+// list_collector_series RPC return shape — one entry per target_table
+// of the collector. `slices` may include an `error` row if the dynamic
+// query against the underlying table failed.
+
+export interface SliceBreakdown {
+  slice_value: string;
+  last_date: string | null;
+  first_date: string | null;
+  row_count: number;
+  cadence_days: number | null;
+}
+
+export interface SliceError {
+  error: string;
+}
+
+export interface CollectorTableSeries {
+  table_name: string;
+  meta_present: boolean;
+  label?: string | null;
+  date_column?: string | null;
+  slice_column?: string | null;
+  category?: string | null;
+  country?: string | null;
+  is_critical?: boolean;
+  slices: (SliceBreakdown | SliceError)[];
+}
+
+// get_collector_full_detail return shape
+
+export interface CollectorFullDetail {
+  definition: {
+    name: string;
+    description: string | null;
+    repo: string | null;
+    repo_path: string | null;
+    workflow_file: string | null;
+    schedule_cron: string | null;
+    expected_frequency: string | null;
+    target_tables: string[];
+    severity: 'critical' | 'warning' | 'info';
+    teams_mention: boolean;
+    enabled: boolean;
+    source_name: string | null;
+    notes: string | null;
+    updated_at: string;
+  };
+  source: DataSource | null;
+  series: CollectorTableSeries[];
+  reviews: CollectorTableReview[];
+  consumers: DataConsumer[];
+}


### PR DESCRIPTION
Closes #350

## Summary
- Adds a second tab (**Catálogo**) inside `/admin/monitor/[name]` next to the existing "Estado actual" timeline. Super_admin only.
- New catalog tab renders three sections backed by `get_collector_full_detail` RPC:
  - **Origen** — source dropdown + free-form collector notes (autosaved, 800ms debounce).
  - **Series por tabla** — per-target-table card showing last_date, row_count, median cadence, plus per-(collector, table) review status (`pendiente|mantener|arreglar|deprecar|documentar`) and notes.
  - **Consumidores** — table of consumers with reads/writes columns and a star badge for tables this collector writes to.
- Wires a new `CatalogSlice` into the Zustand `useAppStore` with per-collector detail caching, distinct-classification autocomplete, and save mutations that refresh the detail snapshot.

## What ships
- `src/types/catalog.ts` — types mirroring the catalog RPCs.
- `src/models/catalog/` — RPC wrappers (`getCollectorFullDetail`, `listDataSources/Tables/Consumers`, `listDistinctClassification`, `updateCollectorMetadata`, `updateCollectorTableReview`, …).
- `src/store/catalog/` + `src/store/index.ts` — Zustand slice composed into `useAppStore`.
- `src/pages/admin/monitor/_CatalogTab.tsx` — the catalog tab UI (Origen / Series / Consumidores).
- `src/pages/admin/monitor/[name].tsx` — refactored to host a tab bar; existing run timeline lives under **Estado actual**, the new component under **Catálogo**.

## Dependencies
Backed by these xerenity-db migrations (already merged):
- `20260429_data_catalog_foundation.sql`
- `20260429_data_catalog_rpcs.sql`
- `20260429_data_catalog_seed_sources_and_tables.sql`
- `20260429_data_catalog_seed_consumers.sql`

## Test plan
- [ ] Vercel preview builds green
- [ ] As super_admin, open `/admin/monitor/<collector>` — both tabs render
- [ ] **Estado actual**: same content as before (catalog card + runs timeline)
- [ ] **Catálogo** → Origen: change source dropdown / edit notes → autosave indicator transitions saving → saved
- [ ] **Catálogo** → Series: edit review status and per-pair notes → autosaves
- [ ] **Catálogo** → Consumidores: shows reads_tables / writes_tables (★ badge for writes)
- [ ] Non-super_admin user still sees the role-guard fallback