### PR TITLE
feat(loans): add 'custom' loan type for non-linear amortization schedules

### DIFF
--- a/src/models/loans/fetchCashFlows.ts
+++ b/src/models/loans/fetchCashFlows.ts
@@ -33,6 +33,11 @@ const CASH_FLOW_UVR = {
   error: 'Error Fetching UVR Cash Flows',
 };
 
+const CASH_FLOW_CUSTOM = {
+  key: 'custom_cash_flow',
+  error: 'Error Fetching Custom Cash Flows',
+};
+
 const SCHEMA = 'xerenity';
 const supabase = createClientComponentClient();
 
@@ -48,6 +53,8 @@ export const fetchCashFlows = async (
     requestKey = CASH_FLOW_IBR.key;
   } else if (loanType === 'uvr') {
     requestKey = CASH_FLOW_UVR.key;
+  } else if (loanType === 'custom') {
+    requestKey = CASH_FLOW_CUSTOM.key;
   }
   const response: CashflowResponse = {
     data: [],

--- a/src/pages/loans/index.tsx
+++ b/src/pages/loans/index.tsx
@@ -60,18 +60,20 @@ const fmtMM = (v: number | null | undefined) => {
 };
 
 const TYPE_PILL_COLORS: Record<string, { bg: string; color: string }> = {
-  ibr:  { bg: '#fff3cd', color: '#856404' },
-  uvr:  { bg: '#e8d5f5', color: '#6f42c1' },
-  fija: { bg: '#cce5ff', color: '#004085' },
+  ibr:    { bg: '#fff3cd', color: '#856404' },
+  uvr:    { bg: '#e8d5f5', color: '#6f42c1' },
+  fija:   { bg: '#cce5ff', color: '#004085' },
+  custom: { bg: '#d1f7e7', color: '#0f5132' },
 };
 
-type TypeFilter = 'Todos' | 'ibr' | 'uvr' | 'fija';
+type TypeFilter = 'Todos' | 'ibr' | 'uvr' | 'fija' | 'custom';
 
 const TYPE_OPTIONS: { key: TypeFilter; label: string }[] = [
   { key: 'Todos', label: 'Todos' },
   { key: 'ibr', label: 'IBR' },
   { key: 'uvr', label: 'UVR' },
   { key: 'fija', label: 'Tasa Fija' },
+  { key: 'custom', label: 'Custom' },
 ];
 
 // ─── Page ───────────────────────────────────────────────────────────────────
@@ -142,7 +144,7 @@ export default function LoansPage() {
 
   // Type counts for pills
   const typeCounts = useMemo(() => {
-    const counts = { ibr: 0, uvr: 0, fija: 0 };
+    const counts = { ibr: 0, uvr: 0, fija: 0, custom: 0 };
     loans.forEach((l) => {
       if (l.type in counts) counts[l.type as keyof typeof counts] += 1;
     });
@@ -402,6 +404,7 @@ export default function LoansPage() {
           {typeCounts.ibr > 0 && <SummaryItem label="IBR" value={`${typeCounts.ibr} créditos`} color="#856404" />}
           {typeCounts.uvr > 0 && <SummaryItem label="UVR" value={`${typeCounts.uvr} créditos`} color="#6f42c1" />}
           {typeCounts.fija > 0 && <SummaryItem label="Tasa Fija" value={`${typeCounts.fija} créditos`} color="#004085" />}
+          {typeCounts.custom > 0 && <SummaryItem label="Custom" value={`${typeCounts.custom} créditos`} color="#0f5132" />}
         </div>
 
         {/* ─── Filters ─── */}


### PR DESCRIPTION
Closes #370

## Summary
- Adds new `custom` loan type. Reuses pysdk IBR forward-curve interest logic but takes per-period principal from an explicit schedule stored in `loans.loan_schedule`.
- Dispatched in `fetchCashFlows` to new RPC `xerenity.custom_cash_flow`.
- Adds Custom pill filter + color + summary counter on the loans page.

## Why
Several créditos agroverde Bancolombia, BBVA swap inverso y leasings tienen amortización **back-loaded** (AÑO 1=0, AÑO 2-4 incrementales, AÑO 5 mayor). El motor IBR linealiza con `original_balance / capital_payments` y subestima saldos hasta en 60%. Para Super de Alimentos esto resulta en un gap de **~\$56B** entre el saldo del front y el Excel de Sandra Pilar.

## Componentes asociados
- `xerenity-db`: migration `add_custom_loan_type_and_schedule` + RPCs `xerenity.custom_cash_flow_data` y `xerenity.custom_cash_flow`
- `pysdk`: clase `CustomLoan` (hereda `IbrLoan`), endpoint `/custom_rates`, deployed a `xerenity-pysdk.fly.dev`
- 23 créditos hot-spot ya migrados a `type='custom'` en producción con sus schedules cargados

## Test plan
- [x] Reasignar 23 créditos hot-spot a `type='custom'` y poblar `loan_schedule`
- [x] Verificar que el saldo en el motor converge al saldo Excel (gap <2.7%, antes 13.7%)
- [x] Confirmar que créditos `type='ibr'` existentes siguen calculando igual

🤖 Generated with [Claude Code](https://claude.com/claude-code)