### PR TITLE
fix(loans): gate loan loading on selected company

### DIFF
--- a/src/pages/loans/index.tsx
+++ b/src/pages/loans/index.tsx
@@ -99,7 +99,6 @@ export default function LoansPage() {
     deleteMultipleLoans,
     setCurrentSelection,
     activeCompanyId,
-    selectedCompanyId,
   } = useAppStore();
 
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('Todos');
@@ -236,11 +235,20 @@ export default function LoansPage() {
     }
   };
 
+  // Only fetch loans when a company is selected. Without one, leave the
+  // store empty and let the render show the "select a company" state —
+  // calling the RPC with a null company_id would fall back to data outside
+  // the user's intended scope.
+  const companyId = activeCompanyId();
   useEffect(() => {
-    getLoanData([], activeCompanyId());
+    if (!companyId) {
+      resetStore();
+      return undefined;
+    }
+    getLoanData([], companyId);
     return () => resetStore();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getLoanData, resetStore, selectedCompanyId]);
+  }, [getLoanData, resetStore, companyId]);
 
   useEffect(() => { wakeServer(); }, [wakeServer]);
 
@@ -258,6 +266,35 @@ export default function LoansPage() {
   }, [errorMessage, successMessage]);
 
   const bankSelectItems = banks.map((bck) => ({ value: bck.bank_name, label: bck.bank_name }));
+
+  if (!companyId) {
+    return (
+      <CoreLayout>
+        <div style={{ padding: '0 16px 16px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', padding: '8px 0', marginBottom: 8 }}>
+            <PageTitle>
+              <Icon icon={faLandmark} size="1x" />
+              <h4>{PAGE_TITLE}</h4>
+            </PageTitle>
+          </div>
+          <div
+            style={{
+              padding: 48,
+              textAlign: 'center',
+              color: '#6c757d',
+              fontSize: 13,
+              border: '2px dashed #dee2e6',
+              borderRadius: 8,
+              background: '#fff',
+            }}
+          >
+            Selecciona una empresa para ver sus créditos.
+          </div>
+        </div>
+        <ToastContainer />
+      </CoreLayout>
+    );
+  }
 
   return (
     <CoreLayout>


### PR DESCRIPTION
Closes #367

## Summary

La página \`/loans\` ahora **solo carga créditos cuando hay una empresa seleccionada**. Sin empresa, no se hace ningún fetch y se muestra un mensaje claro: *"Selecciona una empresa para ver sus créditos."*

## Why

Antes, el \`useEffect\` de carga llamaba \`getLoanData([], activeCompanyId())\` siempre que se montaba la página. Si \`activeCompanyId()\` retornaba undefined (usuario sin company default, justo después de hacer logout-de-empresa, etc.), \`fetchLoans\` enviaba \`p_company_id: null\` al RPC y el backend devolvía datos fuera del scope esperado.

## Cambios

- \`src/pages/loans/index.tsx\`:
  - Captura \`companyId = activeCompanyId()\` antes del effect.
  - Si no hay company → \`resetStore()\` y skip del fetch.
  - Early-return en el render con un empty-state cuando \`companyId\` es undefined.
  - Eliminada la dep no usada \`selectedCompanyId\` del destructuring (el effect ahora depende de \`companyId\` derivado).

## Test plan

- [ ] Abrir \`/loans\` con empresa seleccionada → carga normal.
- [ ] Abrir \`/loans\` sin empresa seleccionada → ver el mensaje "Selecciona una empresa para ver sus créditos." y ningún fetch en Network.
- [ ] Cambiar de empresa → la página re-fetchea con la nueva company; \`resetStore\` limpia loans/cashflows previos.
- [ ] Deseleccionar empresa después de tener una → vuelve al empty-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)