### PR TITLE
feat(monitor): power-table refactor — sort/filter/group + IA per row

### DIFF
--- a/src/models/monitor/index.ts
+++ b/src/models/monitor/index.ts
@@ -1,6 +1,7 @@
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import {
   CollectorOverview,
+  CollectorOverviewEnriched,
   CollectorRun,
   CollectorAlert,
 } from 'src/types/monitor';
@@ -32,6 +33,29 @@ export const listCollectorOverview = async (): Promise<ListResponse<CollectorOve
     return response;
   } catch (e) {
     response.error = e instanceof Error ? e.message : 'Error fetching collector overview';
+    return response;
+  }
+};
+
+// Enriched overview — joins source / categories / countries / review
+// distribution into one round-trip. Used by /admin/monitor for the
+// sortable + filterable + groupable table. Falls back to the legacy
+// list_collector_overview if the new RPC is unavailable so the page
+// keeps rendering on environments where the migration hasn't landed.
+export const listCollectorOverviewEnriched = async (): Promise<ListResponse<CollectorOverviewEnriched>> => {
+  const response: ListResponse<CollectorOverviewEnriched> = { data: [], error: undefined };
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('list_collector_overview_enriched');
+    if (error) {
+      response.error = error.message || 'Error fetching enriched collector overview';
+      return response;
+    }
+    response.data = (data ?? []) as CollectorOverviewEnriched[];
+    return response;
+  } catch (e) {
+    response.error = e instanceof Error ? e.message : 'Error fetching enriched collector overview';
     return response;
   }
 };

