### PR TITLE
fix(risk): hardcode temporal USD row en Benchmark (Abril 2026)

### DIFF
--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -1309,6 +1309,15 @@ function RiskManagement() {
         if (row.asset === 'Total') return;
 
         // ── USD row: fed from OTC store (FX Delta + P&L MTD USD) ──
+        // TODO(hardcode-temporal): el row USD deberia leer dinamicamente del OTC
+        // store (pricedXccy + pricedNdf + summary + refPrices.mtd) anclados a
+        // benchmarkDateStr. Por ahora no se dispara la carga del OTC store en
+        // este page (eso quedo fuera del PR #372 hasta organizar arquitectura
+        // de fechas). Mientras tanto, se hardcodean los valores de Abril 2026
+        // copiados manualmente del tab Portafolio OTC al 2026-04-30:
+        //   FX Delta total (sum XCCY + NDF)  = -$8,800,000
+        //   P&L MTD USD (npv hoy - npv MTD)  = +$121,300
+        // Quitar este hardcode cuando se implemente el flujo dinamico.
         if (row.asset === 'USD') {
           const fxDeltaTotal = (pricedXccyStore ?? []).reduce((s, p) => s + (p.fx_delta ?? 0), 0)
             + (pricedNdfStore ?? []).reduce((s, p) => s + (p.fx_delta ?? 0), 0);
@@ -1316,8 +1325,15 @@ function RiskManagement() {
           const pnlMtdUsd = (otcSummary && mtdRef)
             ? otcSummary.total_npv_usd - mtdRef.summary.total_npv_usd
             : 0;
-          next[i].position_gr = fxDeltaTotal !== 0 ? String(Math.round(fxDeltaTotal)) : '0';
-          next[i].pnl_gr = pnlMtdUsd !== 0 ? String(Math.round(pnlMtdUsd)) : '0';
+          // Si el store esta poblado, usar valores reales. Si no, fallback al
+          // hardcode de Abril 2026.
+          const useStore = fxDeltaTotal !== 0 || pnlMtdUsd !== 0;
+          next[i].position_gr = useStore
+            ? String(Math.round(fxDeltaTotal))
+            : '-8800000';
+          next[i].pnl_gr = useStore
+            ? String(Math.round(pnlMtdUsd))
+            : '121300';
           return;
         }
 


### PR DESCRIPTION
Closes #374

## Summary

Hardcode temporal de la fila USD del tab Benchmark de \`/risk-management\` mientras se organiza la arquitectura de fechas para que el OTC store se cargue dinamicamente al cambiar de mes.

**Valores hardcoded (de Abril 2026, tomados manualmente del tab Portafolio OTC al 2026-04-30):**
- \`position_gr\` (FX Delta total XCCY + NDF) = **-\$8,800,000**
- \`pnl_gr\` (P&L MTD USD = npv_hoy - npv_mtd_ref) = **+\$121,300**

## Comportamiento dual

Si el OTC store SI esta poblado (caso: usuario navega primero a Portafolio OTC y luego al Benchmark), se usan los valores dinamicos reales en lugar del hardcode. Esto evita romper el flujo cuando se implemente la solucion permanente.

## Por que es necesario ahora

Sin esto, la fila USD del Benchmark muestra 0/0 a menos que el usuario haya pre-cargado el tab Portafolio OTC. El usuario necesita ver los valores correctos en la pantalla mientras se trabaja en el fix arquitectonico.

## Archivos modificados

- \`src/pages/risk-management/index.tsx\`: solo el bloque del row USD dentro del \`useEffect\` que rellena position_gr/pnl_gr. Comentario \`TODO(hardcode-temporal)\` marca el lugar para facil remocion.

## Test plan

- [ ] Abrir \`/risk-management\` → tab Benchmark → mes Abril 2026
- [ ] Fila USD debe mostrar Portafolio GR = **-\$8,800,000** y P&G GR = **+\$121,300**
- [ ] Sumas del Total row reflejan estos valores

🤖 Generated with [Claude Code](https://claude.com/claude-code)