### PR TITLE
fix(risk): Benchmark Portafolio GR / P&G GR usa precios per-contract

### DIFF
--- a/src/lib/risk/futuresCalculator.ts
+++ b/src/lib/risk/futuresCalculator.ts
@@ -280,10 +280,12 @@ export function calculateFuturesPortfolio(
       closed_date: null,
       closed_price: null,
       rolled_to: null,
+      valor_compra: Math.round(group.valorCompra),
     });
   }
 
   // Grand total row
+  const grandValorCompra = Array.from(assetGroups.values()).reduce((s, g) => s + g.valorCompra, 0);
   sorted.push({
     id: '',
     asset: 'Total',
@@ -306,6 +308,7 @@ export function calculateFuturesPortfolio(
     closed_date: null,
     closed_price: null,
     rolled_to: null,
+    valor_compra: Math.round(grandValorCompra),
   });
 
   return sorted;

--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -1299,11 +1299,9 @@ function RiskManagement() {
   }, [exposureResult, varianceMap]);
 
   // When futures portfolio or benchmark month changes, auto-fill position_gr and pnl_gr
-  // Only positions opened ON or BEFORE the selected benchmark month are included
+  // Solo se incluyen posiciones con entry_date <= benchmarkDateStr (filtro que
+  // ya hizo calculateFuturesPortfolio antes de poblar futuresPortfolio).
   useEffect(() => {
-    // Use Px Inicio (price_start) and Px Fin (price_end) from benchmark factors for P&G
-    const factors = benchmarkFactors?.factors ?? {};
-
     setBenchmarkRows((prev) => {
       const next = prev.map((r) => ({ ...r }));
 
@@ -1323,43 +1321,24 @@ function RiskManagement() {
           return;
         }
 
-        // Filter positions: only those opened on or before the selected month
-        const positions = (futuresPortfolio ?? []).filter((p) =>
-          p.asset === row.asset
-          && p.entry_date != null
-          && p.entry_date !== ''
-          && p.entry_date <= benchmarkDateStr,
-        );
-
-        if (positions.length === 0) {
-          next[i].position_gr = '0';
-          next[i].pnl_gr = '0';
-          return;
-        }
-
-        // Position GR = sum of Valor Compra (entry_price × multiplier × nominal × toUsd)
-        const valorCompra = positions.reduce((s, p) => {
-          const toUsd = ({ MAIZ: 0.01, AZUCAR: 0.01, CACAO: 1 } as Record<string, number>)[p.asset] ?? 1;
-          return s + (p.entry_price ?? 0) * (p.multiplier ?? 1) * (p.nominal ?? 0) * toUsd;
-        }, 0);
-        next[i].position_gr = String(Math.round(valorCompra));
-
-        // P&G GR = sum of (price_end - price_start) × multiplier × nominal × dirSign × toUsd
-        // Use benchmark prices for the selected month
-        const f = factors[row.asset];
-        if (f?.price_start != null && f?.price_end != null) {
-          const pnlGr = positions.reduce((s, p) => {
-            const toUsd = ({ MAIZ: 0.01, AZUCAR: 0.01, CACAO: 1 } as Record<string, number>)[p.asset] ?? 1;
-            const dirSign = p.direction === 'LONG' ? 1 : -1;
-            // For positions opened in the current month: P&G = (price_end - entry_price) × ...
-            // For older positions: P&G = (price_end - price_start) × ...
-            const entryMonth = (p.entry_date ?? '').slice(0, 7);
-            const filterMonth = benchmarkDateStr.slice(0, 7);
-            const startPrice = entryMonth === filterMonth ? (p.entry_price ?? 0) : (f.price_start ?? 0);
-            return s + (f.price_end! - startPrice) * (p.multiplier ?? 1) * (p.nominal ?? 0) * dirSign * toUsd;
-          }, 0);
-          next[i].pnl_gr = String(Math.round(pnlGr));
+        // Lookup el subtotal row del Portafolio GR tab para este activo.
+        // Single source of truth: las dos pestañas (Benchmark y Portafolio GR)
+        // deben mostrar los mismos numeros para Valor Compra y P&L Mes.
+        //
+        // Antes: aqui se recalculaba con el FRONT contract price para todos los
+        // contratos del activo (lineas 1380-1404 del codigo anterior). Esto
+        // producia errores de hasta $20K en el P&G GR para AZUCAR/MAIZ porque
+        // contratos lejanos (SBH27, SBV27, ZCK27, ZCN27) tienen precios muy
+        // distintos al front (SBN26, ZCN26).
+        //
+        // Ahora: leer directo del subtotal del Portafolio GR (que usa precios
+        // per-contract de risk_prices_all_contracts).
+        const subtotalRow = (futuresPortfolio ?? []).find((p) => p.asset === `Total ${row.asset}`);
+        if (subtotalRow) {
+          next[i].position_gr = String(subtotalRow.valor_compra ?? 0);
+          next[i].pnl_gr = String(subtotalRow.pnl_month ?? 0);
         } else {
+          next[i].position_gr = '0';
           next[i].pnl_gr = '0';
         }
       });
@@ -1367,7 +1346,7 @@ function RiskManagement() {
       return recalcBenchmark(next, varianceMap);
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [futuresPortfolio, varianceMap, benchmarkDateStr, benchmarkFactors, otcSummary, pricedXccyStore, pricedNdfStore, refPricesStore]);
+  }, [futuresPortfolio, varianceMap, benchmarkDateStr, otcSummary, pricedXccyStore, pricedNdfStore, refPricesStore]);
 
   // Build chart data for rolling var
   const buildChartData = (asset: string, field: 'prices' | 'rolling_var') => {

--- a/src/types/risk.ts
+++ b/src/types/risk.ts
@@ -208,6 +208,10 @@ export interface FuturesPosition {
   closed_price?: number | null;
   rolled_to?: string | null;
   portfolio_id?: string | null;
+  // Solo presente en subtotal rows (asset='Total ...'): suma de entry_price *
+  // multiplier * nominal * toUsd para el grupo (sin direccion). Coincide con la
+  // columna "Valor Compra" del tab Portafolio GR.
+  valor_compra?: number | null;
 }
 
 export interface FuturesPortfolioResponse {


### PR DESCRIPTION
Closes #373

## Summary

- Benchmark de `/risk-management` mostraba P&G GR usando precio del **front contract** (SBN26 para AZUCAR, ZCN26 para MAIZ) aplicado a TODOS los contratos del activo. Eso producía errores grandes en contratos lejanos cuyos precios reales difieren mucho del front (ej. SBH27 a 15.86 vs SBN26 a 14.61).
- Ahora el Benchmark lee directo del **subtotal row** del Portafolio GR tab, que ya usa precios per-contract de `risk_prices_all_contracts`. Single source of truth: las dos pestañas muestran los mismos números.

## Datos antes vs después (Abril 2026, Super)

| Activo | Benchmark antes | Portafolio GR tab | Benchmark después |
|---|---:|---:|---:|
| AZUCAR P&G GR | -\$56,179 | -\$8,511 | **-\$8,511** ✅ |
| MAIZ P&G GR | -\$10,025 | +\$10,275 | **+\$10,275** ✅ |

## Archivos modificados

- `src/types/risk.ts`: añadido campo opcional `valor_compra` a `FuturesPosition` (solo presente en subtotal rows).
- `src/lib/risk/futuresCalculator.ts`: expone `group.valorCompra` en los subtotal rows (per-asset) y en el grand total.
- `src/pages/risk-management/index.tsx`: el `useEffect` que rellena `position_gr`/`pnl_gr` ahora hace lookup `Total {asset}` y lee `valor_compra` / `pnl_month` del subtotal en lugar de recalcular con el front contract. Removida la dep `benchmarkFactors` (ya no se usa en este effect).

## Test plan

- [ ] Abrir `/risk-management` → tab Benchmark → mes Abril 2026 (Super de Alimentos)
- [ ] Confirmar AZUCAR Portafolio GR = \$1,707,798, P&G GR = -\$8,511
- [ ] Confirmar MAIZ Portafolio GR = \$745,476, P&G GR = +\$10,275
- [ ] Cambiar a tab Portafolio GR sin moverse de Abril → Total AZUCAR y Total MAIZ coinciden con Benchmark
- [ ] Navegar a otros meses (Marzo, Mayo) → los valores cambian acorde y siguen coincidiendo entre pestañas
- [ ] La fila USD se mantiene como antes (sin cambios en este PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)