### PR TITLE
fix(portfolio): restore "Add trade" buttons in OTC/TES after role migration

### DIFF
--- a/src/store/trading/index.ts
+++ b/src/store/trading/index.ts
@@ -18,6 +18,7 @@ import {
   MarketDataConfig,
   DEFAULT_MARKET_DATA_CONFIG,
 } from 'src/types/trading';
+import type { UserProfile } from 'src/types/user';
 import { computePnlRefDates } from 'src/utils/pnlDates';
 import {
   fetchXccyPositions,
@@ -222,9 +223,18 @@ const createTradingSlice: StateCreator<TradingSlice> = (set, get) => {
 
   loadUserRole: async () => {
     const role = await fetchUserTradingRole();
+    // After the role-system migration, userProfile is the canonical source.
+    // The legacy trading RPC returns null for new role names, leaving canEdit
+    // false and hiding the "Add" buttons in OTC/TES portfolios.
+    const profile = (get() as unknown as { userProfile: UserProfile | null }).userProfile;
+    const modernCanEdit =
+      profile?.role === 'super_admin' ||
+      profile?.role === 'corp_admin' ||
+      profile?.role === 'gestor';
+    const legacyCanEdit = role.role === 'admin' || role.role === 'manager';
     set({
       userRole: role,
-      canEdit: role.role === 'admin' || role.role === 'manager',
+      canEdit: modernCanEdit || legacyCanEdit,
     });
   },
 


### PR DESCRIPTION
Closes #358

## Summary
- En `/portfolio` (Portafolio OTC) y `/tes-portfolio` los botones para incluir trades (XCCY Swap / NDF / IBR Swap / TES) habían desaparecido.
- Causa: `canEdit` se derivaba del RPC legado `get_user_trading_role` (roles `admin`/`manager`). Tras la migración al sistema moderno (`super_admin`/`corp_admin`/`gestor`/`lector`), el RPC retorna `null` y los botones quedaban ocultos.
- Fix: derivar `canEdit` también de `userProfile.role` (fuente canónica moderna) manteniendo compatibilidad con los roles legados.

## Test plan
- [ ] `npm run dev` → entrar a `/portfolio` con usuario `super_admin` / `corp_admin` / `gestor` → ver los 3 botones "Add XCCY Swap / Add NDF / Add IBR Swap" en el header.
- [ ] Mismo check en `/tes-portfolio` → ver botón "Add TES".
- [ ] Crear una posición XCCY/NDF/IBR y validar que se guarda y aparece en el blotter.
- [ ] Con rol `lector`, los botones NO deben aparecer.
- [ ] Loans (`/loans`): el botón "Nuevo Crédito" no usa `canEdit`, no se ve afectado — verificar que sigue funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)