### PR TITLE
feat(inflation): rediseño v2 top-of-the-art con 6 secciones, ciudades, núcleo y subgrupos

### DIFF
--- a/src/components/inflation/ContributionChart.tsx
+++ b/src/components/inflation/ContributionChart.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useMemo } from 'react';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ReferenceLine,
+} from 'recharts';
+import useAppStore from 'src/store';
+import Panel from '@components/Panel';
+import { getHexColor } from 'src/utils/getHexColors';
+import { SectionTitle } from './styled';
+
+const fmtMonth = (s: string) => {
+  const d = new Date(`${s}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: '2-digit', year: '2-digit' });
+};
+
+interface Row {
+  time: string;
+  total: number;
+  [k: string]: number | string;
+}
+
+export default function ContributionChart() {
+  const contributions = useAppStore((s) => s.contributions);
+  const canastas = useAppStore((s) => s.canastas);
+  const loadContributions = useAppStore((s) => s.loadContributions);
+
+  useEffect(() => {
+    if (contributions.length === 0) {
+      loadContributions(24);
+    }
+  }, [contributions.length, loadContributions]);
+
+  const { rows, divisions, colorById } = useMemo(() => {
+    const byTime = new Map<string, Row>();
+    const divSet = new Map<number, string>();
+    contributions.forEach((c) => {
+      if (!byTime.has(c.time)) byTime.set(c.time, { time: c.time, total: 0 });
+      const r = byTime.get(c.time) as Row;
+      r[`d_${c.id_canasta}`] = c.valorcontribucion;
+      r.total += c.valorcontribucion;
+      divSet.set(c.id_canasta, c.nombre);
+    });
+    const divs = Array.from(divSet.entries()).map(([id, nombre]) => ({ id, nombre }));
+    const colors: Record<number, string> = {};
+    divs.forEach((d, i) => {
+      colors[d.id] = getHexColor(i + 1);
+    });
+    return {
+      rows: Array.from(byTime.values()).sort((a, b) => a.time.localeCompare(b.time)),
+      divisions: divs,
+      colorById: colors,
+    };
+  }, [contributions]);
+
+  const labelFor = (id: number) =>
+    canastas.find((c) => c.id === id)?.nombre ||
+    divisions.find((d) => d.id === id)?.nombre ||
+    `#${id}`;
+
+  return (
+    <Panel>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+        <SectionTitle style={{ margin: 0 }}>Contribuciones al IPC mensual (últimos 24 meses)</SectionTitle>
+      </div>
+      <div style={{ width: '100%', height: 320 }}>
+        <ResponsiveContainer>
+          <BarChart data={rows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid stroke="#eee" strokeDasharray="3 3" />
+            <XAxis dataKey="time" tickFormatter={fmtMonth} minTickGap={20} />
+            <YAxis
+              tickFormatter={(v) => `${v.toFixed(2)}`}
+              width={50}
+            />
+            <ReferenceLine y={0} stroke="#a6a6a6" />
+            <Tooltip
+              formatter={(v: number) => `${v?.toFixed?.(3) ?? '—'} pp`}
+              labelFormatter={(label: string) => fmtMonth(label)}
+            />
+            <Legend
+              verticalAlign="bottom"
+              iconType="square"
+              wrapperStyle={{ fontSize: 11 }}
+              formatter={(value) => {
+                const id = Number(String(value).replace('d_', ''));
+                return labelFor(id);
+              }}
+            />
+            {divisions.map((d) => (
+              <Bar
+                key={d.id}
+                dataKey={`d_${d.id}`}
+                stackId="contrib"
+                fill={colorById[d.id]}
+                isAnimationActive={false}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </Panel>
+  );
+}

--- a/src/components/inflation/InflationHeatmap.tsx
+++ b/src/components/inflation/InflationHeatmap.tsx
@@ -1,0 +1,149 @@
+import React, { useMemo } from 'react';
+import useAppStore from 'src/store';
+import Panel from '@components/Panel';
+import { SectionTitle } from './styled';
+
+const fmtMonth = (s: string) => {
+  const d = new Date(`${s}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: '2-digit', year: '2-digit' });
+};
+
+const colorFor = (v: number, max: number): string => {
+  if (Number.isNaN(v) || v === null || v === undefined) return '#fff';
+  const pos = Math.max(0, Math.min(1, v / max));
+  const neg = Math.max(0, Math.min(1, -v / max));
+  if (v >= 0) {
+    const a = (0.05 + pos * 0.85).toFixed(2);
+    return `rgba(176, 42, 55, ${a})`;
+  }
+  const a = (0.05 + neg * 0.85).toFixed(2);
+  return `rgba(24, 135, 84, ${a})`;
+};
+
+const cellFontColor = (v: number, max: number) => {
+  const intensity = Math.min(1, Math.abs(v) / max);
+  return intensity > 0.55 ? '#fff' : '#212529';
+};
+
+export default function InflationHeatmap() {
+  const contributions = useAppStore((s) => s.contributions);
+  const canastas = useAppStore((s) => s.canastas);
+
+  const { months, byKey, divisions, max } = useMemo(() => {
+    const monthSet = new Set<string>();
+    const divSet = new Map<number, string>();
+    const map = new Map<string, number>();
+    let m = 0;
+    contributions.forEach((c) => {
+      monthSet.add(c.time);
+      divSet.set(c.id_canasta, c.nombre);
+      map.set(`${c.id_canasta}|${c.time}`, c.valormensual);
+      m = Math.max(m, Math.abs(c.valormensual));
+    });
+    return {
+      months: Array.from(monthSet).sort(),
+      byKey: map,
+      divisions: Array.from(divSet.entries()).map(([id, nombre]) => ({
+        id,
+        nombre,
+      })),
+      max: m || 1,
+    };
+  }, [contributions]);
+
+  const labelFor = (id: number) =>
+    canastas.find((c) => c.id === id)?.nombre ||
+    divisions.find((d) => d.id === id)?.nombre ||
+    `#${id}`;
+
+  if (months.length === 0 || divisions.length === 0) {
+    return (
+      <Panel>
+        <SectionTitle>Heatmap mensual por división</SectionTitle>
+        <div style={{ color: '#777', fontSize: 12 }}>Sin datos.</div>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel>
+      <SectionTitle>Heatmap MoM por división (últimos 24 meses)</SectionTitle>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ borderCollapse: 'separate', borderSpacing: 2, fontSize: 11 }}>
+          <thead>
+            <tr>
+              <th
+                style={{
+                  textAlign: 'left',
+                  padding: '4px 8px',
+                  position: 'sticky',
+                  left: 0,
+                  background: '#fff',
+                  zIndex: 1,
+                }}
+              >
+                División
+              </th>
+              {months.map((m) => (
+                <th
+                  key={m}
+                  style={{
+                    padding: '4px 6px',
+                    fontWeight: 500,
+                    color: '#777',
+                    textAlign: 'center',
+                  }}
+                >
+                  {fmtMonth(m)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {divisions.map((d) => (
+              <tr key={d.id}>
+                <td
+                  style={{
+                    padding: '4px 8px',
+                    position: 'sticky',
+                    left: 0,
+                    background: '#fff',
+                    fontWeight: 500,
+                    whiteSpace: 'nowrap',
+                    maxWidth: 220,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                  title={labelFor(d.id)}
+                >
+                  {labelFor(d.id)}
+                </td>
+                {months.map((m) => {
+                  const v = byKey.get(`${d.id}|${m}`);
+                  const num = typeof v === 'number' ? v : NaN;
+                  const display = Number.isNaN(num) ? '' : num.toFixed(2);
+                  return (
+                    <td
+                      key={`${d.id}-${m}`}
+                      style={{
+                        padding: '4px 6px',
+                        background: colorFor(num, max),
+                        color: cellFontColor(num, max),
+                        textAlign: 'center',
+                        minWidth: 38,
+                        borderRadius: 3,
+                      }}
+                      title={`${labelFor(d.id)} · ${fmtMonth(m)}: ${display}%`}
+                    >
+                      {display}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Panel>
+  );
+}

--- a/src/components/inflation/InflationKPIs.tsx
+++ b/src/components/inflation/InflationKPIs.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect } from 'react';
+import useAppStore from 'src/store';
+import { CPISnapshot } from 'src/types/inflation';
+import {
+  KpiGrid,
+  KpiCard,
+  KpiLabel,
+  KpiValue,
+  KpiDelta,
+  KpiSubtle,
+} from './styled';
+
+const TOTAL_ID = 1;
+const BANREP_TARGET = 3;
+const BANREP_TOL = 1;
+
+const fmtPct = (v: number | null | undefined, digits = 2) =>
+  v === null || v === undefined || Number.isNaN(v)
+    ? '—'
+    : `${v >= 0 ? '+' : ''}${v.toFixed(digits)}%`;
+
+const fmtMonthYear = (iso: string | null) => {
+  if (!iso) return '—';
+  const d = new Date(`${iso}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: 'long', year: 'numeric' });
+};
+
+const arrowTone = (delta: number | null | undefined) => {
+  if (delta === null || delta === undefined || Number.isNaN(delta)) return 'neutral';
+  return delta > 0 ? 'positive' : 'negative';
+};
+
+const arrow = (delta: number | null | undefined) => {
+  if (delta === null || delta === undefined || Number.isNaN(delta)) return '';
+  if (Math.abs(delta) < 0.005) return '·';
+  return delta > 0 ? '▲' : '▼';
+};
+
+const targetTone = (yoy: number | null | undefined) => {
+  if (yoy === null || yoy === undefined || Number.isNaN(yoy)) return 'neutral';
+  if (yoy > BANREP_TARGET + BANREP_TOL) return 'positive';
+  if (yoy < BANREP_TARGET - BANREP_TOL) return 'negative';
+  return 'neutral';
+};
+
+const targetLabel = (yoy: number | null | undefined) => {
+  if (yoy === null || yoy === undefined || Number.isNaN(yoy)) return '—';
+  if (yoy > BANREP_TARGET + BANREP_TOL) return `+${(yoy - (BANREP_TARGET + BANREP_TOL)).toFixed(2)} pp sobre el techo`;
+  if (yoy < BANREP_TARGET - BANREP_TOL) return `${((BANREP_TARGET - BANREP_TOL) - yoy).toFixed(2)} pp bajo el piso`;
+  return 'dentro del rango';
+};
+
+export default function InflationKPIs() {
+  const snapshot = useAppStore((s) => s.snapshotByCanasta[TOTAL_ID]) as CPISnapshot | undefined;
+  const loadCanastaSnapshot = useAppStore((s) => s.loadCanastaSnapshot);
+
+  useEffect(() => {
+    loadCanastaSnapshot(TOTAL_ID);
+  }, [loadCanastaSnapshot]);
+
+  const yoy = snapshot?.last_yoy ?? null;
+  const yoyDelta =
+    snapshot && snapshot.last_yoy !== null && snapshot.prev_yoy !== null
+      ? snapshot.last_yoy - snapshot.prev_yoy
+      : null;
+  const mom = snapshot?.last_mom ?? null;
+  const ytd = snapshot?.last_ytd ?? null;
+
+  return (
+    <KpiGrid>
+      <KpiCard>
+        <KpiLabel>IPC anual (YoY)</KpiLabel>
+        <KpiValue tone={arrowTone(yoy)}>{fmtPct(yoy)}</KpiValue>
+        <KpiDelta tone={arrowTone(yoyDelta)}>
+          {arrow(yoyDelta)} {fmtPct(yoyDelta, 2)} vs mes anterior
+        </KpiDelta>
+        <KpiSubtle>{fmtMonthYear(snapshot?.last_date ?? null)}</KpiSubtle>
+      </KpiCard>
+
+      <KpiCard>
+        <KpiLabel>IPC mensual (MoM)</KpiLabel>
+        <KpiValue tone={arrowTone(mom)}>{fmtPct(mom)}</KpiValue>
+        <KpiDelta tone="neutral">Variación punta a punta del mes</KpiDelta>
+        <KpiSubtle>{fmtMonthYear(snapshot?.last_date ?? null)}</KpiSubtle>
+      </KpiCard>
+
+      <KpiCard>
+        <KpiLabel>Año corrido (YTD)</KpiLabel>
+        <KpiValue tone={arrowTone(ytd)}>{fmtPct(ytd)}</KpiValue>
+        <KpiDelta tone="neutral">Acumulado desde enero</KpiDelta>
+        <KpiSubtle>Cierre {fmtMonthYear(snapshot?.last_date ?? null)}</KpiSubtle>
+      </KpiCard>
+
+      <KpiCard>
+        <KpiLabel>Meta Banrep 3% ±1%</KpiLabel>
+        <KpiValue tone={targetTone(yoy)}>{fmtPct(yoy)}</KpiValue>
+        <KpiDelta tone={targetTone(yoy)}>{targetLabel(yoy)}</KpiDelta>
+        <KpiSubtle>Rango objetivo: 2% – 4%</KpiSubtle>
+      </KpiCard>
+    </KpiGrid>
+  );
+}

--- a/src/components/inflation/InflationMainChart.tsx
+++ b/src/components/inflation/InflationMainChart.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceArea,
+  ReferenceLine,
+  Legend,
+} from 'recharts';
+import useAppStore from 'src/store';
+import Panel from '@components/Panel';
+import { CPIPoint, InflationView } from 'src/types/inflation';
+import { getHexColor } from 'src/utils/getHexColors';
+import {
+  ChipRow,
+  Chip,
+  SegmentedRow,
+  SegmentedButton,
+  SectionTitle,
+} from './styled';
+
+const TOTAL_ID = 1;
+const VIEWS: { id: InflationView; label: string }[] = [
+  { id: 'yoy', label: 'YoY' },
+  { id: 'mom', label: 'MoM' },
+  { id: 'ytd', label: 'YTD' },
+  { id: 'indice', label: 'Índice' },
+];
+
+const RANGES: { label: string; months: number | null }[] = [
+  { label: '1A', months: 12 },
+  { label: '3A', months: 36 },
+  { label: '5A', months: 60 },
+  { label: '10A', months: 120 },
+  { label: 'Max', months: null },
+];
+
+const fmtTick = (v: number) => `${v.toFixed(1)}%`;
+const fmtTickIdx = (v: number) => v.toFixed(0);
+const fmtMonth = (s: string) => {
+  const d = new Date(`${s}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: '2-digit', year: '2-digit' });
+};
+
+interface Row {
+  time: string;
+  [k: string]: number | string | null;
+}
+
+export default function InflationMainChart() {
+  const canastas = useAppStore((s) => s.canastas);
+  const selected = useAppStore((s) => s.selectedCanastaIds);
+  const seriesByCanasta = useAppStore((s) => s.seriesByCanasta);
+  const toggleCanasta = useAppStore((s) => s.toggleCanasta);
+  const setSelected = useAppStore((s) => s.setSelectedCanastaIds);
+
+  const [view, setView] = useState<InflationView>('yoy');
+  const [rangeMonths, setRangeMonths] = useState<number | null>(60);
+
+  useEffect(() => {
+    if (selected.length === 0) {
+      setSelected([TOTAL_ID]);
+    }
+  }, [selected.length, setSelected]);
+
+  const colorByCanasta = useMemo(() => {
+    const m: Record<number, string> = {};
+    canastas.forEach((c, i) => {
+      m[c.id] = c.id === TOTAL_ID ? '#786CF7' : getHexColor(i + 1);
+    });
+    return m;
+  }, [canastas]);
+
+  const merged: Row[] = useMemo(() => {
+    if (selected.length === 0) return [];
+    const allTimes = new Set<string>();
+    selected.forEach((id) => {
+      (seriesByCanasta[id] || []).forEach((p) => allTimes.add(p.time));
+    });
+    const sortedTimes = Array.from(allTimes).sort();
+    const cutoff = rangeMonths
+      ? new Date(
+          new Date(sortedTimes[sortedTimes.length - 1] || Date.now())
+            .getTime() -
+            rangeMonths * 30.5 * 86400 * 1000
+        )
+          .toISOString()
+          .slice(0, 10)
+      : null;
+    const filteredTimes = cutoff
+      ? sortedTimes.filter((t) => t >= cutoff)
+      : sortedTimes;
+
+    const indexBySeries: Record<number, Map<string, CPIPoint>> = {};
+    selected.forEach((id) => {
+      const map = new Map<string, CPIPoint>();
+      (seriesByCanasta[id] || []).forEach((p) => map.set(p.time, p));
+      indexBySeries[id] = map;
+    });
+
+    return filteredTimes.map((time) => {
+      const row: Row = { time };
+      selected.forEach((id) => {
+        const p = indexBySeries[id].get(time);
+        const v = p ? (p[view] as number | null) : null;
+        row[`s_${id}`] = v;
+      });
+      return row;
+    });
+  }, [selected, seriesByCanasta, view, rangeMonths]);
+
+  const isPercent = view !== 'indice';
+  const showBanrepBand = view === 'yoy' && selected.includes(TOTAL_ID);
+
+  const tooltipFmt = (v: unknown) => {
+    if (typeof v !== 'number') return '—';
+    return isPercent ? `${v.toFixed(2)}%` : v.toFixed(2);
+  };
+
+  const labelFor = (id: number) =>
+    canastas.find((c) => c.id === id)?.nombre || `#${id}`;
+
+  return (
+    <Panel>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8, gap: 12, flexWrap: 'wrap' }}>
+        <SectionTitle style={{ margin: 0 }}>Series IPC</SectionTitle>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <SegmentedRow>
+            {VIEWS.map((v) => (
+              <SegmentedButton
+                key={v.id}
+                active={view === v.id}
+                onClick={() => setView(v.id)}
+              >
+                {v.label}
+              </SegmentedButton>
+            ))}
+          </SegmentedRow>
+          <SegmentedRow>
+            {RANGES.map((r) => (
+              <SegmentedButton
+                key={r.label}
+                active={rangeMonths === r.months}
+                onClick={() => setRangeMonths(r.months)}
+              >
+                {r.label}
+              </SegmentedButton>
+            ))}
+          </SegmentedRow>
+        </div>
+      </div>
+
+      <ChipRow style={{ marginBottom: 12 }}>
+        {canastas.map((c) => {
+          const active = selected.includes(c.id);
+          return (
+            <Chip
+              key={c.id}
+              active={active}
+              color={colorByCanasta[c.id]}
+              onClick={() => toggleCanasta(c.id)}
+              title={`${c.nombre} (peso ${(c.peso * 100).toFixed(2)}%)`}
+            >
+              {c.nombre}
+            </Chip>
+          );
+        })}
+      </ChipRow>
+
+      <div style={{ width: '100%', height: 360 }}>
+        <ResponsiveContainer>
+          <LineChart data={merged} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid stroke="#eee" strokeDasharray="3 3" />
+            <XAxis dataKey="time" tickFormatter={fmtMonth} minTickGap={32} />
+            <YAxis
+              tickFormatter={isPercent ? fmtTick : fmtTickIdx}
+              width={56}
+            />
+            {showBanrepBand && (
+              <ReferenceArea
+                y1={2}
+                y2={4}
+                fill="#75B798"
+                fillOpacity={0.1}
+                ifOverflow="extendDomain"
+              />
+            )}
+            {showBanrepBand && (
+              <ReferenceLine y={3} stroke="#469F76" strokeDasharray="4 4" />
+            )}
+            {isPercent && (
+              <ReferenceLine y={0} stroke="#a6a6a6" strokeDasharray="2 2" />
+            )}
+            <Tooltip
+              formatter={tooltipFmt}
+              labelFormatter={(label: string) => fmtMonth(label)}
+            />
+            <Legend
+              verticalAlign="bottom"
+              iconType="line"
+              wrapperStyle={{ fontSize: 12 }}
+              formatter={(value) => {
+                const id = Number(String(value).replace('s_', ''));
+                return labelFor(id);
+              }}
+            />
+            {selected.map((id) => (
+              <Line
+                key={id}
+                type="monotone"
+                dataKey={`s_${id}`}
+                stroke={colorByCanasta[id]}
+                strokeWidth={id === TOTAL_ID ? 2.4 : 1.6}
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </Panel>
+  );
+}

--- a/src/components/inflation/InflationPivotTable.tsx
+++ b/src/components/inflation/InflationPivotTable.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useMemo } from 'react';
+import useAppStore from 'src/store';
+import Panel from '@components/Panel';
+import { SectionTitle } from './styled';
+
+const fmtPct = (v: number | null | undefined) =>
+  v === null || v === undefined || Number.isNaN(v) ? '—' : `${v.toFixed(2)}%`;
+
+const fmtMonth = (s: string) => {
+  const d = new Date(`${s}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: 'short', year: '2-digit' });
+};
+
+const TOTAL_ID = 1;
+
+interface Row {
+  id: number;
+  nombre: string;
+  peso: number;
+  yoy: number | null;
+  ytd: number | null;
+  monthly: Record<string, number | null>;
+}
+
+export default function InflationPivotTable() {
+  const canastas = useAppStore((s) => s.canastas);
+  const seriesByCanasta = useAppStore((s) => s.seriesByCanasta);
+  const setSelected = useAppStore((s) => s.setSelectedCanastaIds);
+
+  // Make sure all canastas have their full series loaded, so the pivot is complete.
+  useEffect(() => {
+    if (canastas.length > 0) {
+      setSelected(canastas.map((c) => c.id));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canastas.length]);
+
+  const { rows, lastMonths } = useMemo(() => {
+    if (canastas.length === 0) return { rows: [] as Row[], lastMonths: [] as string[] };
+
+    // Determine the most recent 12 months from the Total series (most complete)
+    const totalSeries = seriesByCanasta[TOTAL_ID] || [];
+    const last12 = totalSeries.slice(-12).map((p) => p.time);
+
+    const built: Row[] = canastas.map((c) => {
+      const ser = seriesByCanasta[c.id] || [];
+      const last = ser[ser.length - 1];
+      const monthly: Record<string, number | null> = {};
+      const idx = new Map(ser.map((p) => [p.time, p]));
+      last12.forEach((m) => {
+        const p = idx.get(m);
+        monthly[m] = p?.mom ?? null;
+      });
+      return {
+        id: c.id,
+        nombre: c.nombre,
+        peso: c.peso,
+        yoy: last?.yoy ?? null,
+        ytd: last?.ytd ?? null,
+        monthly,
+      };
+    });
+    return { rows: built, lastMonths: last12 };
+  }, [canastas, seriesByCanasta]);
+
+  if (rows.length === 0) {
+    return (
+      <Panel>
+        <SectionTitle>Tabla por división</SectionTitle>
+        <div style={{ color: '#777', fontSize: 12 }}>Cargando series…</div>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel>
+      <SectionTitle>Tabla por división — últimos 12 meses</SectionTitle>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ borderCollapse: 'collapse', fontSize: 12, width: '100%' }}>
+          <thead>
+            <tr style={{ background: '#EEEEEE', textAlign: 'right' }}>
+              <th style={{ padding: '8px 10px', textAlign: 'left' }}>División</th>
+              <th style={{ padding: '8px 10px' }}>Peso</th>
+              <th style={{ padding: '8px 10px' }}>YoY</th>
+              <th style={{ padding: '8px 10px' }}>YTD</th>
+              {lastMonths.map((m) => (
+                <th key={m} style={{ padding: '8px 6px', fontWeight: 500 }}>
+                  {fmtMonth(m)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr
+                key={r.id}
+                style={{
+                  borderBottom: '1px solid #f1f1f1',
+                  background: r.id === TOTAL_ID ? '#F1F0EC' : 'transparent',
+                  fontWeight: r.id === TOTAL_ID ? 600 : 400,
+                  textAlign: 'right',
+                }}
+              >
+                <td
+                  style={{
+                    padding: '6px 10px',
+                    textAlign: 'left',
+                    maxWidth: 260,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                  title={r.nombre}
+                >
+                  {r.nombre}
+                </td>
+                <td style={{ padding: '6px 10px' }}>
+                  {(r.peso * 100).toFixed(2)}%
+                </td>
+                <td style={{ padding: '6px 10px' }}>{fmtPct(r.yoy)}</td>
+                <td style={{ padding: '6px 10px' }}>{fmtPct(r.ytd)}</td>
+                {lastMonths.map((m) => (
+                  <td key={`${r.id}-${m}`} style={{ padding: '6px 6px' }}>
+                    {fmtPct(r.monthly[m])}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Panel>
+  );
+}

--- a/src/components/inflation/styled.tsx
+++ b/src/components/inflation/styled.tsx
@@ -1,0 +1,134 @@
+import styled from 'styled-components';
+import tokens from 'design-tokens/tokens.json';
+
+const t = tokens.xerenity;
+const PURPLE = t['purple-100'].value;
+const PURPLE_50 = t['purple-50'].value;
+const GRAY_100 = t['gray-100'].value;
+const GRAY_200 = t['gray-200'].value;
+const GRAY_300 = t['gray-300'].value;
+const GRAY_500 = t['gray-500'].value;
+const WHITE = t['white-100'].value;
+const RED = t['red-600'].value;
+const GREEN = t['green-500'].value;
+
+export const KpiGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+  @media (max-width: 1100px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+`;
+
+export const KpiCard = styled.div`
+  background: ${WHITE};
+  border: 1px solid ${GRAY_200};
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 92px;
+`;
+
+export const KpiLabel = styled.div`
+  font-size: 12px;
+  color: ${GRAY_500};
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+`;
+
+export const KpiValue = styled.div<{ tone?: 'positive' | 'negative' | 'neutral' }>`
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1.1;
+  color: ${({ tone }) => {
+    if (tone === 'positive') return RED;
+    if (tone === 'negative') return GREEN;
+    return '#212529';
+  }};
+`;
+
+export const KpiDelta = styled.span<{ tone?: 'positive' | 'negative' | 'neutral' }>`
+  font-size: 12px;
+  font-weight: 500;
+  color: ${({ tone }) => {
+    if (tone === 'positive') return RED;
+    if (tone === 'negative') return GREEN;
+    return GRAY_500;
+  }};
+`;
+
+export const KpiSubtle = styled.div`
+  font-size: 11px;
+  color: ${GRAY_500};
+`;
+
+export const ChipRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+`;
+
+export const Chip = styled.button<{ active?: boolean; color?: string }>`
+  border: 1px solid ${({ active, color }) =>
+    active ? color || PURPLE : GRAY_300};
+  background: ${({ active, color }) =>
+    active ? `${color || PURPLE}1a` : WHITE};
+  color: ${({ active, color }) =>
+    active ? color || PURPLE : '#212529'};
+  border-radius: 999px;
+  font-size: 12px;
+  padding: 4px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 120ms ease;
+  &:hover {
+    background: ${({ color }) => (color ? `${color}1a` : GRAY_100)};
+  }
+`;
+
+export const SegmentedRow = styled.div`
+  display: inline-flex;
+  background: ${GRAY_100};
+  border-radius: 6px;
+  padding: 2px;
+  gap: 2px;
+`;
+
+export const SegmentedButton = styled.button<{ active?: boolean }>`
+  border: 0;
+  background: ${({ active }) => (active ? WHITE : 'transparent')};
+  color: ${({ active }) => (active ? PURPLE : '#212529')};
+  font-size: 12px;
+  font-weight: ${({ active }) => (active ? 600 : 500)};
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  box-shadow: ${({ active }) =>
+    active ? '0 1px 2px rgba(0,0,0,0.06)' : 'none'};
+`;
+
+export const SectionTitle = styled.h5`
+  font-size: 13px;
+  font-weight: 600;
+  color: #212529;
+  margin: 0 0 8px 0;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+`;
+
+export const PALETTE = {
+  PURPLE,
+  PURPLE_50,
+  GRAY_100,
+  GRAY_200,
+  GRAY_300,
+  GRAY_500,
+  WHITE,
+  RED,
+  GREEN,
+};

--- a/src/components/inflation/v2/CityRanking.tsx
+++ b/src/components/inflation/v2/CityRanking.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import useAppStore from 'src/store';
+import { CitySnapshot } from 'src/types/inflation';
+import { fetchCitySnapshot } from 'src/models/inflation';
+
+const TARGET = 3;
+const BAND = 1;
+
+const Wrap = styled.section`
+  background: #fff;
+  border: 1px solid #ECECEE;
+  border-radius: 14px;
+  padding: 18px 22px;
+  margin-bottom: 18px;
+  font-feature-settings: 'tnum' on;
+`;
+const Header = styled.div`
+  display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px;
+`;
+const Title = styled.h3`
+  font-size: 14px; font-weight: 600; color: #212529; margin: 0;
+  text-transform: uppercase; letter-spacing: 0.2px;
+`;
+const Sub = styled.div`
+  font-size: 11px; color: #6E6B7B;
+`;
+const Grid = styled.div`
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 6px;
+`;
+const Row = styled.div<{ tone: 'high' | 'mid' | 'low' | 'neutral' }>`
+  display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center;
+  padding: 6px 10px; border-radius: 6px;
+  background: ${({ tone }) =>
+    tone === 'high' ? '#FCE5E720' :
+    tone === 'low'  ? '#DCEFE320' :
+    tone === 'mid'  ? '#FFF3CD20' : '#F5F5F7'};
+  border-left: 3px solid ${({ tone }) =>
+    tone === 'high' ? '#B02A37' :
+    tone === 'low'  ? '#188754' :
+    tone === 'mid'  ? '#FFC106' : '#A6A6A6'};
+`;
+const City = styled.div`
+  font-size: 12px; color: #212529; font-weight: 500;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+`;
+const Yoy = styled.div<{ tone: 'high' | 'mid' | 'low' | 'neutral' }>`
+  font-size: 14px; font-weight: 700; font-feature-settings: 'tnum' on;
+  color: ${({ tone }) =>
+    tone === 'high' ? '#B02A37' :
+    tone === 'low'  ? '#188754' : '#212529'};
+`;
+
+const tone = (yoy: number | null | undefined): 'high' | 'mid' | 'low' | 'neutral' => {
+  if (yoy == null || Number.isNaN(yoy)) return 'neutral';
+  if (yoy > TARGET + BAND) return 'high';
+  if (yoy < TARGET - BAND) return 'low';
+  return 'mid';
+};
+
+const fmtPct = (v: number | null | undefined) =>
+  v == null || Number.isNaN(v) ? '—' : `${v.toFixed(2)}%`;
+
+export default function CityRanking() {
+  const [snapshot, setSnapshot] = useState<CitySnapshot[]>([]);
+  const [date, setDate] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const res = await fetchCitySnapshot();
+      if (cancelled || !res.data) return;
+      setSnapshot(res.data);
+      setDate(res.data[0]?.fecha ?? null);
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const sorted = [...snapshot].sort((a, b) => (b.yoy ?? -Infinity) - (a.yoy ?? -Infinity));
+  const minYoy = Math.min(...sorted.map((c) => c.yoy ?? Infinity));
+  const maxYoy = Math.max(...sorted.map((c) => c.yoy ?? -Infinity));
+
+  return (
+    <Wrap>
+      <Header>
+        <Title>IPC por ciudad · ranking YoY</Title>
+        <Sub>
+          {sorted.length > 0
+            ? `${sorted.length} ciudades · cierre ${date ?? '—'} · rango ${minYoy.toFixed(2)}%–${maxYoy.toFixed(2)}%`
+            : 'Cargando…'}
+        </Sub>
+      </Header>
+      <Grid>
+        {sorted.map((c) => {
+          const t = tone(c.yoy);
+          return (
+            <Row key={c.ciudad} tone={t}>
+              <City title={c.ciudad}>{c.ciudad}</City>
+              <Yoy tone={t}>{fmtPct(c.yoy)}</Yoy>
+            </Row>
+          );
+        })}
+      </Grid>
+    </Wrap>
+  );
+}

--- a/src/components/inflation/v2/CityRanking.tsx
+++ b/src/components/inflation/v2/CityRanking.tsx
@@ -2,12 +2,15 @@
 
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import useAppStore from 'src/store';
 import { CitySnapshot } from 'src/types/inflation';
 import { fetchCitySnapshot } from 'src/models/inflation';
-
-const TARGET = 3;
-const BAND = 1;
+import {
+  toneFromYoy,
+  toneText,
+  toneBorder,
+  toneRowBg,
+  Tone,
+} from './toneColors';
 
 const Wrap = styled.section`
   background: #fff;
@@ -30,35 +33,20 @@ const Sub = styled.div`
 const Grid = styled.div`
   display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 6px;
 `;
-const Row = styled.div<{ tone: 'high' | 'mid' | 'low' | 'neutral' }>`
+const Row = styled.div<{ $tone: Tone }>`
   display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center;
   padding: 6px 10px; border-radius: 6px;
-  background: ${({ tone }) =>
-    tone === 'high' ? '#FCE5E720' :
-    tone === 'low'  ? '#DCEFE320' :
-    tone === 'mid'  ? '#FFF3CD20' : '#F5F5F7'};
-  border-left: 3px solid ${({ tone }) =>
-    tone === 'high' ? '#B02A37' :
-    tone === 'low'  ? '#188754' :
-    tone === 'mid'  ? '#FFC106' : '#A6A6A6'};
+  background: ${({ $tone }) => toneRowBg($tone)};
+  border-left: 3px solid ${({ $tone }) => toneBorder($tone)};
 `;
 const City = styled.div`
   font-size: 12px; color: #212529; font-weight: 500;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 `;
-const Yoy = styled.div<{ tone: 'high' | 'mid' | 'low' | 'neutral' }>`
+const Yoy = styled.div<{ $tone: Tone }>`
   font-size: 14px; font-weight: 700; font-feature-settings: 'tnum' on;
-  color: ${({ tone }) =>
-    tone === 'high' ? '#B02A37' :
-    tone === 'low'  ? '#188754' : '#212529'};
+  color: ${({ $tone }) => toneText($tone)};
 `;
-
-const tone = (yoy: number | null | undefined): 'high' | 'mid' | 'low' | 'neutral' => {
-  if (yoy == null || Number.isNaN(yoy)) return 'neutral';
-  if (yoy > TARGET + BAND) return 'high';
-  if (yoy < TARGET - BAND) return 'low';
-  return 'mid';
-};
 
 const fmtPct = (v: number | null | undefined) =>
   v == null || Number.isNaN(v) ? '—' : `${v.toFixed(2)}%`;
@@ -82,23 +70,24 @@ export default function CityRanking() {
   const minYoy = Math.min(...sorted.map((c) => c.yoy ?? Infinity));
   const maxYoy = Math.max(...sorted.map((c) => c.yoy ?? -Infinity));
 
+  let subText = 'Cargando…';
+  if (sorted.length > 0) {
+    subText = `${sorted.length} ciudades · cierre ${date ?? '—'} · rango ${minYoy.toFixed(2)}%–${maxYoy.toFixed(2)}%`;
+  }
+
   return (
     <Wrap>
       <Header>
         <Title>IPC por ciudad · ranking YoY</Title>
-        <Sub>
-          {sorted.length > 0
-            ? `${sorted.length} ciudades · cierre ${date ?? '—'} · rango ${minYoy.toFixed(2)}%–${maxYoy.toFixed(2)}%`
-            : 'Cargando…'}
-        </Sub>
+        <Sub>{subText}</Sub>
       </Header>
       <Grid>
         {sorted.map((c) => {
-          const t = tone(c.yoy);
+          const t = toneFromYoy(c.yoy);
           return (
-            <Row key={c.ciudad} tone={t}>
+            <Row key={c.ciudad} $tone={t}>
               <City title={c.ciudad}>{c.ciudad}</City>
-              <Yoy tone={t}>{fmtPct(c.yoy)}</Yoy>
+              <Yoy $tone={t}>{fmtPct(c.yoy)}</Yoy>
             </Row>
           );
         })}

--- a/src/components/inflation/v2/CoreInflationPanel.tsx
+++ b/src/components/inflation/v2/CoreInflationPanel.tsx
@@ -54,7 +54,6 @@ interface Row {
 
 export default function CoreInflationPanel() {
   const [data, setData] = useState<Row[]>([]);
-  const [latest, setLatest] = useState<Record<number, number | null>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -64,9 +63,7 @@ export default function CoreInflationPanel() {
       if (cancelled || !res.data) return;
       // Merge by date
       const map = new Map<string, Row>();
-      const last: Record<number, number | null> = {};
       res.data.forEach(({ id, values }) => {
-        if (values.length) last[id] = values[values.length - 1].value;
         values.forEach((v) => {
           if (!map.has(v.time)) map.set(v.time, { time: v.time });
           (map.get(v.time) as Row)[`s${id}`] = v.value;
@@ -77,7 +74,6 @@ export default function CoreInflationPanel() {
       );
       // last 120 months
       setData(rows.slice(-120));
-      setLatest(last);
     })();
     return () => { cancelled = true; };
   }, []);

--- a/src/components/inflation/v2/CoreInflationPanel.tsx
+++ b/src/components/inflation/v2/CoreInflationPanel.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceArea,
+  ReferenceLine,
+  Legend,
+} from 'recharts';
+import { CORE_INFLATION_SERIES, fetchCoreInflationSeries } from 'src/models/inflation';
+
+const Wrap = styled.section`
+  background: #fff;
+  border: 1px solid #ECECEE;
+  border-radius: 14px;
+  padding: 18px 22px;
+  margin-bottom: 18px;
+  font-feature-settings: 'tnum' on;
+`;
+const Header = styled.div`
+  display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; flex-wrap: wrap;
+`;
+const Title = styled.h3`
+  font-size: 14px; font-weight: 600; color: #212529; margin: 0;
+  text-transform: uppercase; letter-spacing: 0.2px;
+`;
+const Sub = styled.div`
+  font-size: 11px; color: #6E6B7B;
+`;
+
+const COLORS = ['#786CF7', '#188754', '#B02A37', '#FFC106', '#0D6EFD', '#6F42C1', '#E35D6A'];
+
+const fmtMonth = (s: string) => {
+  const d = new Date(`${s}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: '2-digit', year: '2-digit' });
+};
+
+const fmtMonthLong = (s: string) => {
+  const d = new Date(`${s}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: 'short', year: 'numeric' });
+};
+
+interface Row {
+  time: string;
+  [k: string]: number | string | null;
+}
+
+export default function CoreInflationPanel() {
+  const [data, setData] = useState<Row[]>([]);
+  const [latest, setLatest] = useState<Record<number, number | null>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const ids = CORE_INFLATION_SERIES.map((s) => s.id);
+      const res = await fetchCoreInflationSeries(ids);
+      if (cancelled || !res.data) return;
+      // Merge by date
+      const map = new Map<string, Row>();
+      const last: Record<number, number | null> = {};
+      res.data.forEach(({ id, values }) => {
+        if (values.length) last[id] = values[values.length - 1].value;
+        values.forEach((v) => {
+          if (!map.has(v.time)) map.set(v.time, { time: v.time });
+          (map.get(v.time) as Row)[`s${id}`] = v.value;
+        });
+      });
+      const rows = Array.from(map.values()).sort((a, b) =>
+        a.time.localeCompare(b.time as string)
+      );
+      // last 120 months
+      setData(rows.slice(-120));
+      setLatest(last);
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <Wrap>
+      <Header>
+        <Title>Inflación núcleo · medidas BanRep</Title>
+        <Sub>Histórico 10 años · medidas que excluyen alimentos / regulados / núcleo 15-20</Sub>
+      </Header>
+
+      <div style={{ width: '100%', height: 320 }}>
+        <ResponsiveContainer>
+          <LineChart data={data} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid stroke="#F1F1F2" strokeDasharray="3 3" />
+            <XAxis dataKey="time" tickFormatter={fmtMonth} minTickGap={32}
+              stroke="#A6A6A6" tick={{ fill: '#6E6B7B', fontSize: 11 }} />
+            <YAxis tickFormatter={(v) => `${v.toFixed(0)}%`} width={42}
+              stroke="#A6A6A6" tick={{ fill: '#6E6B7B', fontSize: 11 }} />
+            <ReferenceArea y1={2} y2={4} fill="#A3CFBB" fillOpacity={0.18} />
+            <ReferenceLine y={3} stroke="#469F76" strokeDasharray="4 4" />
+            <Tooltip
+              contentStyle={{ fontSize: 12, borderRadius: 6, borderColor: '#ECECEE' }}
+              formatter={(v: number) => `${v?.toFixed?.(2) ?? '—'}%`}
+              labelFormatter={fmtMonthLong}
+            />
+            <Legend
+              verticalAlign="bottom"
+              iconType="line"
+              wrapperStyle={{ fontSize: 11 }}
+              formatter={(value) => {
+                const id = Number(String(value).replace('s', ''));
+                const meta = CORE_INFLATION_SERIES.find((m) => m.id === id);
+                return meta ? meta.nombre.replace('Inflación ', '') : String(value);
+              }}
+            />
+            {CORE_INFLATION_SERIES.map((s, i) => (
+              <Line
+                key={s.id}
+                type="monotone"
+                dataKey={`s${s.id}`}
+                stroke={COLORS[i % COLORS.length]}
+                strokeWidth={1.6}
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </Wrap>
+  );
+}

--- a/src/components/inflation/v2/DecompositionBlock.tsx
+++ b/src/components/inflation/v2/DecompositionBlock.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import React, { useEffect, useMemo } from 'react';
+import styled from 'styled-components';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+} from 'recharts';
+import useAppStore from 'src/store';
+
+const Wrap = styled.section`
+  background: #fff;
+  border: 1px solid #ECECEE;
+  border-radius: 14px;
+  padding: 18px 22px;
+  margin-bottom: 18px;
+  font-feature-settings: 'tnum' on;
+`;
+const Header = styled.div`
+  display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px;
+`;
+const Title = styled.h3`
+  font-size: 14px; font-weight: 600; color: #212529; margin: 0;
+  text-transform: uppercase; letter-spacing: 0.2px;
+`;
+const Sub = styled.div`
+  font-size: 11px; color: #6E6B7B;
+`;
+
+const Layout = styled.div`
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 16px;
+  @media (max-width: 1100px) { grid-template-columns: 1fr; }
+`;
+
+// 12 colores diferenciados — para las divisiones
+const DIV_COLORS: Record<number, string> = {
+  317: '#B02A37', 390: '#FFC106', 402: '#0D6EFD', 419: '#188754',
+  443: '#6F42C1', 475: '#E35D6A', 496: '#0DCAF0', 528: '#7E57C2',
+  535: '#FF9800', 575: '#9C27B0', 592: '#3F51B5', 605: '#795548',
+};
+
+const fmtMonth = (s: string) => {
+  const d = new Date(`${s}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: '2-digit', year: '2-digit' });
+};
+
+const fmtMonthLong = (s: string) => {
+  const d = new Date(`${s}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: 'short', year: 'numeric' });
+};
+
+export default function DecompositionBlock() {
+  const contributions = useAppStore((s) => s.contributions);
+  const canastas = useAppStore((s) => s.canastas);
+  const loadContributions = useAppStore((s) => s.loadContributions);
+
+  useEffect(() => {
+    if (contributions.length === 0) loadContributions(36);
+  }, [contributions.length, loadContributions]);
+
+  const { stackedData, divisions, heatmapMonths, heatmapMax, heatmapBy } = useMemo(() => {
+    const byTime = new Map<string, { time: string; [k: string]: number | string }>();
+    const divSet = new Map<number, string>();
+    const monthSet = new Set<string>();
+    const heatBy = new Map<string, number>();
+    let max = 0;
+
+    contributions.forEach((c) => {
+      monthSet.add(c.time);
+      divSet.set(c.id_canasta, c.nombre);
+      if (!byTime.has(c.time)) byTime.set(c.time, { time: c.time });
+      const r = byTime.get(c.time) as { [k: string]: number | string };
+      r[`d${c.id_canasta}`] = c.valorcontribucion;
+      heatBy.set(`${c.id_canasta}|${c.time}`, c.valormensual);
+      max = Math.max(max, Math.abs(c.valormensual));
+    });
+
+    const divs = Array.from(divSet.entries()).map(([id, nombre]) => ({ id, nombre }));
+    const months = Array.from(monthSet).sort();
+
+    return {
+      stackedData: Array.from(byTime.values()).sort((a, b) =>
+        (a.time as string).localeCompare(b.time as string)
+      ),
+      divisions: divs,
+      heatmapMonths: months,
+      heatmapMax: max || 1,
+      heatmapBy: heatBy,
+    };
+  }, [contributions]);
+
+  const labelFor = (id: number) =>
+    canastas.find((c) => c.id === id)?.nombre ||
+    divisions.find((d) => d.id === id)?.nombre ||
+    `#${id}`;
+
+  const heatColor = (v: number, max: number) => {
+    if (Number.isNaN(v) || v == null) return '#fff';
+    const intensity = Math.max(0.05, Math.min(1, Math.abs(v) / max));
+    const a = (0.05 + intensity * 0.85).toFixed(2);
+    return v >= 0 ? `rgba(176,42,55,${a})` : `rgba(24,135,84,${a})`;
+  };
+
+  const heatTextColor = (v: number, max: number) => {
+    const intensity = Math.min(1, Math.abs(v) / max);
+    return intensity > 0.55 ? '#fff' : '#212529';
+  };
+
+  return (
+    <Wrap>
+      <Header>
+        <Title>Descomposición · ¿de dónde viene la inflación?</Title>
+        <Sub>{stackedData.length} meses · contribuciones en pp del IPC mensual</Sub>
+      </Header>
+
+      <Layout>
+        {/* Stacked bar */}
+        <div>
+          <div style={{ fontSize: 11, color: '#6E6B7B', marginBottom: 6 }}>
+            Contribución mensual por división (pp)
+          </div>
+          <div style={{ height: 320 }}>
+            <ResponsiveContainer>
+              <BarChart data={stackedData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                <CartesianGrid stroke="#F1F1F2" strokeDasharray="3 3" />
+                <XAxis dataKey="time" tickFormatter={fmtMonth} minTickGap={20}
+                  stroke="#A6A6A6" tick={{ fill: '#6E6B7B', fontSize: 11 }} />
+                <YAxis tickFormatter={(v) => v.toFixed(2)} width={48}
+                  stroke="#A6A6A6" tick={{ fill: '#6E6B7B', fontSize: 11 }} />
+                <ReferenceLine y={0} stroke="#A6A6A6" />
+                <Tooltip
+                  contentStyle={{ fontSize: 11, borderRadius: 6, borderColor: '#ECECEE' }}
+                  labelFormatter={fmtMonthLong}
+                  formatter={(value: number, name: string) => {
+                    const id = Number(String(name).replace('d', ''));
+                    return [
+                      `${value?.toFixed?.(3) ?? '—'} pp`,
+                      labelFor(id),
+                    ];
+                  }}
+                />
+                {divisions.map((d) => (
+                  <Bar
+                    key={d.id}
+                    dataKey={`d${d.id}`}
+                    stackId="contrib"
+                    fill={DIV_COLORS[d.id] || '#888'}
+                    isAnimationActive={false}
+                  />
+                ))}
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+
+        {/* Heatmap */}
+        <div>
+          <div style={{ fontSize: 11, color: '#6E6B7B', marginBottom: 6 }}>
+            Heatmap MoM divisiones × meses (intensidad por magnitud)
+          </div>
+          <div style={{ overflowX: 'auto', maxHeight: 320 }}>
+            <table style={{ borderCollapse: 'separate', borderSpacing: 1, fontSize: 10 }}>
+              <thead>
+                <tr>
+                  <th
+                    style={{
+                      textAlign: 'left', padding: '4px 8px',
+                      position: 'sticky', left: 0, top: 0, background: '#fff', zIndex: 2,
+                      fontWeight: 600, color: '#6E6B7B', textTransform: 'uppercase',
+                      letterSpacing: 0.3, fontSize: 10,
+                    }}
+                  >
+                    División
+                  </th>
+                  {heatmapMonths.slice(-12).map((m) => (
+                    <th key={m} style={{
+                      padding: '4px 4px',
+                      fontWeight: 500, color: '#A6A6A6',
+                      textAlign: 'center', minWidth: 40,
+                    }}>{fmtMonth(m)}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {divisions.map((d) => (
+                  <tr key={d.id}>
+                    <td
+                      style={{
+                        padding: '4px 8px',
+                        position: 'sticky', left: 0, background: '#fff',
+                        whiteSpace: 'nowrap',
+                        maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis',
+                        fontWeight: 500, color: '#212529', fontSize: 11,
+                      }}
+                      title={labelFor(d.id)}
+                    >
+                      {labelFor(d.id)}
+                    </td>
+                    {heatmapMonths.slice(-12).map((m) => {
+                      const v = heatmapBy.get(`${d.id}|${m}`);
+                      const num = typeof v === 'number' ? v : NaN;
+                      const display = Number.isNaN(num) ? '' : num.toFixed(1);
+                      return (
+                        <td
+                          key={`${d.id}-${m}`}
+                          style={{
+                            padding: '4px 4px',
+                            background: heatColor(num, heatmapMax),
+                            color: heatTextColor(num, heatmapMax),
+                            textAlign: 'center', borderRadius: 3,
+                            fontFeatureSettings: '"tnum" on',
+                          }}
+                          title={`${labelFor(d.id)} · ${fmtMonthLong(m)}: ${display}%`}
+                        >
+                          {display}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </Layout>
+    </Wrap>
+  );
+}

--- a/src/components/inflation/v2/HeroBlock.tsx
+++ b/src/components/inflation/v2/HeroBlock.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import React, { useEffect, useMemo } from 'react';
+import styled from 'styled-components';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  YAxis,
+  ReferenceArea,
+  ReferenceLine,
+  Tooltip,
+} from 'recharts';
+import useAppStore from 'src/store';
+import { CPISnapshot } from 'src/types/inflation';
+
+const TOTAL_ID = 1;
+const TARGET = 3;
+const BAND = 1;
+
+// ── styled ─────────────────────────────────────────────────────
+const Wrap = styled.section`
+  background: linear-gradient(180deg, #ffffff 0%, #faf9fc 100%);
+  border: 1px solid #ECECEE;
+  border-radius: 14px;
+  padding: 24px 28px;
+  display: grid;
+  grid-template-columns: minmax(220px, 1.1fr) minmax(280px, 1.4fr) minmax(280px, 1.6fr);
+  gap: 28px;
+  margin-bottom: 18px;
+  font-feature-settings: 'tnum' on, 'cv11' on;
+  @media (max-width: 1100px) { grid-template-columns: 1fr; }
+`;
+
+const HeadlineCol = styled.div`
+  display: flex; flex-direction: column; gap: 4px;
+`;
+const Label = styled.div`
+  font-size: 11px; letter-spacing: 0.6px; text-transform: uppercase; color: #6E6B7B;
+  font-weight: 600;
+`;
+const HeadlineNumber = styled.div<{ tone: 'high' | 'mid' | 'low' }>`
+  font-size: 64px; font-weight: 700; line-height: 1; letter-spacing: -1.5px;
+  color: ${({ tone }) =>
+    tone === 'high' ? '#B02A37' : tone === 'low' ? '#188754' : '#212529'};
+`;
+const Sub = styled.div`
+  font-size: 12px; color: #6E6B7B;
+`;
+const PillRow = styled.div`
+  display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px;
+`;
+const Pill = styled.span<{ tone?: 'pos' | 'neg' | 'neutral' }>`
+  font-size: 11px; padding: 3px 8px; border-radius: 999px;
+  background: ${({ tone }) =>
+    tone === 'pos' ? '#FCE5E7' : tone === 'neg' ? '#DCEFE3' : '#EDEDEF'};
+  color: ${({ tone }) =>
+    tone === 'pos' ? '#B02A37' : tone === 'neg' ? '#188754' : '#3A3845'};
+  font-weight: 500;
+`;
+const SparkBox = styled.div`
+  height: 90px; width: 100%;
+`;
+const GaugeBox = styled.div`
+  height: 90px; width: 100%; padding-top: 8px;
+`;
+const KpiGrid = styled.div`
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 6px 24px;
+`;
+const KpiRow = styled.div`
+  display: flex; flex-direction: column; gap: 0;
+`;
+const KpiSm = styled.div<{ tone?: 'pos' | 'neg' | 'neutral' }>`
+  font-size: 22px; font-weight: 600; line-height: 1.05;
+  color: ${({ tone }) =>
+    tone === 'pos' ? '#B02A37' : tone === 'neg' ? '#188754' : '#212529'};
+`;
+
+// ── helpers ───────────────────────────────────────────────────
+const fmtPct = (v: number | null | undefined, d = 2) =>
+  v == null || Number.isNaN(v) ? '—' : `${v >= 0 ? '+' : ''}${v.toFixed(d)}%`;
+
+const tone = (v: number | null | undefined): 'pos' | 'neg' | 'neutral' => {
+  if (v == null || Number.isNaN(v)) return 'neutral';
+  if (v > 0.005) return 'pos';
+  if (v < -0.005) return 'neg';
+  return 'neutral';
+};
+
+const headlineTone = (yoy: number | null | undefined): 'high' | 'mid' | 'low' => {
+  if (yoy == null || Number.isNaN(yoy)) return 'mid';
+  if (yoy > TARGET + BAND) return 'high';
+  if (yoy < TARGET - BAND) return 'low';
+  return 'mid';
+};
+
+const fmtMonthYear = (iso: string | null | undefined) => {
+  if (!iso) return '—';
+  const d = new Date(`${iso}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: 'long', year: 'numeric' });
+};
+
+// ── component ─────────────────────────────────────────────────
+export default function HeroBlock() {
+  const snapshot = useAppStore((s) => s.snapshotByCanasta[TOTAL_ID]) as CPISnapshot | undefined;
+  const series = useAppStore((s) => s.seriesByCanasta[TOTAL_ID]);
+  const loadSnapshot = useAppStore((s) => s.loadCanastaSnapshot);
+  const loadSeries = useAppStore((s) => s.loadCanastaSeries);
+
+  useEffect(() => {
+    loadSnapshot(TOTAL_ID);
+    loadSeries(TOTAL_ID);
+  }, [loadSnapshot, loadSeries]);
+
+  const sparkData = useMemo(() => {
+    if (!series) return [];
+    return series.slice(-36).map((p) => ({ time: p.time, yoy: p.yoy }));
+  }, [series]);
+
+  const yoy = snapshot?.last_yoy ?? null;
+  const mom = snapshot?.last_mom ?? null;
+  const ytd = snapshot?.last_ytd ?? null;
+  const dYoY =
+    snapshot && snapshot.last_yoy != null && snapshot.prev_yoy != null
+      ? snapshot.last_yoy - snapshot.prev_yoy
+      : null;
+
+  const gaugeMax = 18;
+
+  return (
+    <Wrap>
+      {/* Col 1 — headline */}
+      <HeadlineCol>
+        <Label>Inflación anual {fmtMonthYear(snapshot?.last_date ?? null)}</Label>
+        <HeadlineNumber tone={headlineTone(yoy)}>{fmtPct(yoy)}</HeadlineNumber>
+        <Sub>
+          {dYoY != null && (
+            <>
+              <strong style={{ color: tone(dYoY) === 'pos' ? '#B02A37' : tone(dYoY) === 'neg' ? '#188754' : '#3A3845' }}>
+                {dYoY > 0 ? '▲' : dYoY < 0 ? '▼' : '·'} {fmtPct(dYoY, 2)}
+              </strong>{' '}
+              vs mes anterior
+            </>
+          )}
+        </Sub>
+        <PillRow>
+          <Pill tone={tone(mom)}>MoM {fmtPct(mom)}</Pill>
+          <Pill tone={tone(ytd)}>YTD {fmtPct(ytd)}</Pill>
+          <Pill>Meta Banrep {TARGET}% ±{BAND}</Pill>
+        </PillRow>
+      </HeadlineCol>
+
+      {/* Col 2 — sparkline 36m con banda meta */}
+      <div>
+        <Label>Tendencia 36 meses (YoY)</Label>
+        <SparkBox>
+          <ResponsiveContainer>
+            <LineChart data={sparkData} margin={{ top: 8, right: 6, left: 0, bottom: 6 }}>
+              <YAxis hide domain={[0, 'dataMax + 1']} />
+              <ReferenceArea y1={TARGET - BAND} y2={TARGET + BAND} fill="#A3CFBB" fillOpacity={0.18} />
+              <ReferenceLine y={TARGET} stroke="#469F76" strokeDasharray="3 3" />
+              <Tooltip
+                contentStyle={{ fontSize: 11, padding: 4 }}
+                formatter={(v: number) => `${v?.toFixed?.(2) ?? '—'}%`}
+                labelFormatter={fmtMonthYear}
+              />
+              <Line type="monotone" dataKey="yoy" stroke="#786CF7" strokeWidth={2} dot={false} isAnimationActive={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </SparkBox>
+        <Sub>banda 2-4% = rango meta</Sub>
+      </div>
+
+      {/* Col 3 — gauge + secondary KPIs */}
+      <div>
+        <Label>Posición vs rango Banrep</Label>
+        <GaugeBox>
+          <ResponsiveContainer>
+            <LineChart
+              data={[{ x: 0, v: yoy ?? 0 }, { x: 1, v: yoy ?? 0 }]}
+              margin={{ top: 16, right: 0, left: 0, bottom: 8 }}
+            >
+              <YAxis hide domain={[0, gaugeMax]} type="number" />
+              <ReferenceArea x1={0} x2={1} y1={0} y2={2} fill="#A3CFBB" fillOpacity={0.25} />
+              <ReferenceArea x1={0} x2={1} y1={2} y2={4} fill="#A3CFBB" fillOpacity={0.5} />
+              <ReferenceArea x1={0} x2={1} y1={4} y2={6} fill="#FFDA6A" fillOpacity={0.45} />
+              <ReferenceArea x1={0} x2={1} y1={6} y2={9} fill="#E35D6A" fillOpacity={0.4} />
+              <ReferenceArea x1={0} x2={1} y1={9} y2={gaugeMax} fill="#B02A37" fillOpacity={0.35} />
+              <ReferenceLine y={yoy ?? 0} stroke="#212529" strokeWidth={3} />
+            </LineChart>
+          </ResponsiveContainer>
+        </GaugeBox>
+        <KpiGrid>
+          <KpiRow>
+            <Label>Mensual</Label>
+            <KpiSm tone={tone(mom)}>{fmtPct(mom)}</KpiSm>
+          </KpiRow>
+          <KpiRow>
+            <Label>Año corrido</Label>
+            <KpiSm tone={tone(ytd)}>{fmtPct(ytd)}</KpiSm>
+          </KpiRow>
+        </KpiGrid>
+      </div>
+    </Wrap>
+  );
+}

--- a/src/components/inflation/v2/HeroBlock.tsx
+++ b/src/components/inflation/v2/HeroBlock.tsx
@@ -13,6 +13,15 @@ import {
 } from 'recharts';
 import useAppStore from 'src/store';
 import { CPISnapshot } from 'src/types/inflation';
+import {
+  Tone,
+  DirTone,
+  toneFromYoy,
+  dirToneFromDelta,
+  toneText,
+  pillBg,
+  pillText,
+} from './toneColors';
 
 const TOTAL_ID = 1;
 const TARGET = 3;
@@ -39,10 +48,9 @@ const Label = styled.div`
   font-size: 11px; letter-spacing: 0.6px; text-transform: uppercase; color: #6E6B7B;
   font-weight: 600;
 `;
-const HeadlineNumber = styled.div<{ tone: 'high' | 'mid' | 'low' }>`
+const HeadlineNumber = styled.div<{ $tone: Tone }>`
   font-size: 64px; font-weight: 700; line-height: 1; letter-spacing: -1.5px;
-  color: ${({ tone }) =>
-    tone === 'high' ? '#B02A37' : tone === 'low' ? '#188754' : '#212529'};
+  color: ${({ $tone }) => toneText($tone)};
 `;
 const Sub = styled.div`
   font-size: 12px; color: #6E6B7B;
@@ -50,12 +58,10 @@ const Sub = styled.div`
 const PillRow = styled.div`
   display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px;
 `;
-const Pill = styled.span<{ tone?: 'pos' | 'neg' | 'neutral' }>`
+const Pill = styled.span<{ $tone?: DirTone }>`
   font-size: 11px; padding: 3px 8px; border-radius: 999px;
-  background: ${({ tone }) =>
-    tone === 'pos' ? '#FCE5E7' : tone === 'neg' ? '#DCEFE3' : '#EDEDEF'};
-  color: ${({ tone }) =>
-    tone === 'pos' ? '#B02A37' : tone === 'neg' ? '#188754' : '#3A3845'};
+  background: ${({ $tone }) => pillBg($tone ?? 'neutral')};
+  color: ${({ $tone }) => pillText($tone ?? 'neutral')};
   font-weight: 500;
 `;
 const SparkBox = styled.div`
@@ -70,34 +76,31 @@ const KpiGrid = styled.div`
 const KpiRow = styled.div`
   display: flex; flex-direction: column; gap: 0;
 `;
-const KpiSm = styled.div<{ tone?: 'pos' | 'neg' | 'neutral' }>`
+const KpiSm = styled.div<{ $tone?: DirTone }>`
   font-size: 22px; font-weight: 600; line-height: 1.05;
-  color: ${({ tone }) =>
-    tone === 'pos' ? '#B02A37' : tone === 'neg' ? '#188754' : '#212529'};
+  color: ${({ $tone }) => pillText($tone ?? 'neutral')};
+`;
+const DeltaText = styled.strong<{ $tone: DirTone }>`
+  color: ${({ $tone }) => pillText($tone)};
 `;
 
 // ── helpers ───────────────────────────────────────────────────
-const fmtPct = (v: number | null | undefined, d = 2) =>
-  v == null || Number.isNaN(v) ? '—' : `${v >= 0 ? '+' : ''}${v.toFixed(d)}%`;
-
-const tone = (v: number | null | undefined): 'pos' | 'neg' | 'neutral' => {
-  if (v == null || Number.isNaN(v)) return 'neutral';
-  if (v > 0.005) return 'pos';
-  if (v < -0.005) return 'neg';
-  return 'neutral';
-};
-
-const headlineTone = (yoy: number | null | undefined): 'high' | 'mid' | 'low' => {
-  if (yoy == null || Number.isNaN(yoy)) return 'mid';
-  if (yoy > TARGET + BAND) return 'high';
-  if (yoy < TARGET - BAND) return 'low';
-  return 'mid';
+const fmtPct = (v: number | null | undefined, d = 2) => {
+  if (v == null || Number.isNaN(v)) return '—';
+  const sign = v >= 0 ? '+' : '';
+  return `${sign}${v.toFixed(d)}%`;
 };
 
 const fmtMonthYear = (iso: string | null | undefined) => {
   if (!iso) return '—';
   const d = new Date(`${iso}T00:00:00`);
   return d.toLocaleDateString('es-CO', { month: 'long', year: 'numeric' });
+};
+
+const deltaArrow = (v: number) => {
+  if (v > 0) return '▲';
+  if (v < 0) return '▼';
+  return '·';
 };
 
 // ── component ─────────────────────────────────────────────────
@@ -126,26 +129,30 @@ export default function HeroBlock() {
       : null;
 
   const gaugeMax = 18;
+  const headlineTone = toneFromYoy(yoy);
+  const momTone = dirToneFromDelta(mom);
+  const ytdTone = dirToneFromDelta(ytd);
+  const dYoYTone = dYoY != null ? dirToneFromDelta(dYoY) : 'neutral';
 
   return (
     <Wrap>
       {/* Col 1 — headline */}
       <HeadlineCol>
         <Label>Inflación anual {fmtMonthYear(snapshot?.last_date ?? null)}</Label>
-        <HeadlineNumber tone={headlineTone(yoy)}>{fmtPct(yoy)}</HeadlineNumber>
+        <HeadlineNumber $tone={headlineTone}>{fmtPct(yoy)}</HeadlineNumber>
         <Sub>
           {dYoY != null && (
             <>
-              <strong style={{ color: tone(dYoY) === 'pos' ? '#B02A37' : tone(dYoY) === 'neg' ? '#188754' : '#3A3845' }}>
-                {dYoY > 0 ? '▲' : dYoY < 0 ? '▼' : '·'} {fmtPct(dYoY, 2)}
-              </strong>{' '}
+              <DeltaText $tone={dYoYTone}>
+                {deltaArrow(dYoY)} {fmtPct(dYoY, 2)}
+              </DeltaText>{' '}
               vs mes anterior
             </>
           )}
         </Sub>
         <PillRow>
-          <Pill tone={tone(mom)}>MoM {fmtPct(mom)}</Pill>
-          <Pill tone={tone(ytd)}>YTD {fmtPct(ytd)}</Pill>
+          <Pill $tone={momTone}>MoM {fmtPct(mom)}</Pill>
+          <Pill $tone={ytdTone}>YTD {fmtPct(ytd)}</Pill>
           <Pill>Meta Banrep {TARGET}% ±{BAND}</Pill>
         </PillRow>
       </HeadlineCol>
@@ -193,11 +200,11 @@ export default function HeroBlock() {
         <KpiGrid>
           <KpiRow>
             <Label>Mensual</Label>
-            <KpiSm tone={tone(mom)}>{fmtPct(mom)}</KpiSm>
+            <KpiSm $tone={momTone}>{fmtPct(mom)}</KpiSm>
           </KpiRow>
           <KpiRow>
             <Label>Año corrido</Label>
-            <KpiSm tone={tone(ytd)}>{fmtPct(ytd)}</KpiSm>
+            <KpiSm $tone={ytdTone}>{fmtPct(ytd)}</KpiSm>
           </KpiRow>
         </KpiGrid>
       </div>

--- a/src/components/inflation/v2/SmallMultiples.tsx
+++ b/src/components/inflation/v2/SmallMultiples.tsx
@@ -9,10 +9,15 @@ import {
   YAxis,
 } from 'recharts';
 import useAppStore from 'src/store';
+import {
+  Tone,
+  toneFromYoy,
+  toneText,
+  toneBorder,
+  toneAccent,
+} from './toneColors';
 
 const TOTAL_ID = 1;
-const TARGET = 3;
-const BAND = 1;
 
 const Wrap = styled.section`
   background: #fff;
@@ -35,10 +40,9 @@ const Grid = styled.div`
   @media (max-width: 1100px) { grid-template-columns: repeat(2, 1fr); }
 `;
 
-const Card = styled.div<{ tone: 'high' | 'mid' | 'low' | 'neutral' }>`
+const Card = styled.div<{ $tone: Tone }>`
   border: 1px solid #ECECEE;
-  border-left: 3px solid ${({ tone }) =>
-    tone === 'high' ? '#B02A37' : tone === 'low' ? '#188754' : tone === 'mid' ? '#FFC106' : '#A6A6A6'};
+  border-left: 3px solid ${({ $tone }) => toneBorder($tone)};
   border-radius: 8px;
   padding: 10px 12px;
   display: flex; flex-direction: column; gap: 4px;
@@ -56,10 +60,9 @@ const NameTxt = styled.div`
 const PesoTxt = styled.div`
   font-size: 10px; color: #A6A6A6;
 `;
-const Big = styled.div<{ tone: 'high' | 'mid' | 'low' | 'neutral' }>`
+const Big = styled.div<{ $tone: Tone }>`
   font-size: 22px; font-weight: 700; line-height: 1;
-  color: ${({ tone }) =>
-    tone === 'high' ? '#B02A37' : tone === 'low' ? '#188754' : '#212529'};
+  color: ${({ $tone }) => toneText($tone)};
 `;
 const Small = styled.div`
   font-size: 11px; color: #6E6B7B;
@@ -68,14 +71,10 @@ const Spark = styled.div`
   height: 36px; width: 100%; margin-top: auto;
 `;
 
-const fmtPct = (v: number | null | undefined) =>
-  v == null || Number.isNaN(v) ? '—' : `${v >= 0 ? '+' : ''}${v.toFixed(2)}%`;
-
-const tone = (yoy: number | null | undefined): 'high' | 'mid' | 'low' | 'neutral' => {
-  if (yoy == null || Number.isNaN(yoy)) return 'neutral';
-  if (yoy > TARGET + BAND) return 'high';
-  if (yoy < TARGET - BAND) return 'low';
-  return 'mid';
+const fmtPct = (v: number | null | undefined) => {
+  if (v == null || Number.isNaN(v)) return '—';
+  const sign = v >= 0 ? '+' : '';
+  return `${sign}${v.toFixed(2)}%`;
 };
 
 export default function SmallMultiples() {
@@ -93,37 +92,36 @@ export default function SmallMultiples() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canastas.length]);
 
-  const cards = useMemo(() => {
-    return canastas
-      .filter((c) => c.id !== TOTAL_ID && (c.nivel === undefined || c.nivel === 1))
-      .map((c) => {
-        const ser = seriesByCanasta[c.id] || [];
-        const last = ser[ser.length - 1];
-        return {
-          id: c.id,
-          nombre: c.nombre,
-          peso: c.peso,
-          yoy: last?.yoy ?? null,
-          mom: last?.mom ?? null,
-          spark: ser.slice(-24).map((p) => ({ time: p.time, v: p.yoy })),
-        };
-      })
-      .sort((a, b) => (b.yoy ?? -Infinity) - (a.yoy ?? -Infinity));
-  }, [canastas, seriesByCanasta]);
+  const cards = useMemo(() => canastas
+    .filter((c) => c.id !== TOTAL_ID && (c.nivel === undefined || c.nivel === 1))
+    .map((c) => {
+      const ser = seriesByCanasta[c.id] || [];
+      const last = ser[ser.length - 1];
+      return {
+        id: c.id,
+        nombre: c.nombre,
+        peso: c.peso,
+        yoy: last?.yoy ?? null,
+        mom: last?.mom ?? null,
+        spark: ser.slice(-24).map((p) => ({ time: p.time, v: p.yoy })),
+      };
+    })
+    .sort((a, b) => (b.yoy ?? -Infinity) - (a.yoy ?? -Infinity)), [canastas, seriesByCanasta]);
 
   return (
     <Wrap>
       <Title>Las 12 divisiones · YoY actual y tendencia 24m</Title>
       <Grid>
         {cards.map((c) => {
-          const t = tone(c.yoy);
+          const t = toneFromYoy(c.yoy);
+          const accent = toneAccent(t);
           return (
-            <Card key={c.id} tone={t}>
+            <Card key={c.id} $tone={t}>
               <NameRow>
                 <NameTxt title={c.nombre}>{c.nombre}</NameTxt>
                 <PesoTxt>{(c.peso * 100).toFixed(1)}%</PesoTxt>
               </NameRow>
-              <Big tone={t}>{fmtPct(c.yoy)}</Big>
+              <Big $tone={t}>{fmtPct(c.yoy)}</Big>
               <Small>MoM {fmtPct(c.mom)}</Small>
               <Spark>
                 <ResponsiveContainer>
@@ -131,18 +129,14 @@ export default function SmallMultiples() {
                     <YAxis hide domain={['dataMin - 1', 'dataMax + 1']} />
                     <defs>
                       <linearGradient id={`grad-${c.id}`} x1="0" y1="0" x2="0" y2="1">
-                        <stop offset="0%"
-                          stopColor={t === 'high' ? '#B02A37' : t === 'low' ? '#188754' : '#FFC106'}
-                          stopOpacity={0.35} />
-                        <stop offset="100%"
-                          stopColor={t === 'high' ? '#B02A37' : t === 'low' ? '#188754' : '#FFC106'}
-                          stopOpacity={0} />
+                        <stop offset="0%" stopColor={accent} stopOpacity={0.35} />
+                        <stop offset="100%" stopColor={accent} stopOpacity={0} />
                       </linearGradient>
                     </defs>
                     <Area
                       type="monotone"
                       dataKey="v"
-                      stroke={t === 'high' ? '#B02A37' : t === 'low' ? '#188754' : '#FFC106'}
+                      stroke={accent}
                       strokeWidth={1.5}
                       fill={`url(#grad-${c.id})`}
                       isAnimationActive={false}

--- a/src/components/inflation/v2/SmallMultiples.tsx
+++ b/src/components/inflation/v2/SmallMultiples.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import React, { useEffect, useMemo } from 'react';
+import styled from 'styled-components';
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  YAxis,
+} from 'recharts';
+import useAppStore from 'src/store';
+
+const TOTAL_ID = 1;
+const TARGET = 3;
+const BAND = 1;
+
+const Wrap = styled.section`
+  background: #fff;
+  border: 1px solid #ECECEE;
+  border-radius: 14px;
+  padding: 18px 22px;
+  margin-bottom: 18px;
+  font-feature-settings: 'tnum' on;
+`;
+
+const Title = styled.h3`
+  font-size: 14px; font-weight: 600; color: #212529; margin: 0 0 14px 0;
+  letter-spacing: 0.2px; text-transform: uppercase;
+`;
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  @media (max-width: 1100px) { grid-template-columns: repeat(2, 1fr); }
+`;
+
+const Card = styled.div<{ tone: 'high' | 'mid' | 'low' | 'neutral' }>`
+  border: 1px solid #ECECEE;
+  border-left: 3px solid ${({ tone }) =>
+    tone === 'high' ? '#B02A37' : tone === 'low' ? '#188754' : tone === 'mid' ? '#FFC106' : '#A6A6A6'};
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex; flex-direction: column; gap: 4px;
+  min-height: 110px;
+`;
+
+const NameRow = styled.div`
+  display: flex; justify-content: space-between; gap: 6px; align-items: baseline;
+`;
+const NameTxt = styled.div`
+  font-size: 11px; font-weight: 600; color: #6E6B7B;
+  text-transform: uppercase; letter-spacing: 0.3px;
+  flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+`;
+const PesoTxt = styled.div`
+  font-size: 10px; color: #A6A6A6;
+`;
+const Big = styled.div<{ tone: 'high' | 'mid' | 'low' | 'neutral' }>`
+  font-size: 22px; font-weight: 700; line-height: 1;
+  color: ${({ tone }) =>
+    tone === 'high' ? '#B02A37' : tone === 'low' ? '#188754' : '#212529'};
+`;
+const Small = styled.div`
+  font-size: 11px; color: #6E6B7B;
+`;
+const Spark = styled.div`
+  height: 36px; width: 100%; margin-top: auto;
+`;
+
+const fmtPct = (v: number | null | undefined) =>
+  v == null || Number.isNaN(v) ? '—' : `${v >= 0 ? '+' : ''}${v.toFixed(2)}%`;
+
+const tone = (yoy: number | null | undefined): 'high' | 'mid' | 'low' | 'neutral' => {
+  if (yoy == null || Number.isNaN(yoy)) return 'neutral';
+  if (yoy > TARGET + BAND) return 'high';
+  if (yoy < TARGET - BAND) return 'low';
+  return 'mid';
+};
+
+export default function SmallMultiples() {
+  const canastas = useAppStore((s) => s.canastas);
+  const seriesByCanasta = useAppStore((s) => s.seriesByCanasta);
+  const setSelected = useAppStore((s) => s.setSelectedCanastaIds);
+
+  // Cargar series para todas las divisiones (nivel 1, no Total, no subgrupos)
+  useEffect(() => {
+    if (canastas.length === 0) return;
+    const divisionIds = canastas
+      .filter((c) => c.id !== TOTAL_ID && (c.nivel === undefined || c.nivel === 1))
+      .map((c) => c.id);
+    if (divisionIds.length > 0) setSelected([TOTAL_ID, ...divisionIds]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canastas.length]);
+
+  const cards = useMemo(() => {
+    return canastas
+      .filter((c) => c.id !== TOTAL_ID && (c.nivel === undefined || c.nivel === 1))
+      .map((c) => {
+        const ser = seriesByCanasta[c.id] || [];
+        const last = ser[ser.length - 1];
+        return {
+          id: c.id,
+          nombre: c.nombre,
+          peso: c.peso,
+          yoy: last?.yoy ?? null,
+          mom: last?.mom ?? null,
+          spark: ser.slice(-24).map((p) => ({ time: p.time, v: p.yoy })),
+        };
+      })
+      .sort((a, b) => (b.yoy ?? -Infinity) - (a.yoy ?? -Infinity));
+  }, [canastas, seriesByCanasta]);
+
+  return (
+    <Wrap>
+      <Title>Las 12 divisiones · YoY actual y tendencia 24m</Title>
+      <Grid>
+        {cards.map((c) => {
+          const t = tone(c.yoy);
+          return (
+            <Card key={c.id} tone={t}>
+              <NameRow>
+                <NameTxt title={c.nombre}>{c.nombre}</NameTxt>
+                <PesoTxt>{(c.peso * 100).toFixed(1)}%</PesoTxt>
+              </NameRow>
+              <Big tone={t}>{fmtPct(c.yoy)}</Big>
+              <Small>MoM {fmtPct(c.mom)}</Small>
+              <Spark>
+                <ResponsiveContainer>
+                  <AreaChart data={c.spark} margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
+                    <YAxis hide domain={['dataMin - 1', 'dataMax + 1']} />
+                    <defs>
+                      <linearGradient id={`grad-${c.id}`} x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%"
+                          stopColor={t === 'high' ? '#B02A37' : t === 'low' ? '#188754' : '#FFC106'}
+                          stopOpacity={0.35} />
+                        <stop offset="100%"
+                          stopColor={t === 'high' ? '#B02A37' : t === 'low' ? '#188754' : '#FFC106'}
+                          stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <Area
+                      type="monotone"
+                      dataKey="v"
+                      stroke={t === 'high' ? '#B02A37' : t === 'low' ? '#188754' : '#FFC106'}
+                      strokeWidth={1.5}
+                      fill={`url(#grad-${c.id})`}
+                      isAnimationActive={false}
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </Spark>
+            </Card>
+          );
+        })}
+      </Grid>
+    </Wrap>
+  );
+}

--- a/src/components/inflation/v2/TrendBlock.tsx
+++ b/src/components/inflation/v2/TrendBlock.tsx
@@ -6,14 +6,12 @@ import {
   ResponsiveContainer,
   ComposedChart,
   Area,
-  Line,
   XAxis,
   YAxis,
   CartesianGrid,
   Tooltip,
   ReferenceArea,
   ReferenceLine,
-  Legend,
 } from 'recharts';
 import useAppStore from 'src/store';
 
@@ -100,10 +98,12 @@ export default function TrendBlock() {
   const data = useMemo(() => {
     if (!series) return [];
     const base = rangeMonths ? series.slice(-rangeMonths) : series;
-    return base.map((p) => ({
-      time: p.time,
-      v: view === 'yoy' ? p.yoy : view === 'mom' ? p.mom : p.indice,
-    }));
+    const pickValue = (p: typeof base[number]) => {
+      if (view === 'yoy') return p.yoy;
+      if (view === 'mom') return p.mom;
+      return p.indice;
+    };
+    return base.map((p) => ({ time: p.time, v: pickValue(p) }));
   }, [series, view, rangeMonths]);
 
   const visibleAnnotations = useMemo(() => {

--- a/src/components/inflation/v2/TrendBlock.tsx
+++ b/src/components/inflation/v2/TrendBlock.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import {
+  ResponsiveContainer,
+  ComposedChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceArea,
+  ReferenceLine,
+  Legend,
+} from 'recharts';
+import useAppStore from 'src/store';
+
+const TOTAL_ID = 1;
+
+const Wrap = styled.section`
+  background: #fff;
+  border: 1px solid #ECECEE;
+  border-radius: 14px;
+  padding: 18px 22px;
+  margin-bottom: 18px;
+  font-feature-settings: 'tnum' on;
+`;
+
+const Header = styled.div`
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 12px; flex-wrap: wrap; gap: 12px;
+`;
+
+const Title = styled.h3`
+  font-size: 14px; font-weight: 600; color: #212529; margin: 0;
+  letter-spacing: 0.2px; text-transform: uppercase;
+`;
+
+const Toggle = styled.div`
+  display: inline-flex; gap: 2px; padding: 2px;
+  background: #F5F5F7; border-radius: 8px;
+`;
+
+const TogBtn = styled.button<{ active?: boolean }>`
+  border: 0; background: ${({ active }) => (active ? '#fff' : 'transparent')};
+  color: ${({ active }) => (active ? '#212529' : '#6E6B7B')};
+  font-size: 11px; font-weight: ${({ active }) => (active ? 600 : 500)};
+  padding: 6px 12px; border-radius: 6px; cursor: pointer;
+  box-shadow: ${({ active }) => (active ? '0 1px 2px rgba(0,0,0,0.06)' : 'none')};
+`;
+
+const RANGES: { label: string; months: number | null }[] = [
+  { label: '1A', months: 12 },
+  { label: '3A', months: 36 },
+  { label: '5A', months: 60 },
+  { label: '10A', months: 120 },
+  { label: '20A', months: 240 },
+  { label: 'Max', months: null },
+];
+
+const VIEWS = [
+  { id: 'yoy', label: 'YoY' },
+  { id: 'mom', label: 'MoM' },
+  { id: 'indice', label: 'Índice' },
+] as const;
+
+type ViewId = typeof VIEWS[number]['id'];
+
+const fmtMonth = (s: string) => {
+  const d = new Date(`${s}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: '2-digit', year: '2-digit' });
+};
+
+const fmtMonthLong = (s: string) => {
+  const d = new Date(`${s}T00:00:00`);
+  return d.toLocaleDateString('es-CO', { month: 'short', year: 'numeric' });
+};
+
+// Anotaciones macro inline
+const ANNOTATIONS: { time: string; label: string }[] = [
+  { time: '1991-12-01', label: 'Apertura económica' },
+  { time: '1999-09-01', label: 'Crisis financiera local' },
+  { time: '2008-09-01', label: 'Crisis subprime' },
+  { time: '2015-12-01', label: 'Choque petrolero' },
+  { time: '2020-04-01', label: 'COVID' },
+  { time: '2022-12-01', label: 'Pico TRM/commodities' },
+];
+
+export default function TrendBlock() {
+  const series = useAppStore((s) => s.seriesByCanasta[TOTAL_ID]);
+  const loadSeries = useAppStore((s) => s.loadCanastaSeries);
+
+  const [view, setView] = useState<ViewId>('yoy');
+  const [rangeMonths, setRangeMonths] = useState<number | null>(120);
+
+  useEffect(() => { loadSeries(TOTAL_ID); }, [loadSeries]);
+
+  const data = useMemo(() => {
+    if (!series) return [];
+    const base = rangeMonths ? series.slice(-rangeMonths) : series;
+    return base.map((p) => ({
+      time: p.time,
+      v: view === 'yoy' ? p.yoy : view === 'mom' ? p.mom : p.indice,
+    }));
+  }, [series, view, rangeMonths]);
+
+  const visibleAnnotations = useMemo(() => {
+    if (data.length === 0) return [];
+    const start = data[0].time;
+    const end = data[data.length - 1].time;
+    return ANNOTATIONS.filter((a) => a.time >= start && a.time <= end);
+  }, [data]);
+
+  const isPercent = view !== 'indice';
+
+  return (
+    <Wrap>
+      <Header>
+        <Title>Tendencia · IPC Total Nacional</Title>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <Toggle>
+            {VIEWS.map((v) => (
+              <TogBtn key={v.id} active={view === v.id} onClick={() => setView(v.id)}>{v.label}</TogBtn>
+            ))}
+          </Toggle>
+          <Toggle>
+            {RANGES.map((r) => (
+              <TogBtn
+                key={r.label}
+                active={rangeMonths === r.months}
+                onClick={() => setRangeMonths(r.months)}
+              >{r.label}</TogBtn>
+            ))}
+          </Toggle>
+        </div>
+      </Header>
+
+      <div style={{ width: '100%', height: 360 }}>
+        <ResponsiveContainer>
+          <ComposedChart data={data} margin={{ top: 12, right: 16, left: 0, bottom: 0 }}>
+            <defs>
+              <linearGradient id="trendGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%"   stopColor="#786CF7" stopOpacity={0.32} />
+                <stop offset="100%" stopColor="#786CF7" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid stroke="#F1F1F2" strokeDasharray="3 3" />
+            <XAxis
+              dataKey="time"
+              tickFormatter={fmtMonth}
+              minTickGap={32}
+              stroke="#A6A6A6"
+              tick={{ fill: '#6E6B7B', fontSize: 11 }}
+            />
+            <YAxis
+              tickFormatter={(v) => (isPercent ? `${v.toFixed(0)}%` : v.toFixed(0))}
+              width={50}
+              stroke="#A6A6A6"
+              tick={{ fill: '#6E6B7B', fontSize: 11 }}
+            />
+            {view === 'yoy' && (
+              <>
+                <ReferenceArea y1={2} y2={4} fill="#A3CFBB" fillOpacity={0.18} />
+                <ReferenceLine y={3} stroke="#469F76" strokeDasharray="4 4" />
+              </>
+            )}
+            {isPercent && <ReferenceLine y={0} stroke="#A6A6A6" strokeDasharray="2 2" />}
+            {visibleAnnotations.map((a) => (
+              <ReferenceLine
+                key={a.time}
+                x={a.time}
+                stroke="#B5B3BD"
+                strokeDasharray="3 3"
+                label={{
+                  value: a.label,
+                  position: 'top',
+                  fill: '#6E6B7B',
+                  fontSize: 10,
+                  offset: 4,
+                }}
+              />
+            ))}
+            <Tooltip
+              contentStyle={{ fontSize: 12, borderRadius: 6, borderColor: '#ECECEE' }}
+              formatter={(v: number) => (isPercent ? `${v?.toFixed?.(2) ?? '—'}%` : v?.toFixed?.(2))}
+              labelFormatter={fmtMonthLong}
+            />
+            <Area
+              type="monotone"
+              dataKey="v"
+              stroke="#786CF7"
+              strokeWidth={2}
+              fill="url(#trendGrad)"
+              isAnimationActive={false}
+              connectNulls
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+    </Wrap>
+  );
+}

--- a/src/components/inflation/v2/toneColors.ts
+++ b/src/components/inflation/v2/toneColors.ts
@@ -1,0 +1,71 @@
+// Shared tone palette for the v2 inflation dashboard.
+// Status bands are derived from the Banrep inflation target (3% ±1).
+
+export type Tone = 'high' | 'mid' | 'low' | 'neutral';
+
+const TEXT_BY_TONE: Record<Tone, string> = {
+  high: '#B02A37',
+  low: '#188754',
+  mid: '#212529',
+  neutral: '#212529',
+};
+
+const BORDER_BY_TONE: Record<Tone, string> = {
+  high: '#B02A37',
+  low: '#188754',
+  mid: '#FFC106',
+  neutral: '#A6A6A6',
+};
+
+const ACCENT_BY_TONE: Record<Tone, string> = {
+  high: '#B02A37',
+  low: '#188754',
+  mid: '#FFC106',
+  neutral: '#A6A6A6',
+};
+
+const PILL_BG_BY_TONE: Record<'pos' | 'neg' | 'neutral', string> = {
+  pos: '#FCE5E7',
+  neg: '#DCEFE3',
+  neutral: '#EDEDEF',
+};
+
+const PILL_TEXT_BY_TONE: Record<'pos' | 'neg' | 'neutral', string> = {
+  pos: '#B02A37',
+  neg: '#188754',
+  neutral: '#3A3845',
+};
+
+const ROW_BG_BY_TONE: Record<Tone, string> = {
+  high: '#FCE5E720',
+  low: '#DCEFE320',
+  mid: '#FFF3CD20',
+  neutral: '#F5F5F7',
+};
+
+export const toneText = (t: Tone) => TEXT_BY_TONE[t];
+export const toneBorder = (t: Tone) => BORDER_BY_TONE[t];
+export const toneAccent = (t: Tone) => ACCENT_BY_TONE[t];
+export const toneRowBg = (t: Tone) => ROW_BG_BY_TONE[t];
+
+export type DirTone = 'pos' | 'neg' | 'neutral';
+
+export const pillBg = (t: DirTone) => PILL_BG_BY_TONE[t];
+export const pillText = (t: DirTone) => PILL_TEXT_BY_TONE[t];
+
+export const TARGET = 3;
+export const BAND = 1;
+
+export const toneFromYoy = (yoy: number | null | undefined): Tone => {
+  if (yoy == null || Number.isNaN(yoy)) return 'neutral';
+  if (yoy > TARGET + BAND) return 'high';
+  if (yoy < TARGET - BAND) return 'low';
+  return 'mid';
+};
+
+export const dirToneFromDelta = (v: number | null | undefined): DirTone => {
+  if (v == null || Number.isNaN(v)) return 'neutral';
+  if (v > 0.005) return 'pos';
+  if (v < -0.005) return 'neg';
+  return 'neutral';
+};

--- a/src/models/inflation/index.ts
+++ b/src/models/inflation/index.ts
@@ -1,0 +1,70 @@
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import {
+  CPIPoint,
+  CPISnapshot,
+  CPIContribution,
+  InflationCanasta,
+} from 'src/types/inflation';
+
+const supabase = createClientComponentClient();
+const SCHEMA = 'xerenity';
+
+export type Result<T> = { data: T | undefined; error: string | undefined };
+
+const fail = <T>(message: string): Result<T> => ({ data: undefined, error: message });
+
+export const fetchCanastas = async (): Promise<Result<InflationCanasta[]>> => {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .from('canasta')
+      .select('id,nombre,peso')
+      .order('id');
+    if (error) return fail(error.message);
+    return { data: (data ?? []) as InflationCanasta[], error: undefined };
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : 'Error fetching canastas');
+  }
+};
+
+export const fetchCPIFullSeries = async (
+  idCanasta: number
+): Promise<Result<CPIPoint[]>> => {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('cpi_full_series', { id_canasta_search: idCanasta });
+    if (error) return fail(error.message);
+    return { data: (data ?? []) as CPIPoint[], error: undefined };
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : 'Error fetching CPI series');
+  }
+};
+
+export const fetchCPISnapshot = async (
+  idCanasta: number
+): Promise<Result<CPISnapshot>> => {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('cpi_snapshot', { id_canasta_search: idCanasta });
+    if (error) return fail(error.message);
+    return { data: data as CPISnapshot, error: undefined };
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : 'Error fetching CPI snapshot');
+  }
+};
+
+export const fetchCPIContributions = async (
+  monthsBack: number
+): Promise<Result<CPIContribution[]>> => {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('cpi_contribution_history', { months_back: monthsBack });
+    if (error) return fail(error.message);
+    return { data: (data ?? []) as CPIContribution[], error: undefined };
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : 'Error fetching CPI contributions');
+  }
+};

--- a/src/models/inflation/index.ts
+++ b/src/models/inflation/index.ts
@@ -4,6 +4,8 @@ import {
   CPISnapshot,
   CPIContribution,
   InflationCanasta,
+  CityCPIPoint,
+  CitySnapshot,
 } from 'src/types/inflation';
 
 const supabase = createClientComponentClient();
@@ -66,5 +68,84 @@ export const fetchCPIContributions = async (
     return { data: (data ?? []) as CPIContribution[], error: undefined };
   } catch (e) {
     return fail(e instanceof Error ? e.message : 'Error fetching CPI contributions');
+  }
+};
+
+export const fetchCanastaTree = async (): Promise<Result<InflationCanasta[]>> => {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('cpi_canasta_tree');
+    if (error) return fail(error.message);
+    return { data: (data ?? []) as InflationCanasta[], error: undefined };
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : 'Error fetching canasta tree');
+  }
+};
+
+export const fetchCitySeries = async (
+  ciudad: string
+): Promise<Result<CityCPIPoint[]>> => {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('cpi_city_series', { ciudad_search: ciudad });
+    if (error) return fail(error.message);
+    return { data: (data ?? []) as CityCPIPoint[], error: undefined };
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : 'Error fetching city series');
+  }
+};
+
+export const fetchCitySnapshot = async (
+  targetDate?: string
+): Promise<Result<CitySnapshot[]>> => {
+  try {
+    const args = targetDate ? { target_date: targetDate } : {};
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('cpi_city_snapshot', args);
+    if (error) return fail(error.message);
+    return { data: (data ?? []) as CitySnapshot[], error: undefined };
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : 'Error fetching city snapshot');
+  }
+};
+
+const CORE_SERIES_IDS_YOY = [
+  { id: 124, nombre: 'Inflación sin alimentos' },
+  { id: 126, nombre: 'Inflación sin alimentos ni regulados' },
+  { id: 128, nombre: 'Inflación núcleo 15' },
+  { id: 130, nombre: 'Inflación de bienes, sin alimentos ni regulados' },
+  { id: 132, nombre: 'Inflación de servicios, sin alimentos ni regulados' },
+  { id: 134, nombre: 'Inflación de regulados' },
+  { id: 140, nombre: 'Inflación de alimentos' },
+];
+
+export const CORE_INFLATION_SERIES = CORE_SERIES_IDS_YOY;
+
+export const fetchCoreInflationSeries = async (
+  ids: number[]
+): Promise<Result<{ id: number; values: { time: string; value: number }[] }[]>> => {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .from('banrep_series_value_v2')
+      .select('id_serie,fecha,valor')
+      .in('id_serie', ids)
+      .order('fecha');
+    if (error) return fail(error.message);
+    const map = new Map<number, { time: string; value: number }[]>();
+    (data ?? []).forEach((r: { id_serie: number; fecha: string; valor: number }) => {
+      if (!map.has(r.id_serie)) map.set(r.id_serie, []);
+      map.get(r.id_serie)!.push({
+        time: String(r.fecha).slice(0, 10),
+        value: r.valor,
+      });
+    });
+    const out = Array.from(map.entries()).map(([id, values]) => ({ id, values }));
+    return { data: out, error: undefined };
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : 'Error fetching core inflation');
   }
 };

--- a/src/pages/inflation/index.tsx
+++ b/src/pages/inflation/index.tsx
@@ -1,28 +1,52 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import { Container, Row, Col } from 'react-bootstrap';
+import { Container } from 'react-bootstrap';
+import styled from 'styled-components';
 import { CoreLayout } from '@layout';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import {
-  faFileCsv,
   faMoneyBillTrendUp,
+  faFileCsv,
 } from '@fortawesome/free-solid-svg-icons';
-import Toolbar from '@components/UI/Toolbar';
-import Button from '@components/UI/Button';
-import PageTitle from '@components/PageTitle';
 import useAppStore from 'src/store';
 import { ExportToCsv, downloadBlob } from 'src/utils/downloadCSV';
-import InflationKPIs from '@components/inflation/InflationKPIs';
-import InflationMainChart from '@components/inflation/InflationMainChart';
-import ContributionChart from '@components/inflation/ContributionChart';
-import InflationHeatmap from '@components/inflation/InflationHeatmap';
-import InflationPivotTable from '@components/inflation/InflationPivotTable';
 
-const PAGE_TITLE = 'Inflación';
+import HeroBlock from '@components/inflation/v2/HeroBlock';
+import TrendBlock from '@components/inflation/v2/TrendBlock';
+import SmallMultiples from '@components/inflation/v2/SmallMultiples';
+import DecompositionBlock from '@components/inflation/v2/DecompositionBlock';
+import CityRanking from '@components/inflation/v2/CityRanking';
+import CoreInflationPanel from '@components/inflation/v2/CoreInflationPanel';
+
 const TOTAL_ID = 1;
+
+const Topbar = styled.div`
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 16px; padding: 4px 0;
+`;
+const Heading = styled.div`
+  display: flex; align-items: center; gap: 12px;
+  h2 { margin: 0; font-size: 22px; font-weight: 700; color: #212529; }
+  .subtitle { font-size: 12px; color: #6E6B7B; margin-top: 2px; }
+`;
+const ExportBtn = styled.button`
+  display: inline-flex; align-items: center; gap: 6px;
+  background: #fff; border: 1px solid #DEDEDE; border-radius: 8px;
+  padding: 7px 12px; font-size: 12px; font-weight: 500; color: #212529;
+  cursor: pointer;
+  &:hover { background: #F5F5F7; }
+`;
+
+const Footer = styled.div`
+  margin-top: 24px;
+  padding: 12px 0;
+  border-top: 1px solid #ECECEE;
+  font-size: 10px; color: #A6A6A6;
+  display: flex; flex-wrap: wrap; gap: 16px;
+`;
 
 export default function InflationPage() {
   const loadInflationCatalog = useAppStore((s) => s.loadInflationCatalog);
@@ -30,13 +54,12 @@ export default function InflationPage() {
   const loadCanastaSnapshot = useAppStore((s) => s.loadCanastaSnapshot);
   const loadContributions = useAppStore((s) => s.loadContributions);
   const seriesByCanasta = useAppStore((s) => s.seriesByCanasta);
-  const canastas = useAppStore((s) => s.canastas);
 
   useEffect(() => {
     loadInflationCatalog();
     loadCanastaSeries(TOTAL_ID);
     loadCanastaSnapshot(TOTAL_ID);
-    loadContributions(24);
+    loadContributions(36);
   }, [
     loadInflationCatalog,
     loadCanastaSeries,
@@ -62,52 +85,33 @@ export default function InflationPage() {
 
   return (
     <CoreLayout>
-      <Container fluid className="px-4 pb-3">
-        <Row>
-          <div
-            className="d-flex align-items-center justify-content-between gap-2 py-1"
-            style={{ flexWrap: 'wrap' }}
-          >
-            <PageTitle>
-              <Icon icon={faMoneyBillTrendUp} size="1x" />
-              <h4>{PAGE_TITLE}</h4>
-            </PageTitle>
-            <Toolbar>
-              <Button variant="outline-primary" onClick={downloadCsv}>
-                <Icon icon={faFileCsv} className="mr-4" /> Descargar CSV
-              </Button>
-            </Toolbar>
-          </div>
-        </Row>
+      <Container fluid className="px-4 pb-3" style={{ background: '#FAFAFB', minHeight: '100vh' }}>
+        <Topbar>
+          <Heading>
+            <Icon icon={faMoneyBillTrendUp} size="lg" color="#786CF7" />
+            <div>
+              <h2>Inflación Colombia</h2>
+              <div className="subtitle">DANE · empalmado BanRep desde 1954 · 25 ciudades · medidas de núcleo</div>
+            </div>
+          </Heading>
+          <ExportBtn onClick={downloadCsv}>
+            <Icon icon={faFileCsv} /> Exportar CSV
+          </ExportBtn>
+        </Topbar>
 
-        <InflationKPIs />
+        <HeroBlock />
+        <TrendBlock />
+        <SmallMultiples />
+        <DecompositionBlock />
+        <CityRanking />
+        <CoreInflationPanel />
 
-        <Row>
-          <Col xs={12} className="mb-3">
-            <InflationMainChart />
-          </Col>
-        </Row>
-
-        <Row>
-          <Col xs={12} lg={6} className="mb-3">
-            <ContributionChart />
-          </Col>
-          <Col xs={12} lg={6} className="mb-3">
-            <InflationHeatmap />
-          </Col>
-        </Row>
-
-        <Row>
-          <Col xs={12}>
-            <InflationPivotTable />
-          </Col>
-        </Row>
-
-        <div style={{ marginTop: 12, fontSize: 11, color: '#777' }}>
-          Fuente: DANE (canasta IPC base 2018=100, 12 divisiones COICOP){' '}
-          {canastas.length > 0 ? `· ${canastas.length - 1} divisiones` : ''} ·{' '}
-          Histórico headline empalmado vía BanRep desde 1954.
-        </div>
+        <Footer>
+          <div>Fuente: DANE — Sistema Estadístico Nacional (SEN)</div>
+          <div>Histórico headline: BanRep id=7 (IPC base 2018=100)</div>
+          <div>Núcleo: BanRep — Inflación básica</div>
+          <div>Última actualización: {new Date().toLocaleDateString('es-CO')}</div>
+        </Footer>
       </Container>
       <ToastContainer />
     </CoreLayout>

--- a/src/pages/inflation/index.tsx
+++ b/src/pages/inflation/index.tsx
@@ -1,112 +1,62 @@
 'use client';
 
-import React, { useCallback, useState, useEffect } from 'react';
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
-import { Container, Col, Row } from 'react-bootstrap';
+import React, { useEffect } from 'react';
+import { Container, Row, Col } from 'react-bootstrap';
 import { CoreLayout } from '@layout';
-import { LightSerieValue } from 'src/types/lightserie';
-import { ExportToCsv, downloadBlob } from 'src/utils/downloadCSV';
-import { ToastContainer, toast } from 'react-toastify';
+import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import {
   faFileCsv,
   faMoneyBillTrendUp,
 } from '@fortawesome/free-solid-svg-icons';
-import Form from 'react-bootstrap/Form';
 import Toolbar from '@components/UI/Toolbar';
-import tokens from 'design-tokens/tokens.json';
-import Chart from '@components/chart/Chart';
 import Button from '@components/UI/Button';
 import PageTitle from '@components/PageTitle';
-import Panel from '@components/Panel';
-import { ConsumerPrice } from 'src/types/consumerprice';
-
-import InflationTable from './_InflationTable';
-
-import ConsumerPriceList from './_InflationList';
-
-const designSystem = tokens.xerenity;
-const PURPLE_COLOR_100 = designSystem['purple-100'].value;
+import useAppStore from 'src/store';
+import { ExportToCsv, downloadBlob } from 'src/utils/downloadCSV';
+import InflationKPIs from '@components/inflation/InflationKPIs';
+import InflationMainChart from '@components/inflation/InflationMainChart';
+import ContributionChart from '@components/inflation/ContributionChart';
+import InflationHeatmap from '@components/inflation/InflationHeatmap';
+import InflationPivotTable from '@components/inflation/InflationPivotTable';
 
 const PAGE_TITLE = 'Inflación';
-const FILTER_OPTION_TXT = 'Periodos de cambio en IPC';
-const DOWNLOAD_TXT = 'Descargar';
+const TOTAL_ID = 1;
 
-const filterStyles = {
-  display: 'flex',
-  padding: '15px 0',
-  justifyContent: 'start',
-  gap: '10px',
-};
-
-export default function LoansPage() {
-  const supabase = createClientComponentClient();
-
-  const [prices, setConsumerPrices] = useState<ConsumerPrice[]>([]);
-
-  const [selectedPrices, setSelectecConsumerPrice] = useState<number>(1);
-
-  const [lagValue, setLagValue] = useState<number>(12);
-
-  const [priceValues, setPriceValues] = useState<LightSerieValue[]>([]);
-
-  const fetchPrices = useCallback(async () => {
-    const { data, error } = await supabase
-      .schema('xerenity')
-      .from('canasta')
-      .select('*')
-      .order('id', { ascending: true });
-
-    if (error) {
-      toast.error('Error leyendo datos de inflación');
-    } else {
-      const allPrices = data as ConsumerPrice[];
-
-      setConsumerPrices(allPrices);
-    }
-  }, [supabase]);
+export default function InflationPage() {
+  const loadInflationCatalog = useAppStore((s) => s.loadInflationCatalog);
+  const loadCanastaSeries = useAppStore((s) => s.loadCanastaSeries);
+  const loadCanastaSnapshot = useAppStore((s) => s.loadCanastaSnapshot);
+  const loadContributions = useAppStore((s) => s.loadContributions);
+  const seriesByCanasta = useAppStore((s) => s.seriesByCanasta);
+  const canastas = useAppStore((s) => s.canastas);
 
   useEffect(() => {
-    async function fetchData() {
-      const { data, error } = await supabase
-        .schema('xerenity')
-        .rpc('cpi_index_change', {
-          lag_value: lagValue,
-          id_canasta_search: selectedPrices,
-        });
+    loadInflationCatalog();
+    loadCanastaSeries(TOTAL_ID);
+    loadCanastaSnapshot(TOTAL_ID);
+    loadContributions(24);
+  }, [
+    loadInflationCatalog,
+    loadCanastaSeries,
+    loadCanastaSnapshot,
+    loadContributions,
+  ]);
 
-      if (error) {
-        toast.error('Error al calcular el cpi index');
-      } else {
-        setPriceValues(data as LightSerieValue[]);
-      }
-    }
-
-    fetchData();
-  }, [supabase, selectedPrices, lagValue]);
-
-  useEffect(() => {
-    fetchPrices();
-  }, [fetchPrices]);
-
-  const onPriceSelect = useCallback(
-    async (priceId: number) => {
-      setSelectecConsumerPrice(priceId);
-    },
-    [setSelectecConsumerPrice]
-  );
-
-  const downloadSeries = () => {
-    const allValues: string[][] = [];
-    allValues.push(['Fecha', 'Indice CPI']);
-
-    priceValues.forEach((price) => {
-      allValues.push([price.time, price.value.toString()]);
+  const downloadCsv = () => {
+    const total = seriesByCanasta[TOTAL_ID] || [];
+    const rows: string[][] = [['Fecha', 'Indice', 'MoM%', 'YoY%', 'YTD%']];
+    total.forEach((p) => {
+      rows.push([
+        p.time,
+        p.indice.toFixed(4),
+        p.mom?.toFixed(4) ?? '',
+        p.yoy?.toFixed(4) ?? '',
+        p.ytd?.toFixed(4) ?? '',
+      ]);
     });
-
-    const csv = ExportToCsv(allValues);
-
+    const csv = ExportToCsv(rows);
     downloadBlob(csv, 'xerenity_inflacion.csv', 'text/csv;charset=utf-8;');
   };
 
@@ -114,68 +64,50 @@ export default function LoansPage() {
     <CoreLayout>
       <Container fluid className="px-4 pb-3">
         <Row>
-          <div className="d-flex align-items-center gap-2 py-1">
+          <div
+            className="d-flex align-items-center justify-content-between gap-2 py-1"
+            style={{ flexWrap: 'wrap' }}
+          >
             <PageTitle>
               <Icon icon={faMoneyBillTrendUp} size="1x" />
               <h4>{PAGE_TITLE}</h4>
             </PageTitle>
-          </div>
-        </Row>
-        <Row>
-          <div className="d-flex justify-content-end pb-3">
             <Toolbar>
-              <Button variant="outline-primary" onClick={downloadSeries}>
-                <Icon icon={faFileCsv} className="mr-4" />
-                {DOWNLOAD_TXT}
+              <Button variant="outline-primary" onClick={downloadCsv}>
+                <Icon icon={faFileCsv} className="mr-4" /> Descargar CSV
               </Button>
             </Toolbar>
           </div>
         </Row>
+
+        <InflationKPIs />
+
         <Row>
-          <Col sm={8}>
-            <Row className="mb-4">
-              <Chart showToolbar>
-                <Chart.Bar
-                  data={priceValues}
-                  color={PURPLE_COLOR_100}
-                  scaleId="right"
-                  title={
-                    prices.findLast((e) => e.id === selectedPrices)?.nombre ||
-                    ''
-                  }
-                />
-              </Chart>
-            </Row>
-            <Row>
-              <Panel>
-                <InflationTable data={priceValues} />
-              </Panel>
-            </Row>
-          </Col>
-          <Col sm={4}>
-            <Panel>
-              <div style={filterStyles}>
-                <Form.Select
-                  defaultValue={lagValue}
-                  onChange={(e) => {
-                    setLagValue(Number(e.currentTarget.value));
-                  }}
-                >
-                  {Array.from(Array(13).keys()).map((item) => (
-                    <option key={`tr-${item}`} value={item}>
-                      {`${item} ${FILTER_OPTION_TXT}`}
-                    </option>
-                  ))}
-                </Form.Select>
-              </div>
-              <ConsumerPriceList
-                list={prices}
-                onSelect={onPriceSelect}
-                selected={selectedPrices}
-              />
-            </Panel>
+          <Col xs={12} className="mb-3">
+            <InflationMainChart />
           </Col>
         </Row>
+
+        <Row>
+          <Col xs={12} lg={6} className="mb-3">
+            <ContributionChart />
+          </Col>
+          <Col xs={12} lg={6} className="mb-3">
+            <InflationHeatmap />
+          </Col>
+        </Row>
+
+        <Row>
+          <Col xs={12}>
+            <InflationPivotTable />
+          </Col>
+        </Row>
+
+        <div style={{ marginTop: 12, fontSize: 11, color: '#777' }}>
+          Fuente: DANE (canasta IPC base 2018=100, 12 divisiones COICOP){' '}
+          {canastas.length > 0 ? `· ${canastas.length - 1} divisiones` : ''} ·{' '}
+          Histórico headline empalmado vía BanRep desde 1954.
+        </div>
       </Container>
       <ToastContainer />
     </CoreLayout>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -12,9 +12,10 @@ import createUserSlice, { UserSlice } from './user';
 import createChatSlice, { ChatSlice } from './chat';
 import createAgentConfigSlice, { AgentConfigSlice } from './agentConfig';
 import createMonitorSlice, { MonitorSlice } from './monitor';
+import createInflationSlice, { InflationSlice } from './inflation';
 
 const useAppStore = create<
-  LoansSlice & DashboardSlice & SeriesSlice & MarketDashboardSlice & TradingSlice & CurveSlice & UserSlice & ChatSlice & AgentConfigSlice & MonitorSlice
+  LoansSlice & DashboardSlice & SeriesSlice & MarketDashboardSlice & TradingSlice & CurveSlice & UserSlice & ChatSlice & AgentConfigSlice & MonitorSlice & InflationSlice
 >()(
   devtools((...args) => ({
     ...createLoansSlice(...args),
@@ -27,6 +28,7 @@ const useAppStore = create<
     ...createChatSlice(...args),
     ...createAgentConfigSlice(...args),
     ...createMonitorSlice(...args),
+    ...createInflationSlice(...args),
   }))
 );
 

--- a/src/store/inflation/index.ts
+++ b/src/store/inflation/index.ts
@@ -1,0 +1,115 @@
+import { StateCreator } from 'zustand';
+import {
+  CPIPoint,
+  CPISnapshot,
+  CPIContribution,
+  InflationCanasta,
+} from 'src/types/inflation';
+import {
+  fetchCanastas,
+  fetchCPIFullSeries,
+  fetchCPISnapshot,
+  fetchCPIContributions,
+} from 'src/models/inflation';
+
+const TOTAL_ID = 1;
+const DEFAULT_CONTRIB_MONTHS = 24;
+
+export interface InflationSlice {
+  canastas: InflationCanasta[];
+  selectedCanastaIds: number[];
+  seriesByCanasta: Record<number, CPIPoint[]>;
+  snapshotByCanasta: Record<number, CPISnapshot>;
+  contributions: CPIContribution[];
+  contribMonthsBack: number;
+  inflationLoading: boolean;
+  inflationError: string | undefined;
+
+  loadInflationCatalog: () => Promise<void>;
+  loadCanastaSeries: (id: number) => Promise<void>;
+  loadCanastaSnapshot: (id: number) => Promise<void>;
+  loadContributions: (monthsBack?: number) => Promise<void>;
+  toggleCanasta: (id: number) => Promise<void>;
+  setSelectedCanastaIds: (ids: number[]) => Promise<void>;
+}
+
+const initialState = {
+  canastas: [] as InflationCanasta[],
+  selectedCanastaIds: [TOTAL_ID],
+  seriesByCanasta: {} as Record<number, CPIPoint[]>,
+  snapshotByCanasta: {} as Record<number, CPISnapshot>,
+  contributions: [] as CPIContribution[],
+  contribMonthsBack: DEFAULT_CONTRIB_MONTHS,
+  inflationLoading: false,
+  inflationError: undefined as string | undefined,
+};
+
+const createInflationSlice: StateCreator<InflationSlice> = (set, get) => ({
+  ...initialState,
+
+  loadInflationCatalog: async () => {
+    set({ inflationLoading: true, inflationError: undefined });
+    const res = await fetchCanastas();
+    if (res.error || !res.data) {
+      set({ inflationLoading: false, inflationError: res.error });
+      return;
+    }
+    const total: InflationCanasta = { id: TOTAL_ID, nombre: 'Total Nacional', peso: 1 };
+    const merged = [total, ...res.data.filter((c) => c.id !== TOTAL_ID)];
+    set({ canastas: merged, inflationLoading: false });
+  },
+
+  loadCanastaSeries: async (id: number) => {
+    if (get().seriesByCanasta[id]) return;
+    const res = await fetchCPIFullSeries(id);
+    if (res.error || !res.data) {
+      set({ inflationError: res.error });
+      return;
+    }
+    set((state) => ({
+      seriesByCanasta: { ...state.seriesByCanasta, [id]: res.data as CPIPoint[] },
+    }));
+  },
+
+  loadCanastaSnapshot: async (id: number) => {
+    if (get().snapshotByCanasta[id]) return;
+    const res = await fetchCPISnapshot(id);
+    if (res.error || !res.data) {
+      set({ inflationError: res.error });
+      return;
+    }
+    set((state) => ({
+      snapshotByCanasta: { ...state.snapshotByCanasta, [id]: res.data as CPISnapshot },
+    }));
+  },
+
+  loadContributions: async (monthsBack?: number) => {
+    const months = monthsBack ?? get().contribMonthsBack;
+    const res = await fetchCPIContributions(months);
+    if (res.error || !res.data) {
+      set({ inflationError: res.error });
+      return;
+    }
+    set({ contributions: res.data, contribMonthsBack: months });
+  },
+
+  toggleCanasta: async (id: number) => {
+    const current = get().selectedCanastaIds;
+    const next = current.includes(id)
+      ? current.filter((x) => x !== id)
+      : [...current, id];
+    await get().setSelectedCanastaIds(next);
+  },
+
+  setSelectedCanastaIds: async (ids: number[]) => {
+    set({ selectedCanastaIds: ids });
+    await Promise.all(
+      ids.map(async (id) => {
+        await get().loadCanastaSeries(id);
+        await get().loadCanastaSnapshot(id);
+      })
+    );
+  },
+});
+
+export default createInflationSlice;

--- a/src/types/inflation.ts
+++ b/src/types/inflation.ts
@@ -28,6 +28,29 @@ export interface InflationCanasta {
   id: number;
   nombre: string;
   peso: number;
+  id_padre?: number | null;
+  nivel?: 0 | 1 | 2; // 0=Total, 1=división, 2=subgrupo
+}
+
+export interface CityCPIPoint {
+  time: string;
+  indice: number;
+  mom: number | null;
+  yoy: number | null;
+}
+
+export interface CitySnapshot {
+  ciudad: string;
+  fecha: string;
+  indice: number;
+  mom: number | null;
+  yoy: number | null;
+}
+
+export interface CoreInflationSeries {
+  id: number;
+  nombre: string;
+  values: { time: string; value: number }[];
 }
 
 export type InflationView = 'yoy' | 'mom' | 'ytd' | 'indice';

--- a/src/types/inflation.ts
+++ b/src/types/inflation.ts
@@ -1,0 +1,33 @@
+export interface CPIPoint {
+  time: string;
+  indice: number;
+  mom: number | null;
+  yoy: number | null;
+  ytd: number | null;
+}
+
+export interface CPISnapshot {
+  last_date: string | null;
+  last_indice: number | null;
+  last_mom: number | null;
+  last_yoy: number | null;
+  last_ytd: number | null;
+  prev_yoy: number | null;
+  prev_mom: number | null;
+}
+
+export interface CPIContribution {
+  time: string;
+  id_canasta: number;
+  nombre: string;
+  valorcontribucion: number;
+  valormensual: number;
+}
+
+export interface InflationCanasta {
+  id: number;
+  nombre: string;
+  peso: number;
+}
+
+export type InflationView = 'yoy' | 'mom' | 'ytd' | 'indice';


### PR DESCRIPTION
## Summary

Segundo iteración del rediseño de \`/inflation\` ([avelezX/xerenity-fe#351](https://github.com/avelezX/xerenity-fe/issues/351)) — pasa de v1 (KPIs + chart + tabla) a un dashboard \"top-of-the-art\" de 6 secciones inspirado en Atlanta Fed Underlying Inflation Dashboard, Truflation y FT Inflation Tracker.

Aprovecha la nueva data masiva ahora disponible:
- **25 ciudades** desde **1980-01** (8 750 filas) — backfill SEN del DANE.
- **42 subgrupos COICOP nivel 2** desde **1999-01** (9 548 filas).
- **20 medidas BanRep de inflación núcleo** ya pobladas en \`banrep_serie_v2\`.
- IPC Total empalmado **1954+** vía BanRep.

## Layout de 6 zonas verticales

1. **HeroBlock** — headline 64px (YoY) con tono según meta Banrep, sparkline 36m con banda 2-4%, gauge vertical en escala roja/ámbar/verde.
2. **TrendBlock** — área-gradient con **anotaciones inline** (COVID, Crisis subprime, Apertura económica, choque petrolero), brush 1A→Max, toggle YoY/MoM/Índice.
3. **SmallMultiples** — grid 4×3 con las 12 divisiones, sparkline coloreada por desviación de meta, peso visible. Permite barrer las 12 divisiones de un vistazo.
4. **DecompositionBlock** — stacked-bar de contribuciones (36m) × heatmap divisiones × meses lado a lado.
5. **CityRanking** — 25 ciudades rankeadas por YoY con tone band.
6. **CoreInflationPanel** — 7 medidas BanRep núcleo (sin alimentos, núcleo 15-20, bienes/servicios sin alimentos ni regulados, regulados, alimentos) en LineChart con banda meta.

## Patrón visual

- Tipografía con **tabular numerals** (\`font-feature-settings: 'tnum'\`) para alinear cifras.
- **Coloreado relativo a meta Banrep**, no por valor absoluto (Atlanta Fed style).
- **Banda 2-4%** como referencia visual omnipresente.
- Cards limpias con borde lateral por estado.

## Dependencias

- [avelezX/xerenity-db#89](https://github.com/avelezX/xerenity-db/pull/89) — vista \`cpi_total_index\` empalmada + RPCs nuevas (\`cpi_full_series\`, \`cpi_snapshot\`, \`cpi_contribution_history\`, \`cpi_city_series\`, \`cpi_city_snapshot\`, \`cpi_canasta_tree\`) + tablas \`canasta_ciudad\`/\`canasta_ciudad_values\`.

## Test plan

- [ ] Visitar \`/inflation\` y validar que las 6 secciones cargan.
- [ ] Headline debe mostrar 5.56% YoY para mar-2026 con tono rojo (>4%).
- [ ] Sparkline 36m debe atravesar la banda meta 2-4%.
- [ ] Gauge vertical debe colocar el indicador en zona roja.
- [ ] Trend chart con anotaciones COVID-2020, Pico TRM-2022 visibles.
- [ ] Small multiples: 12 cards, peso correcto, sparkline 24m.
- [ ] Stacked bar 36 meses con todas las divisiones diferenciadas por color.
- [ ] Heatmap muestra últimos 12 meses con escala roja/verde.
- [ ] CityRanking carga las 25 ciudades.
- [ ] CoreInflationPanel muestra las 7 series núcleo BanRep sobre 10 años.

🤖 Generated with [Claude Code](https://claude.com/claude-code)