### PR TITLE
fix(portfolio): derive canEdit reactively from userProfile (race condition)

### DIFF
--- a/src/pages/portfolio/index.tsx
+++ b/src/pages/portfolio/index.tsx
@@ -1952,7 +1952,6 @@ function PortfolioPage() {
 
   const {
     tradingError,
-    canEdit,
     loadUserRole,
     userRole,
     marketDataConfig,
@@ -1961,6 +1960,16 @@ function PortfolioPage() {
     activeCompanyId,
     selectedCompanyId,
   } = useAppStore();
+  // Derive canEdit reactively from userProfile so it stays correct even when
+  // loadUserProfile resolves after loadUserRole. The store flag goes stale
+  // across that race; userProfile is the canonical source.
+  const userProfile = useAppStore((s) => s.userProfile);
+  const canEdit =
+    userProfile?.role === 'super_admin' ||
+    userProfile?.role === 'corp_admin' ||
+    userProfile?.role === 'gestor' ||
+    userRole.role === 'admin' ||
+    userRole.role === 'manager';
 
   // #317 — Position lists now come from TanStack Query. Their cache key
   // includes companyId so switching companies invalidates correctly. The

--- a/src/pages/tes-portfolio/index.tsx
+++ b/src/pages/tes-portfolio/index.tsx
@@ -848,12 +848,20 @@ function TesPortfolioPage() {
     repriceTes,
     addTesPosition,
     removeTesPositions,
-    canEdit,
     loadUserRole,
     userRole,
     activeCompanyId,
     selectedCompanyId,
   } = useAppStore();
+  // Derive canEdit reactively from userProfile (avoids the race where
+  // loadUserProfile resolves after loadUserRole and the store flag goes stale).
+  const userProfile = useAppStore((s) => s.userProfile);
+  const canEdit =
+    userProfile?.role === 'super_admin' ||
+    userProfile?.role === 'corp_admin' ||
+    userProfile?.role === 'gestor' ||
+    userRole.role === 'admin' ||
+    userRole.role === 'manager';
 
   // Mount: load positions + role (catalog now comes from useTesCatalog)
   useEffect(() => {


### PR DESCRIPTION
Closes #358 (the FE-side race condition that survived the previous fix).

## Problem
PR #354 set \`canEdit\` inside \`loadUserRole\` by reading \`userProfile\` via the store's \`get()\`. That captures the value at the moment \`loadUserRole\` runs.

\`loadUserProfile\` runs in CoreLayout's useEffect; \`loadUserRole\` runs in the page's useEffect. Both are async-fire-and-forget; their order is not guaranteed. When the page wins the race, \`userProfile\` is still null when \`canEdit\` is derived, the store flag is set to false, and it never recomputes when \`userProfile\` lands later. The "Add XCCY Swap / NDF / IBR Swap" buttons stay hidden for legitimate \`corp_admin\` / \`gestor\` users.

Reproducible: open /portfolio in a fresh browser, sometimes the buttons appear, sometimes they don't.

## Fix
Compute \`canEdit\` at render time on the two pages that use it (\`/portfolio\`, \`/tes-portfolio\`) via:

\`\`\`tsx
const userProfile = useAppStore((s) => s.userProfile);
const canEdit =
  userProfile?.role === 'super_admin' ||
  userProfile?.role === 'corp_admin' ||
  userProfile?.role === 'gestor' ||
  userRole.role === 'admin' ||
  userRole.role === 'manager';
\`\`\`

Selector subscriptions are inherently reactive — the moment \`userProfile\` lands, the component re-renders with the correct value. Legacy roles (\`admin\`, \`manager\`) are kept for backward compat.

The trading store still exposes \`canEdit\` for any other consumers; this PR just stops the two pages from reading it.

## Test plan
- [ ] Cold load /portfolio in a fresh incognito as corp_admin → buttons appear immediately, no race needed.
- [ ] Same for /tes-portfolio.
- [ ] As lector, buttons stay hidden.
- [ ] As legacy admin/manager (in trading.company_member), buttons appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)