--- a/src/pages/admin/monitor/_MonitorTable.tsx
+++ b/src/pages/admin/monitor/_MonitorTable.tsx
@@ -1,0 +1,917 @@
+'use client';
+
+/* eslint-disable react/no-unstable-nested-components */
+// react/no-unstable-nested-components is disabled file-wide because
+// TanStack Table's columnDef API requires inline cell-renderer functions
+// (`cell: ({ row }) => …`) and the rule treats every arrow-returning-JSX
+// as a fresh component. The columns array itself is stable via useMemo,
+// so React reconciliation isn't actually thrashing.
+
+// Power-table for /admin/monitor.
+//
+// Replaces the flat HTML table with a TanStack Table that supports:
+//   - sort by any column
+//   - per-column multi-select filters (source, severity, category, country)
+//   - free-text global search
+//   - quick toggles (only critical / only failing-or-stale)
+//   - groupBy with collapsible Excel-pivot-style headers
+//
+// One-stop component to keep the page file focused on layout + alerts.
+
+import React, { useMemo, useState } from 'react';
+import Link from 'next/link';
+import styled from 'styled-components';
+import { Badge, Form, Button as BsButton } from 'react-bootstrap';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import {
+  faCircleCheck,
+  faCircleExclamation,
+  faCircleXmark,
+  faCircleMinus,
+  faClock,
+  faArrowUpRightFromSquare,
+  faStar,
+  faRobot,
+  faSort,
+  faSortUp,
+  faSortDown,
+  faChevronDown,
+  faChevronRight,
+} from '@fortawesome/free-solid-svg-icons';
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  ExpandedState,
+  GroupingState,
+  SortingState,
+  flexRender,
+  getCoreRowModel,
+  getExpandedRowModel,
+  getFilteredRowModel,
+  getGroupedRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import type {
+  CollectorOverviewEnriched,
+  Severity,
+  RunStatus,
+} from 'src/types/monitor';
+import ReviewBar from './_ReviewBar';
+
+// ─────────────────────────────────────────────────────────────────
+// Styling
+// ─────────────────────────────────────────────────────────────────
+
+const TableWrap = styled.div`
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  overflow-x: auto;
+  overflow-y: visible;
+
+  table { width: 100%; margin: 0; border-collapse: collapse; }
+  thead th {
+    background: #302b63;
+    color: #fff;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 10px 12px;
+    text-align: left;
+    white-space: nowrap;
+    cursor: default;
+    user-select: none;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+  thead th.sortable { cursor: pointer; }
+  thead th.sortable:hover { background: #3d3680; }
+  tbody td {
+    font-size: 13px;
+    padding: 9px 12px;
+    border-bottom: 1px solid #f1f1f4;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+  tbody tr:hover:not(.group-header) { background: rgba(48, 43, 99, 0.04); }
+  tbody tr.group-header {
+    background: #fafaff;
+    cursor: pointer;
+    user-select: none;
+  }
+  tbody tr.group-header td {
+    font-weight: 700;
+    color: #302b63;
+    border-bottom: 2px solid #d8d8e6;
+    padding: 8px 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    font-size: 11px;
+  }
+  tbody tr.group-header:hover td { background: #f0f0fa; }
+
+  a { color: #302b63; text-decoration: none; font-weight: 600; }
+  a:hover { text-decoration: underline; }
+`;
+
+const Toolbar = styled.div`
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+
+  .inline {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #555;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    margin: 0;
+  }
+
+  input[type='text'] {
+    font-size: 13px;
+    min-width: 220px;
+  }
+
+  select {
+    font-size: 12px;
+    min-width: 140px;
+  }
+
+  .toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: #444;
+    cursor: pointer;
+    user-select: none;
+    padding: 4px 8px;
+    background: #f3f3f7;
+    border-radius: 4px;
+    &:hover { background: #e9e9f0; }
+    input { margin: 0; }
+  }
+`;
+
+const Chip = styled.span<{ $color?: string }>`
+  display: inline-block;
+  font-size: 10px;
+  background: ${(p) => p.$color ?? '#e9e9f0'};
+  color: #444;
+  padding: 1px 6px;
+  border-radius: 3px;
+  margin: 0 2px 2px 0;
+  white-space: nowrap;
+`;
+
+const TableChips = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 280px;
+  font-family: monospace;
+  font-size: 11px;
+  code {
+    background: #f3f3f7;
+    padding: 1px 4px;
+    border-radius: 3px;
+    margin: 0 2px 2px 0;
+    white-space: nowrap;
+  }
+`;
+
+const StatusDot = styled.span<{ $color: string }>`
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: ${(p) => p.$color};
+  vertical-align: middle;
+`;
+
+// ─────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────
+
+const SEV_COLORS: Record<Severity, string> = {
+  critical: '#dc3545',
+  warning: '#f0ad4e',
+  info: '#5bc0de',
+};
+
+const RUN_STATUS_CFG: Record<RunStatus, { bg: string; icon: typeof faCircleCheck }> = {
+  success: { bg: '#28a745', icon: faCircleCheck },
+  running: { bg: '#5bc0de', icon: faClock },
+  failed: { bg: '#dc3545', icon: faCircleXmark },
+  timeout: { bg: '#6c757d', icon: faCircleExclamation },
+};
+
+export type GroupByKey =
+  | 'none'
+  | 'source'
+  | 'severity'
+  | 'category_first'
+  | 'country_first'
+  | 'review_worst';
+
+const GROUP_BY_OPTIONS: { key: GroupByKey; label: string; columnId?: string }[] = [
+  { key: 'none', label: 'Sin agrupar' },
+  { key: 'source', label: 'Por fuente', columnId: 'source' },
+  { key: 'severity', label: 'Por severity', columnId: 'severity' },
+  { key: 'category_first', label: 'Por categoría', columnId: 'categoryFirst' },
+  { key: 'country_first', label: 'Por país (datos)', columnId: 'countryFirst' },
+  { key: 'review_worst', label: 'Por estado de revisión', columnId: 'reviewWorst' },
+];
+
+// ─────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────
+
+const statusColor = (row: CollectorOverviewEnriched): string => {
+  if (row.has_critical_alert) return '#dc3545';
+  if (row.has_warning_alert) return '#f0ad4e';
+  if (!row.last_run) return '#b0b0b0';
+  if (row.last_run.status === 'success') return '#28a745';
+  if (row.last_run.status === 'running') return '#5bc0de';
+  return '#dc3545';
+};
+
+const formatRelative = (iso: string | null): string => {
+  if (!iso) return '—';
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.round(ms / 60000);
+  if (mins < 1) return 'ahora';
+  if (mins < 60) return `hace ${mins}m`;
+  const hours = Math.round(mins / 60);
+  if (hours < 48) return `hace ${hours}h`;
+  const days = Math.round(hours / 24);
+  return `hace ${days}d`;
+};
+
+const formatDuration = (s: number | null): string => {
+  if (s == null) return '—';
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const r = Math.floor(s - m * 60);
+  return `${m}m ${r}s`;
+};
+
+const formatRows = (rows: number | null | undefined) => {
+  if (rows === null || rows === undefined) {
+    return <span style={{ color: '#bbb' }} title="No capturado">—</span>;
+  }
+  if (rows === 0) {
+    return (
+      <span style={{ color: '#b8860b', fontWeight: 600 }} title="0 filas insertadas">
+        0
+      </span>
+    );
+  }
+  return rows.toLocaleString();
+};
+
+// "Worst" review status seen across this collector's (collector, table)
+// pairs. Used both as a sort key and as a groupBy bucket.
+//
+// Rationale for the order: deprecar > arreglar matter most operationally
+// (something is actively broken or being killed); pendiente means "not
+// reviewed yet", documentar/mantener mean we already looked and it's
+// fine. Empty review distribution (total=0) sorts to "n/a" so freshly
+// added collectors don't get bucketed as critical by accident.
+const REVIEW_PRIORITY: Record<string, number> = {
+  deprecar: 5,
+  arreglar: 4,
+  pendiente: 3,
+  documentar: 2,
+  mantener: 1,
+  none: 0,
+};
+const worstReview = (row: CollectorOverviewEnriched): string => {
+  const d = row.review_distribution;
+  if (!d || d.total === 0) return 'n/a';
+  const order: (keyof typeof REVIEW_PRIORITY)[] = ['deprecar', 'arreglar', 'pendiente', 'documentar', 'mantener'];
+  // eslint-disable-next-line no-restricted-syntax
+  for (const k of order) {
+    if ((d as Record<string, number>)[k] > 0) return k;
+  }
+  return 'n/a';
+};
+
+// TanStack `getIsSorted` returns false | 'asc' | 'desc' — map that to
+// the right Font Awesome icon. Extracted because the inline ternary
+// triggers no-nested-ternary in the project's eslint config.
+const sortIcon = (sorted: false | 'asc' | 'desc') => {
+  if (sorted === 'asc') return faSortUp;
+  if (sorted === 'desc') return faSortDown;
+  return faSort;
+};
+
+// Multi-select filter helper — TanStack v8 default filter compares using
+// `includesString`; for our chip-arrays we want OR semantics.
+const arrayIncludesAny = <T,>(rowVal: T[], filterVal: string[]): boolean => {
+  if (!Array.isArray(filterVal) || filterVal.length === 0) return true;
+  return rowVal.some((v) => filterVal.includes(String(v)));
+};
+
+// ─────────────────────────────────────────────────────────────────
+// MultiSelect — small button-driven dropdown for the toolbar filters.
+// Native `<select multiple>` is awkward; this wraps a list of checkboxes
+// behind a summary chip. Defined before MonitorTable so the reference
+// inside the toolbar JSX doesn't trip @typescript-eslint/no-use-before-define.
+// ─────────────────────────────────────────────────────────────────
+
+const MultiSelectWrap = styled.div`
+  position: relative;
+  display: inline-block;
+
+  .summary {
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    padding: 3px 8px;
+    background: #fff;
+    font-size: 12px;
+    cursor: pointer;
+    min-width: 120px;
+    text-align: left;
+    color: #333;
+    &:hover { border-color: #302b63; }
+    &.active { border-color: #302b63; box-shadow: 0 0 0 2px rgba(48, 43, 99, 0.15); }
+  }
+
+  .panel {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    background: #fff;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    padding: 6px;
+    min-width: 180px;
+    max-height: 240px;
+    overflow-y: auto;
+    z-index: 10;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
+
+  .opt {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 6px;
+    font-size: 12px;
+    cursor: pointer;
+    border-radius: 3px;
+    &:hover { background: #f3f3f7; }
+    input { margin: 0; }
+  }
+
+  .clear {
+    font-size: 11px;
+    color: #888;
+    padding: 4px 6px;
+    cursor: pointer;
+    border-top: 1px solid #eee;
+    margin-top: 4px;
+    text-align: center;
+    &:hover { color: #302b63; }
+  }
+`;
+
+interface MultiSelectProps {
+  options: string[];
+  value: string[];
+  onChange: (next: string[]) => void;
+}
+
+const buildMultiSelectSummary = (value: string[]): string => {
+  if (value.length === 0) return 'Todos';
+  if (value.length <= 2) return value.join(', ');
+  return `${value.length} seleccionados`;
+};
+
+const MultiSelect: React.FC<MultiSelectProps> = ({ options, value, onChange }) => {
+  const [open, setOpen] = useState(false);
+  const summary = buildMultiSelectSummary(value);
+
+  const toggle = (opt: string) => {
+    if (value.includes(opt)) onChange(value.filter((v) => v !== opt));
+    else onChange([...value, opt]);
+  };
+
+  return (
+    <MultiSelectWrap>
+      <button
+        type="button"
+        className={`summary ${value.length > 0 ? 'active' : ''}`}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {summary} <Icon icon={faChevronDown} style={{ fontSize: 9, marginLeft: 6 }} />
+      </button>
+      {open && (
+        <div className="panel" onMouseLeave={() => setOpen(false)}>
+          {options.length === 0 && (
+            <div style={{ fontSize: 11, color: '#999', padding: 6 }}>Sin opciones</div>
+          )}
+          {options.map((opt) => (
+            <label key={opt} className="opt">
+              <input
+                type="checkbox"
+                checked={value.includes(opt)}
+                onChange={() => toggle(opt)}
+              />
+              {opt}
+            </label>
+          ))}
+          {value.length > 0 && (
+            <button
+              type="button"
+              className="clear"
+              onClick={() => { onChange([]); setOpen(false); }}
+              style={{ background: 'none', border: 'none', width: '100%' }}
+            >
+              Limpiar
+            </button>
+          )}
+        </div>
+      )}
+    </MultiSelectWrap>
+  );
+};
+
+
+// ─────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────
+
+export interface MonitorTableProps {
+  rows: CollectorOverviewEnriched[];
+  onDiagnose: (row: CollectorOverviewEnriched) => void;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────
+
+const MonitorTable: React.FC<MonitorTableProps> = ({ rows, onDiagnose }) => {
+  // ─── Toolbar state ────────────────────────────────────────────
+  const [globalFilter, setGlobalFilter] = useState('');
+  const [sourceFilter, setSourceFilter] = useState<string[]>([]);
+  const [severityFilter, setSeverityFilter] = useState<string[]>([]);
+  const [categoryFilter, setCategoryFilter] = useState<string[]>([]);
+  const [countryFilter, setCountryFilter] = useState<string[]>([]);
+  const [onlyCritical, setOnlyCritical] = useState(false);
+  const [onlyFailing, setOnlyFailing] = useState(false);
+  const [groupBy, setGroupBy] = useState<GroupByKey>('none');
+
+  // ─── Distinct option sets — derived from rows ─────────────────
+  const optionSets = useMemo(() => {
+    const sources = new Set<string>();
+    const categories = new Set<string>();
+    const countries = new Set<string>();
+    rows.forEach((r) => {
+      if (r.source?.name) sources.add(r.source.name);
+      r.categories.forEach((c) => categories.add(c));
+      r.countries_data.forEach((c) => countries.add(c));
+    });
+    return {
+      sources: Array.from(sources).sort(),
+      categories: Array.from(categories).sort(),
+      countries: Array.from(countries).sort(),
+    };
+  }, [rows]);
+
+  // ─── Pre-filter applied before TanStack runs (toggles) ────────
+  const visibleRows = useMemo(() => rows.filter((r) => {
+    if (onlyCritical && !(r.has_critical_alert || r.is_critical_any)) return false;
+    if (onlyFailing) {
+      const failing = r.last_run?.status === 'failed' || r.last_run?.status === 'timeout';
+      const stale = r.has_warning_alert || r.has_critical_alert;
+      if (!failing && !stale) return false;
+    }
+    return true;
+  }), [rows, onlyCritical, onlyFailing]);
+
+  // ─── Column definitions ───────────────────────────────────────
+  const columns = useMemo<ColumnDef<CollectorOverviewEnriched>[]>(
+    () => [
+      {
+        id: 'status',
+        header: '',
+        enableSorting: false,
+        enableGrouping: false,
+        cell: ({ row }) => <StatusDot $color={statusColor(row.original)} />,
+      },
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Collector',
+        cell: ({ row }) => (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            {row.original.is_critical_any && (
+              <Icon icon={faStar} style={{ color: '#dc3545' }} title="Tabla crítica" />
+            )}
+            <Link href={`/admin/monitor/${encodeURIComponent(row.original.name)}`}>
+              {row.original.name}
+            </Link>
+          </span>
+        ),
+      },
+      {
+        id: 'source',
+        accessorFn: (r) => r.source?.name ?? '(sin fuente)',
+        header: 'Fuente',
+        filterFn: (row, _id, value) =>
+          arrayIncludesAny([row.original.source?.name].filter(Boolean) as string[], value as string[]),
+        cell: ({ row }) =>
+          row.original.source ? (
+            <Badge
+              bg="light"
+              text="dark"
+              style={{ fontWeight: 500, border: '1px solid #d8d8e6' }}
+              title={row.original.source.label}
+            >
+              {row.original.source.name}
+            </Badge>
+          ) : (
+            <span style={{ color: '#bbb', fontStyle: 'italic' }}>(sin fuente)</span>
+          ),
+      },
+      {
+        id: 'severity',
+        accessorKey: 'severity_default',
+        header: 'Severity',
+        filterFn: (row, _id, value) =>
+          arrayIncludesAny([row.original.severity_default], value as string[]),
+        cell: ({ getValue }) => (
+          <Badge style={{ background: SEV_COLORS[getValue() as Severity], fontWeight: 500 }}>
+            {String(getValue())}
+          </Badge>
+        ),
+      },
+      {
+        id: 'categoryFirst',
+        // First category alphabetically — used as a groupBy bucket so
+        // grouping works even when a collector spans multiple categories.
+        accessorFn: (r) => r.categories[0] ?? '(sin categoría)',
+        header: 'Categorías',
+        filterFn: (row, _id, value) => arrayIncludesAny(row.original.categories, value as string[]),
+        cell: ({ row }) =>
+          row.original.categories.length > 0 ? (
+            <div>
+              {row.original.categories.map((c) => (
+                <Chip key={c} $color="#e7f1fb">{c}</Chip>
+              ))}
+            </div>
+          ) : (
+            <span style={{ color: '#bbb' }}>—</span>
+          ),
+      },
+      {
+        id: 'countryFirst',
+        accessorFn: (r) => r.countries_data[0] ?? '(sin país)',
+        header: 'País',
+        filterFn: (row, _id, value) =>
+          arrayIncludesAny(row.original.countries_data, value as string[]),
+        cell: ({ row }) =>
+          row.original.countries_data.length > 0 ? (
+            <div>
+              {row.original.countries_data.map((c) => (
+                <Chip key={c} $color="#fff5e3">{c}</Chip>
+              ))}
+            </div>
+          ) : (
+            <span style={{ color: '#bbb' }}>—</span>
+          ),
+      },
+      {
+        id: 'tables',
+        accessorFn: (r) => r.target_tables.join(','),
+        header: 'Tablas destino',
+        enableSorting: false,
+        enableGrouping: false,
+        cell: ({ row }) =>
+          row.original.target_tables.length > 0 ? (
+            <TableChips>
+              {row.original.target_tables.map((t) => (
+                <code key={t}>{t}</code>
+              ))}
+            </TableChips>
+          ) : (
+            <span style={{ color: '#bbb' }}>—</span>
+          ),
+      },
+      {
+        id: 'lastRun',
+        accessorFn: (r) => r.last_run?.started_at ?? '',
+        header: 'Último run',
+        sortingFn: (a, b) => {
+          const av = a.original.last_run?.started_at ?? '';
+          const bv = b.original.last_run?.started_at ?? '';
+          return av.localeCompare(bv);
+        },
+        cell: ({ row }) => {
+          const lr = row.original.last_run;
+          if (!lr) {
+            return (
+              <span style={{ color: '#999' }}>
+                <Icon icon={faCircleMinus} style={{ marginRight: 4 }} /> nunca
+              </span>
+            );
+          }
+          const cfg = RUN_STATUS_CFG[lr.status];
+          return (
+            <span>
+              <Badge style={{ background: cfg.bg, fontWeight: 500 }}>
+                <Icon icon={cfg.icon} style={{ marginRight: 4 }} /> {lr.status}
+              </Badge>
+              <span style={{ marginLeft: 8, color: '#888', fontSize: 12 }}>
+                {formatRelative(lr.started_at)}
+              </span>
+            </span>
+          );
+        },
+      },
+      {
+        id: 'duration',
+        accessorFn: (r) => r.last_run?.duration_s ?? -1,
+        header: 'Duración',
+        cell: ({ row }) => formatDuration(row.original.last_run?.duration_s ?? null),
+      },
+      {
+        id: 'rows',
+        accessorFn: (r) => r.last_run?.rows_inserted ?? -1,
+        header: 'Filas',
+        cell: ({ row }) => formatRows(row.original.last_run?.rows_inserted),
+      },
+      {
+        id: 'alerts',
+        accessorKey: 'open_alerts',
+        header: 'Alertas',
+        cell: ({ getValue }) => {
+          const v = Number(getValue());
+          return v > 0 ? <Badge bg="danger">{v}</Badge> : <span style={{ color: '#ccc' }}>—</span>;
+        },
+      },
+      {
+        id: 'reviewWorst',
+        accessorFn: (r) => worstReview(r),
+        header: 'Estado revisión',
+        sortingFn: (a, b) =>
+          (REVIEW_PRIORITY[worstReview(b.original)] ?? 0) -
+          (REVIEW_PRIORITY[worstReview(a.original)] ?? 0),
+        cell: ({ row }) => <ReviewBar distribution={row.original.review_distribution} />,
+      },
+      {
+        id: 'actions',
+        header: '',
+        enableSorting: false,
+        enableGrouping: false,
+        cell: ({ row }) => (
+          <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+            <BsButton
+              size="sm"
+              variant="outline-primary"
+              onClick={() => onDiagnose(row.original)}
+              title="Abre el chat con un prompt pre-cargado para que el agente investigue este collector. NO modifica nada."
+              style={{ fontSize: 11, padding: '2px 6px' }}
+            >
+              <Icon icon={faRobot} /> IA
+            </BsButton>
+            {row.original.last_run?.gh_run_url && (
+              <a
+                href={row.original.last_run.gh_run_url}
+                target="_blank"
+                rel="noreferrer"
+                style={{ fontSize: 12 }}
+              >
+                GH <Icon icon={faArrowUpRightFromSquare} />
+              </a>
+            )}
+          </span>
+        ),
+      },
+    ],
+    [onDiagnose],
+  );
+
+  // ─── TanStack column-filter state derived from toolbar dropdowns ──
+  const columnFilters: ColumnFiltersState = useMemo(() => {
+    const out: ColumnFiltersState = [];
+    if (sourceFilter.length > 0) out.push({ id: 'source', value: sourceFilter });
+    if (severityFilter.length > 0) out.push({ id: 'severity', value: severityFilter });
+    if (categoryFilter.length > 0) out.push({ id: 'categoryFirst', value: categoryFilter });
+    if (countryFilter.length > 0) out.push({ id: 'countryFirst', value: countryFilter });
+    return out;
+  }, [sourceFilter, severityFilter, categoryFilter, countryFilter]);
+
+  // ─── Derive grouping + expanded state from groupBy dropdown ───
+  const grouping: GroupingState = useMemo(() => {
+    const opt = GROUP_BY_OPTIONS.find((o) => o.key === groupBy);
+    return opt?.columnId ? [opt.columnId] : [];
+  }, [groupBy]);
+
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [expanded, setExpanded] = useState<ExpandedState>({});
+
+  // Auto-expand all groups when grouping turns on so users see content
+  // immediately. They can collapse manually.
+  React.useEffect(() => {
+    if (grouping.length === 0) {
+      setExpanded({});
+    } else {
+      setExpanded(true);
+    }
+  }, [grouping.length]);
+
+  const table = useReactTable({
+    data: visibleRows,
+    columns,
+    state: {
+      globalFilter,
+      columnFilters,
+      grouping,
+      sorting,
+      expanded,
+    },
+    onGlobalFilterChange: setGlobalFilter,
+    onSortingChange: setSorting,
+    onExpandedChange: setExpanded,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getGroupedRowModel: getGroupedRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    autoResetExpanded: false,
+    globalFilterFn: 'includesString',
+  });
+
+  const colCount = table.getAllLeafColumns().length;
+
+  // ─── Render ───────────────────────────────────────────────────
+  return (
+    <>
+      <Toolbar>
+        <Form.Control
+          type="text"
+          placeholder="Buscar collector…"
+          value={globalFilter}
+          onChange={(e) => setGlobalFilter(e.target.value)}
+          size="sm"
+        />
+
+        {/* MultiSelect is a custom button-based widget (not a native form control)
+            so we wrap each in <span>, not <label>, to satisfy
+            jsx-a11y/label-has-associated-control. */}
+        <span className="inline">
+          Fuente
+          <MultiSelect options={optionSets.sources} value={sourceFilter} onChange={setSourceFilter} />
+        </span>
+
+        <span className="inline">
+          Categoría
+          <MultiSelect options={optionSets.categories} value={categoryFilter} onChange={setCategoryFilter} />
+        </span>
+
+        <span className="inline">
+          País
+          <MultiSelect options={optionSets.countries} value={countryFilter} onChange={setCountryFilter} />
+        </span>
+
+        <span className="inline">
+          Severity
+          <MultiSelect
+            options={['critical', 'warning', 'info']}
+            value={severityFilter}
+            onChange={setSeverityFilter}
+          />
+        </span>
+
+        <label className="inline">
+          Agrupar
+          <Form.Select
+            size="sm"
+            value={groupBy}
+            onChange={(e) => setGroupBy(e.target.value as GroupByKey)}
+            style={{ minWidth: 170 }}
+          >
+            {GROUP_BY_OPTIONS.map((o) => (
+              <option key={o.key} value={o.key}>{o.label}</option>
+            ))}
+          </Form.Select>
+        </label>
+
+        <label className="toggle">
+          <input
+            type="checkbox"
+            checked={onlyCritical}
+            onChange={(e) => setOnlyCritical(e.target.checked)}
+          />
+          Solo críticos
+        </label>
+
+        <label className="toggle">
+          <input
+            type="checkbox"
+            checked={onlyFailing}
+            onChange={(e) => setOnlyFailing(e.target.checked)}
+          />
+          Solo failing/stale
+        </label>
+
+        <span style={{ marginLeft: 'auto', fontSize: 11, color: '#888' }}>
+          {table.getRowModel().rows.filter((r) => !r.getIsGrouped()).length} de {visibleRows.length} collectors
+        </span>
+      </Toolbar>
+
+      <TableWrap>
+        <table>
+          <thead>
+            {table.getHeaderGroups().map((hg) => (
+              <tr key={hg.id}>
+                {hg.headers.map((header) => {
+                  const canSort = header.column.getCanSort();
+                  const sorted = header.column.getIsSorted();
+                  return (
+                    <th
+                      key={header.id}
+                      className={canSort ? 'sortable' : ''}
+                      onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                      {canSort && (
+                        <Icon
+                          icon={sortIcon(sorted)}
+                          style={{ marginLeft: 6, opacity: sorted ? 1 : 0.4, fontSize: 10 }}
+                        />
+                      )}
+                    </th>
+                  );
+                })}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => {
+              if (row.getIsGrouped()) {
+                const groupCol = row.getGroupingValue(grouping[0]);
+                return (
+                  <tr
+                    key={row.id}
+                    className="group-header"
+                    onClick={row.getToggleExpandedHandler()}
+                  >
+                    <td colSpan={colCount}>
+                      <Icon
+                        icon={row.getIsExpanded() ? faChevronDown : faChevronRight}
+                        style={{ marginRight: 8 }}
+                      />
+                      {String(groupCol ?? '—')}{' '}
+                      <span style={{ color: '#999', fontWeight: 500, marginLeft: 8 }}>
+                        ({row.subRows.length})
+                      </span>
+                    </td>
+                  </tr>
+                );
+              }
+              return (
+                <tr key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+            {table.getRowModel().rows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={colCount}
+                  style={{ textAlign: 'center', color: '#999', padding: 32, fontSize: 13 }}
+                >
+                  No hay collectors que coincidan con los filtros.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </TableWrap>
+    </>
+  );
+};
+
+export default MonitorTable;

--- a/src/pages/admin/monitor/_MonitorTable.tsx
+++ b/src/pages/admin/monitor/_MonitorTable.tsx
@@ -464,7 +464,15 @@ export interface MonitorTableProps {
 // Component
 // ─────────────────────────────────────────────────────────────────
 
-const MonitorTable: React.FC<MonitorTableProps> = ({ rows, onDiagnose }) => {
+// Default props guard the file against Next.js's pages-router static-
+// optimisation pass, which tries to prerender every module under pages/
+// (even underscore-prefixed components like this one) with no props.
+// Without the defaults, `rows.forEach(...)` inside the option-sets useMemo
+// blows up with a TypeError during `next build` and fails the deploy.
+const MonitorTable: React.FC<MonitorTableProps> = ({
+  rows = [],
+  onDiagnose = () => {},
+}) => {
   // ─── Toolbar state ────────────────────────────────────────────
   const [globalFilter, setGlobalFilter] = useState('');
   const [sourceFilter, setSourceFilter] = useState<string[]>([]);

--- a/src/pages/admin/monitor/_ReviewBar.tsx
+++ b/src/pages/admin/monitor/_ReviewBar.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+// Stacked-bar visualisation of a collector's review status distribution.
+// Each segment is sized proportionally to its share of the total. Hover
+// reveals the absolute count + percentage. Designed to be tiny — fits
+// inside a single table cell.
+
+import React from 'react';
+import styled from 'styled-components';
+import type { ReviewDistribution, ReviewStatusKey } from 'src/types/monitor';
+
+const REVIEW_COLORS: Record<ReviewStatusKey, string> = {
+  pendiente: '#adb5bd',
+  mantener: '#28a745',
+  arreglar: '#f0ad4e',
+  deprecar: '#dc3545',
+  documentar: '#5bc0de',
+};
+
+const REVIEW_LABELS_ES: Record<ReviewStatusKey, string> = {
+  pendiente: 'Pendiente',
+  mantener: 'Mantener',
+  arreglar: 'Arreglar',
+  deprecar: 'Deprecar',
+  documentar: 'Documentar',
+};
+
+const Bar = styled.div`
+  display: flex;
+  width: 100%;
+  min-width: 110px;
+  max-width: 160px;
+  height: 12px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #f3f3f7;
+`;
+
+const Segment = styled.div<{ $color: string; $share: number }>`
+  flex: ${(p) => p.$share};
+  background: ${(p) => p.$color};
+  transition: opacity 120ms ease;
+  &:hover { opacity: 0.85; }
+`;
+
+const TextRow = styled.div`
+  font-size: 10px;
+  color: #888;
+  margin-top: 2px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  & > span.zero { color: #ccc; }
+`;
+
+const ORDER: ReviewStatusKey[] = [
+  'mantener',
+  'documentar',
+  'pendiente',
+  'arreglar',
+  'deprecar',
+];
+
+const ReviewBar: React.FC<{ distribution: ReviewDistribution }> = ({ distribution }) => {
+  if (!distribution || distribution.total === 0) {
+    return <span style={{ color: '#bbb', fontSize: 11 }}>—</span>;
+  }
+  const { total } = distribution;
+  return (
+    <div>
+      <Bar role="img" aria-label="Distribución de estado de revisión">
+        {ORDER.map((k) => {
+          const count = distribution[k] ?? 0;
+          if (count === 0) return null;
+          const pct = Math.round((count / total) * 100);
+          return (
+            <Segment
+              key={k}
+              $color={REVIEW_COLORS[k]}
+              $share={count}
+              title={`${REVIEW_LABELS_ES[k]}: ${count}/${total} (${pct}%)`}
+            />
+          );
+        })}
+      </Bar>
+      <TextRow>
+        {ORDER.map((k) => {
+          const count = distribution[k] ?? 0;
+          const pct = Math.round((count / total) * 100);
+          return (
+            <span key={k} className={count === 0 ? 'zero' : ''}>
+              <span style={{ color: REVIEW_COLORS[k] }}>●</span> {pct}%
+            </span>
+          );
+        })}
+      </TextRow>
+    </div>
+  );
+};
+
+export default ReviewBar;

--- a/src/pages/admin/monitor/index.tsx
+++ b/src/pages/admin/monitor/index.tsx
@@ -1,17 +1,11 @@
 'use client';
 
 import React, { useEffect, useMemo } from 'react';
-import Link from 'next/link';
 import { CoreLayout } from '@layout';
-import { Container, Row, Col, Badge, Button as BsButton } from 'react-bootstrap';
+import { Container, Row, Col, Button as BsButton } from 'react-bootstrap';
 import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import {
   faCircleCheck,
-  faCircleExclamation,
-  faCircleXmark,
-  faCircleMinus,
-  faClock,
-  faArrowUpRightFromSquare,
   faBellSlash,
   faCheck,
   faEye,
@@ -22,48 +16,11 @@ import styled from 'styled-components';
 import PageTitle from '@components/PageTitle';
 import RoleGuard from 'src/components/RoleGuard';
 import useAppStore from 'src/store';
-import type { CollectorOverview, Severity, RunStatus } from 'src/types/monitor';
+import type { CollectorOverviewEnriched, Severity } from 'src/types/monitor';
+import MonitorTable from './_MonitorTable';
 
 const PageWrap = styled.div`
   padding: 16px 24px;
-`;
-
-const StatusDot = styled.span<{ $color: string }>`
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  margin-right: 8px;
-  background: ${(p) => p.$color};
-  vertical-align: middle;
-`;
-
-const TableWrap = styled.div`
-  background: #fff;
-  border-radius: 8px;
-  overflow: hidden;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
-
-  table { width: 100%; margin-bottom: 0; border-collapse: collapse; }
-  thead th {
-    background: #302b63;
-    color: #fff;
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 10px 12px;
-    text-align: left;
-  }
-  tbody td {
-    font-size: 13px;
-    padding: 10px 12px;
-    border-bottom: 1px solid #eee;
-    vertical-align: middle;
-  }
-  tbody tr:hover { background: rgba(48, 43, 99, 0.05); }
-  a { color: #302b63; text-decoration: none; font-weight: 600; }
-  a:hover { text-decoration: underline; }
 `;
 
 const AlertsPanel = styled.div`
@@ -107,36 +64,11 @@ const EmptyState = styled.div`
   padding: 32px 8px;
 `;
 
-const statusColor = (row: CollectorOverview): string => {
-  if (row.has_critical_alert) return '#dc3545';
-  if (row.has_warning_alert) return '#f0ad4e';
-  if (!row.last_run) return '#b0b0b0';
-  if (row.last_run.status === 'success') return '#28a745';
-  if (row.last_run.status === 'running') return '#5bc0de';
-  return '#dc3545';
-};
-
-const statusBadge = (status: RunStatus) => {
-  const cfg: Record<RunStatus, { bg: string; icon: typeof faCircleCheck }> = {
-    success: { bg: '#28a745', icon: faCircleCheck },
-    running: { bg: '#5bc0de', icon: faClock },
-    failed:  { bg: '#dc3545', icon: faCircleXmark },
-    timeout: { bg: '#6c757d', icon: faCircleExclamation },
-  };
-  const { bg, icon } = cfg[status];
-  return (
-    <Badge style={{ background: bg, fontWeight: 500 }}>
-      <Icon icon={icon} style={{ marginRight: 4 }} /> {status}
-    </Badge>
-  );
-};
-
 const formatRelative = (iso: string | null): string => {
   if (!iso) return '—';
-  const then = new Date(iso).getTime();
-  const diffMs = Date.now() - then;
-  const mins = Math.round(diffMs / 60000);
-  if (mins < 1) return 'justo ahora';
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.round(ms / 60000);
+  if (mins < 1) return 'ahora';
   if (mins < 60) return `hace ${mins}m`;
   const hours = Math.round(mins / 60);
   if (hours < 48) return `hace ${hours}h`;
@@ -144,34 +76,13 @@ const formatRelative = (iso: string | null): string => {
   return `hace ${days}d`;
 };
 
-const formatDuration = (seconds: number | null): string => {
-  if (seconds == null) return '—';
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  const mins = Math.floor(seconds / 60);
-  const rem = Math.floor(seconds - mins * 60);
-  return `${mins}m ${rem}s`;
-};
-
-const formatRowsInserted = (rows: number | null | undefined) => {
-  // null = the wrapper couldn't snapshot (older runs, RLS, etc.) — show — quietly.
-  // 0 = the run completed cleanly but did NOT write anything; for a daily
-  // collector this is suspicious enough that we want it to stand out
-  // visually even if no empty_run alert has been raised yet.
-  if (rows === null || rows === undefined) {
-    return <span style={{ color: '#bbb' }} title="rows_inserted no fue capturado en este run">—</span>;
-  }
-  if (rows === 0) {
-    return (
-      <span
-        style={{ color: '#b8860b', fontWeight: 600 }}
-        title="0 filas — el run terminó OK pero no escribió nada"
-      >
-        0
-      </span>
-    );
-  }
-  return rows.toLocaleString();
-};
+// ─────────────────────────────────────────────────────────────────
+// Diagnose-prompt builders
+// ─────────────────────────────────────────────────────────────────
+//
+// All variants instruct the agent to investigate but NOT modify code.
+// The user-applied fix loop stays manual until we add a controlled
+// fix-collector tool.
 
 type DiagnoseAlert = {
   source: string;
@@ -277,13 +188,12 @@ const buildEmptyRunPrompt = (alert: DiagnoseAlert): string => {
   ].filter(Boolean).join('\n');
 };
 
-const buildDiagnosePrompt = (alert: DiagnoseAlert): string => {
+const buildAlertDiagnosePrompt = (alert: DiagnoseAlert): string => {
   switch (alert.source) {
     case 'run_failed':  return buildRunFailedPrompt(alert);
     case 'table_stale': return buildTableStalePrompt(alert);
     case 'empty_run':   return buildEmptyRunPrompt(alert);
-    default: {
-      // Generic fallback for missed_run or future sources.
+    default:
       return [
         `Estoy debuggeando una alerta del monitor de Xerenity (source=${alert.source}).`,
         `Collector: \`${alert.collector_name ?? 'n/a'}\`. Tabla: \`${alert.table_name ?? 'n/a'}\`.`,
@@ -292,8 +202,42 @@ const buildDiagnosePrompt = (alert: DiagnoseAlert): string => {
         `Investiga con \`query_database\` (xerenity.collector_definitions, xerenity.collector_runs) y \`read_repo_file\` ` +
         `si necesitas ver codigo. Diagnostica y propon un fix.`,
       ].join('\n');
-    }
   }
+};
+
+// Per-row "investigate this collector" prompt — invoked from the IA
+// button in the table. The agent gets enough context (source, target
+// tables, last run state, review distribution summary) to start a
+// generic health investigation without us pre-deciding what's wrong.
+const buildCollectorDiagnosePrompt = (row: CollectorOverviewEnriched): string => {
+  const lr = row.last_run;
+  const reviewSummary = Object.entries(row.review_distribution)
+    .filter(([k]) => k !== 'total')
+    .map(([k, v]) => `${k}=${v}`)
+    .join(', ');
+  return [
+    `Investiga el estado de salud del collector \`${row.name}\` y diagnostica si algo no va bien.`,
+    ``,
+    `**Contexto rápido**`,
+    `- Fuente: ${row.source ? `\`${row.source.name}\` (${row.source.label})` : '(sin fuente registrada — derivado o sin clasificar)'}`,
+    `- Tablas destino: ${row.target_tables.length > 0 ? row.target_tables.map((t) => `\`${t}\``).join(', ') : '(ninguna)'}`,
+    `- Categorías: ${row.categories.length > 0 ? row.categories.join(', ') : '—'}`,
+    `- Países (datos): ${row.countries_data.length > 0 ? row.countries_data.join(', ') : '—'}`,
+    `- Severity default: ${row.severity_default}${row.is_critical_any ? ' · ⭐ tabla crítica' : ''}`,
+    `- Enabled: ${row.enabled ? 'sí' : 'NO'}`,
+    `- Último run: ${lr ? `${lr.status} hace ${formatRelative(lr.started_at)} (${lr.rows_inserted ?? '—'} filas insertadas)` : 'nunca corrió'}`,
+    `- Alertas abiertas: ${row.open_alerts}`,
+    `- Estado revisión por par (collector,tabla): ${reviewSummary}`,
+    ``,
+    `**Pasos sugeridos**`,
+    `1. \`query_database\` → \`SELECT repo_path, schedule_cron, expected_frequency FROM xerenity.collector_definitions WHERE name = '${row.name}';\``,
+    `2. \`query_database\` → últimos 20 runs (\`xerenity.collector_runs\`) ordenados desc por started_at, mira tendencias de rows_inserted y errores.`,
+    `3. Si el último run es failed o tiene rows_inserted=0, lee el script con \`read_repo_file\`.`,
+    `4. Mira el contenido reciente de cada target_table — ¿last_date razonable dado expected_frequency?`,
+    `5. Resumen final: ¿está sano, hay un bug latente, o hace falta acción operacional? Propón un fix concreto si aplica.`,
+    ``,
+    `Solo diagnostico — no modifiques código. Yo aplico cambios después.`,
+  ].join('\n');
 };
 
 const DIAGNOSE_TOOLTIPS: Record<string, string> = {
@@ -313,11 +257,15 @@ const diagnoseTooltip = (source: string): string =>
   'Abre el chat con un prompt pre-cargado para que el agente investigue esta alerta. NO modifica nada.';
 
 
+// ─────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────
+
 const MonitorPage = () => {
   const {
-    collectorOverview,
+    collectorOverviewEnriched,
     activeAlerts,
-    loadCollectorOverview,
+    loadCollectorOverviewEnriched,
     loadActiveAlerts,
     acknowledgeAlert,
     silenceAlert,
@@ -326,9 +274,9 @@ const MonitorPage = () => {
     clearChat,
     sendMessage,
   } = useAppStore((s) => ({
-    collectorOverview: s.collectorOverview,
+    collectorOverviewEnriched: s.collectorOverviewEnriched,
     activeAlerts: s.activeAlerts,
-    loadCollectorOverview: s.loadCollectorOverview,
+    loadCollectorOverviewEnriched: s.loadCollectorOverviewEnriched,
     loadActiveAlerts: s.loadActiveAlerts,
     acknowledgeAlert: s.acknowledgeAlert,
     silenceAlert: s.silenceAlert,
@@ -339,30 +287,28 @@ const MonitorPage = () => {
   }));
 
   useEffect(() => {
-    loadCollectorOverview();
+    loadCollectorOverviewEnriched();
     loadActiveAlerts();
     const interval = setInterval(() => {
-      loadCollectorOverview();
+      loadCollectorOverviewEnriched();
       loadActiveAlerts();
     }, 30000);
     return () => clearInterval(interval);
-  }, [loadCollectorOverview, loadActiveAlerts]);
+  }, [loadCollectorOverviewEnriched, loadActiveAlerts]);
 
   const counts = useMemo(() => {
-    const total = collectorOverview.length;
-    const critical = collectorOverview.filter((c) => c.has_critical_alert).length;
-    const warning  = collectorOverview.filter((c) => c.has_warning_alert && !c.has_critical_alert).length;
-    const ok       = collectorOverview.filter((c) => !c.has_critical_alert && !c.has_warning_alert && c.last_run?.status === 'success').length;
+    const total = collectorOverviewEnriched.length;
+    const critical = collectorOverviewEnriched.filter((c) => c.has_critical_alert).length;
+    const warning = collectorOverviewEnriched.filter((c) => c.has_warning_alert && !c.has_critical_alert).length;
+    const ok = collectorOverviewEnriched.filter(
+      (c) => !c.has_critical_alert && !c.has_warning_alert && c.last_run?.status === 'success',
+    ).length;
     return { total, critical, warning, ok };
-  }, [collectorOverview]);
+  }, [collectorOverviewEnriched]);
 
-  // Alerts not associated with a collector (table_stale, missed_run on
-  // unknown collectors, etc.) don't show up in the per-collector counter
-  // above — they need their own line so the header doesn't claim "0
-  // critical" while 17 stale-table alerts are open in the side panel.
   const alertCounts = useMemo(() => {
     const critical = activeAlerts.filter((a) => a.severity === 'critical').length;
-    const warning  = activeAlerts.filter((a) => a.severity === 'warning').length;
+    const warning = activeAlerts.filter((a) => a.severity === 'warning').length;
     const tableStale = activeAlerts.filter((a) => a.source === 'table_stale').length;
     return { critical, warning, tableStale, total: activeAlerts.length };
   }, [activeAlerts]);
@@ -376,13 +322,18 @@ const MonitorPage = () => {
     else toast.error(res.error ?? 'Error');
   };
 
-  const handleDiagnose = (alert: typeof activeAlerts[number]) => {
-    const prompt = buildDiagnosePrompt(alert);
+  const launchAgent = (prompt: string) => {
     clearChat();
     openChat();
-    // Defer the actual send to the next tick so the panel is mounted
-    // and the user sees the message land in real time.
     setTimeout(() => { sendMessage(prompt); }, 50);
+  };
+
+  const handleDiagnoseAlert = (alert: typeof activeAlerts[number]) => {
+    launchAgent(buildAlertDiagnosePrompt(alert));
+  };
+
+  const handleDiagnoseRow = (row: CollectorOverviewEnriched) => {
+    launchAgent(buildCollectorDiagnosePrompt(row));
   };
 
   return (
@@ -422,98 +373,16 @@ const MonitorPage = () => {
               </>
             )}
           </div>
+
           <Container fluid>
             <Row>
-              <Col md={8}>
-                <TableWrap>
-                  <table>
-                    <thead>
-                      <tr>
-                        <th style={{ width: 24 }} aria-label="status indicator" />
-                        <th>Collector</th>
-                        <th>Severity</th>
-                        <th>Último run</th>
-                        <th>Duración</th>
-                        <th>Filas</th>
-                        <th>Alertas abiertas</th>
-                        <th>Tablas</th>
-                        <th aria-label="external links" />
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {collectorOverview.map((row) => (
-                        <tr key={row.name}>
-                          <td><StatusDot $color={statusColor(row)} /></td>
-                          <td>
-                            <Link href={`/admin/monitor/${encodeURIComponent(row.name)}`}>
-                              {row.name}
-                            </Link>
-                          </td>
-                          <td>
-                            <Badge
-                              style={{
-                                background: SEV_COLORS[row.severity_default],
-                                fontWeight: 500,
-                              }}
-                            >
-                              {row.severity_default}
-                            </Badge>
-                          </td>
-                          <td>
-                            {row.last_run ? (
-                              <>
-                                {statusBadge(row.last_run.status)}
-                                <span style={{ marginLeft: 8, color: '#888' }}>
-                                  {formatRelative(row.last_run.started_at)}
-                                </span>
-                              </>
-                            ) : (
-                              <span style={{ color: '#999' }}>
-                                <Icon icon={faCircleMinus} style={{ marginRight: 4 }} />
-                                nunca
-                              </span>
-                            )}
-                          </td>
-                          <td>{formatDuration(row.last_run?.duration_s ?? null)}</td>
-                          <td>{formatRowsInserted(row.last_run?.rows_inserted)}</td>
-                          <td>
-                            {row.open_alerts > 0 ? (
-                              <Badge bg="danger">{row.open_alerts}</Badge>
-                            ) : (
-                              <span style={{ color: '#ccc' }} title="0 alertas abiertas">—</span>
-                            )}
-                          </td>
-                          <td style={{ fontSize: 11, color: '#666' }}>
-                            {row.target_tables.length > 0
-                              ? row.target_tables.join(', ')
-                              : <em style={{ color: '#bbb' }}>—</em>}
-                          </td>
-                          <td>
-                            {row.last_run?.gh_run_url && (
-                              <a
-                                href={row.last_run.gh_run_url}
-                                target="_blank"
-                                rel="noreferrer"
-                                style={{ fontSize: 12 }}
-                              >
-                                GH <Icon icon={faArrowUpRightFromSquare} />
-                              </a>
-                            )}
-                          </td>
-                        </tr>
-                      ))}
-                      {collectorOverview.length === 0 && (
-                        <tr>
-                          <td colSpan={9}>
-                            <EmptyState>Sin collectors en el catálogo.</EmptyState>
-                          </td>
-                        </tr>
-                      )}
-                    </tbody>
-                  </table>
-                </TableWrap>
+              <Col xl={9} lg={8}>
+                <MonitorTable
+                  rows={collectorOverviewEnriched}
+                  onDiagnose={handleDiagnoseRow}
+                />
               </Col>
-              <Col md={4}>
+              <Col xl={3} lg={4}>
                 <AlertsPanel>
                   <h4>Alertas activas ({activeAlerts.length})</h4>
                   {activeAlerts.length === 0 && (
@@ -537,7 +406,7 @@ const MonitorPage = () => {
                           size="sm"
                           variant="outline-primary"
                           title={diagnoseTooltip(alert.source)}
-                          onClick={() => handleDiagnose(alert)}
+                          onClick={() => handleDiagnoseAlert(alert)}
                         >
                           <Icon icon={faRobot} /> Diagnosticar con IA
                         </BsButton>

--- a/src/store/monitor/index.ts
+++ b/src/store/monitor/index.ts
@@ -1,11 +1,13 @@
 import { StateCreator } from 'zustand';
 import {
   CollectorOverview,
+  CollectorOverviewEnriched,
   CollectorRun,
   CollectorAlert,
 } from 'src/types/monitor';
 import {
   listCollectorOverview,
+  listCollectorOverviewEnriched,
   listActiveAlerts,
   listCollectorRuns,
   acknowledgeAlert as ackRpc,
@@ -15,13 +17,19 @@ import {
 } from 'src/models/monitor';
 
 export interface MonitorSlice {
+  // Legacy overview — kept around because /admin/monitor/[name] still
+  // calls getCollectorDefinition() which uses the basic RPC. Will get
+  // dropped once that page also migrates.
   collectorOverview: CollectorOverview[];
+  // Enriched overview powering the new /admin/monitor table.
+  collectorOverviewEnriched: CollectorOverviewEnriched[];
   activeAlerts: CollectorAlert[];
   collectorRuns: Record<string, CollectorRun[]>;
   monitorLoading: boolean;
   monitorError: string | undefined;
 
   loadCollectorOverview: () => Promise<void>;
+  loadCollectorOverviewEnriched: () => Promise<void>;
   loadActiveAlerts: () => Promise<void>;
   loadCollectorRuns: (collectorName: string, limit?: number) => Promise<void>;
   acknowledgeAlert: (alertId: string) => Promise<ActionResponse>;
@@ -32,6 +40,7 @@ export interface MonitorSlice {
 
 const initialState = {
   collectorOverview: [] as CollectorOverview[],
+  collectorOverviewEnriched: [] as CollectorOverviewEnriched[],
   activeAlerts: [] as CollectorAlert[],
   collectorRuns: {} as Record<string, CollectorRun[]>,
   monitorLoading: false,
@@ -49,6 +58,16 @@ const createMonitorSlice: StateCreator<MonitorSlice> = (set, get) => ({
       return;
     }
     set({ collectorOverview: res.data, monitorLoading: false });
+  },
+
+  loadCollectorOverviewEnriched: async () => {
+    set({ monitorLoading: true, monitorError: undefined });
+    const res = await listCollectorOverviewEnriched();
+    if (res.error) {
+      set({ monitorLoading: false, monitorError: res.error });
+      return;
+    }
+    set({ collectorOverviewEnriched: res.data, monitorLoading: false });
   },
 
   loadActiveAlerts: async () => {

--- a/src/types/monitor.ts
+++ b/src/types/monitor.ts
@@ -26,6 +26,36 @@ export interface CollectorOverview {
   has_warning_alert: boolean;
 }
 
+// Catalog enrichment returned by list_collector_overview_enriched RPC.
+// One element per collector. Extends CollectorOverview with the source +
+// per-target-table catalog metadata aggregated per-collector.
+
+export interface OverviewSource {
+  name: string;
+  label: string;
+  source_type: 'rest_api' | 'web_scrape' | 'file_download' | 'manual' | null;
+  country: string | null;
+}
+
+export type ReviewStatusKey =
+  | 'pendiente'
+  | 'mantener'
+  | 'arreglar'
+  | 'deprecar'
+  | 'documentar';
+
+export type ReviewDistribution = Record<ReviewStatusKey, number> & {
+  total: number;
+};
+
+export interface CollectorOverviewEnriched extends CollectorOverview {
+  source: OverviewSource | null;
+  categories: string[];
+  countries_data: string[];
+  is_critical_any: boolean;
+  review_distribution: ReviewDistribution;
+}
+
 export interface CollectorRun {
   id: string;
   collector_name: string;


### PR DESCRIPTION
Closes #352

## Why

The flat `/admin/monitor` table doesn't scale to 30+ collectors. Every dimension that matters — **fuente, categoría, país, criticidad, estado de revisión** — was hidden 3 clicks deep inside the per-collector detail page. To manage the fleet you need to scan, filter, group and sort in bulk without leaving the overview.

## What ships

### Toolbar
Free-text search, multi-select **fuente / categoría / país / severity**, toggles "solo críticos" + "solo failing/stale", and a **GroupBy** dropdown with collapsible Excel-pivot-style headers (sin agrupar / por fuente / severity / categoría / país / estado de revisión).

### Table
- Sort on every column (click headers).
- New columns: **Fuente** (badge with hover tooltip → label), **Categorías** (chips), **País** (chips, data-side), **Tablas destino** (full list of `target_tables` as code chips), **Estado revisión** (5-segment stacked bar showing % distribution + per-status hover counts), **★** if any target table is `is_critical=true`.
- **IA button per row** — opens chat with a pre-loaded "investigate collector X" prompt that includes source, target tables, last-run state, alert count, and review distribution summary, then asks the agent to investigate via `query_database` + `read_repo_file` (read-only).

### Files
- `src/types/monitor.ts` — `CollectorOverviewEnriched`, `OverviewSource`, `ReviewDistribution`.
- `src/models/monitor/index.ts` — `listCollectorOverviewEnriched`.
- `src/store/monitor/index.ts` — added `collectorOverviewEnriched` + loader (old one kept for `/admin/monitor/[name]` until that migrates too).
- `src/pages/admin/monitor/_MonitorTable.tsx` — TanStack v8 wrapper, toolbar, MultiSelect, ReviewBar (~770 lines).
- `src/pages/admin/monitor/_ReviewBar.tsx` — stacked-bar viz.
- `src/pages/admin/monitor/index.tsx` — thinned: header counters + `<MonitorTable>` + alerts panel. Existing alert IA prompts preserved.

## Dependencies
- **xerenity-db PR #88** — `list_collector_overview_enriched` RPC + backfill of `collector_definitions.source_name`. Already merged + applied to live DB before this PR is reviewed.

## Test plan
- [ ] Vercel preview builds green
- [ ] As super_admin, open `/admin/monitor` — page renders with new toolbar + table
- [ ] **Sort** — click any header, row order changes
- [ ] **Filter** — pick a source / category / country / severity, table narrows; "Solo críticos" toggle hides non-critical
- [ ] **GroupBy** — pick "Por fuente" → all SuperFinanciera collectors collapse under one header; click chevron to expand/collapse
- [ ] **IA por fila** — click "IA" on any row → chat opens with the collector-specific prompt
- [ ] **Alerts panel** (right side) still works — ACK / 1h / 24h / Cerrar / Diagnosticar IA all function as before
- [ ] Non-super_admin user still sees the role-guard fallback