### PR TITLE
feat(risk): blotter de fijaciones y compras de cafe

### DIFF
--- a/src/components/risk/BlotterCafe.tsx
+++ b/src/components/risk/BlotterCafe.tsx
@@ -1,0 +1,517 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+/**
+ * Blotter de fijaciones de cafe. Tabla CRUD que se renderiza dentro del
+ * tab Benchmark de /risk-management cuando la empresa tiene CAFE en sus
+ * commodities.
+ *
+ * Cada fila representa una operacion de fijacion: el momento en que se
+ * congela el precio NY (cents/lb) + prima y el TRM para calcular el
+ * precio efectivo en COP/saco / COP/kg / total.
+ *
+ * Formulas (cents/lb -> COP/saco):
+ *   precio_final    = fijacion_ny + prima
+ *   precio_por_saco = precio_final × factor × fijacion_cop
+ *   precio_cop_kg   = precio_por_saco × sacos / kg
+ *   total           = precio_por_saco × sacos
+ *
+ * Donde factor (default 1.5432) = (kg_por_saco × lb_por_kg) / 100.
+ *
+ * El total de la columna Total se reporta hacia arriba via onTotalChange
+ * para alimentar la Exposicion Natural de la fila CAFE del Benchmark.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Table, Form, Button, Spinner } from 'react-bootstrap';
+import { toast } from 'react-toastify';
+
+import {
+  fetchCafeFijaciones,
+  insertCafeFijacion,
+  updateCafeFijacion,
+  deleteCafeFijacion,
+  fetchCafeFactorConversion,
+  updateCafeFactorConversion,
+  CafeFijacionRow,
+} from 'src/lib/risk/supabaseRisk';
+
+type SaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
+
+interface Row extends CafeFijacionRow {
+  _state?: SaveState;
+}
+
+const AUTOSAVE_MS = 600;
+
+interface Props {
+  companyId: string;
+}
+
+const fmtCop = (v: number): string =>
+  new Intl.NumberFormat('es-CO', { minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(Math.round(v));
+
+// USD lleva 0 o 2 decimales segun magnitud
+const fmtUsd = (v: number): string =>
+  new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(Math.round(v));
+
+const fmtCents = (v: number): string => v.toFixed(2);
+const fmtFactor = (v: number): string => v.toFixed(4);
+
+function emptyRow(companyId: string): Omit<Row, 'id' | 'created_at' | 'updated_at'> {
+  return {
+    company_id: companyId,
+    sacos_fijados: 0,
+    kg: 0,
+    fijacion_ny: 0,
+    prima: 0,
+    fijacion_cop: 0,
+    fecha_fijacion: new Date().toISOString().slice(0, 10),
+    moneda: 'COP',
+  };
+}
+
+export default function BlotterCafe({ companyId }: Props) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [factor, setFactor] = useState<number>(1.5432);
+  const [loading, setLoading] = useState(false);
+  const [savingFactor, setSavingFactor] = useState(false);
+
+  // Auto-save por fila con debounce. rowsRef mantiene el snapshot mas
+  // reciente para que el timer no quede pegado a un closure viejo.
+  const saveTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const rowsRef = useRef<Row[]>([]);
+  useEffect(() => { rowsRef.current = rows; }, [rows]);
+
+  useEffect(() => () => {
+    saveTimers.current.forEach((t) => clearTimeout(t));
+    saveTimers.current.clear();
+  }, []);
+
+  // Load on mount / company change
+  useEffect(() => {
+    if (!companyId) return;
+    setLoading(true);
+    (async () => {
+      try {
+        const [fijaciones, fct] = await Promise.all([
+          fetchCafeFijaciones(companyId),
+          fetchCafeFactorConversion(companyId),
+        ]);
+        setRows(fijaciones);
+        setFactor(fct);
+      } catch (e) {
+        toast.error((e as Error)?.message || 'Error cargando blotter cafe');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [companyId]);
+
+  // Calc derived per row (soporta COP y USD)
+  //
+  // Comun:
+  //   precio_final         = NY + prima                    [cents/lb]
+  //   precio_por_saco_USD  = precio_final × factor          (factor 1.5432 = lb/saco / 100)
+  //   precio_por_saco_COP  = precio_por_saco_USD × TRM
+  //
+  // Segun moneda:
+  //   COP -> precio_por_saco / total se muestran en COP
+  //   USD -> precio_por_saco / total se muestran en USD
+  //
+  // Para footer (2 totales), cada fila aporta a AMBAS columnas:
+  //   - Si row.moneda='COP': total_native = total_COP, total_other = total_COP/TRM
+  //   - Si row.moneda='USD': total_native = total_USD, total_other = total_USD×TRM
+  const computed = useMemo(() => rows.map((r) => {
+    const precioFinal = (r.fijacion_ny ?? 0) + (r.prima ?? 0);
+    const trm = r.fijacion_cop ?? 0;
+    const precioPorSacoUsd = precioFinal * factor;
+    const precioPorSacoCop = precioPorSacoUsd * trm;
+    const precioCopKg = r.kg > 0 ? (precioPorSacoCop * r.sacos_fijados) / r.kg : 0;
+    const precioUsdKg = r.kg > 0 ? (precioPorSacoUsd * r.sacos_fijados) / r.kg : 0;
+    const totalCop = precioPorSacoCop * r.sacos_fijados;
+    const totalUsd = precioPorSacoUsd * r.sacos_fijados;
+    return {
+      row: r,
+      precioFinal,
+      precioPorSacoCop,
+      precioPorSacoUsd,
+      precioCopKg,
+      precioUsdKg,
+      totalCop,
+      totalUsd,
+    };
+  }), [rows, factor]);
+
+  // Totals: 2 sumatorias (COP nativos + USD convertidos a COP via TRM por fila, viceversa)
+  const totals = useMemo(() => {
+    let totalCop = 0;
+    let totalUsd = 0;
+    for (const c of computed) {
+      if (c.row.moneda === 'USD') {
+        // fila en USD: total nativo USD, COP equivalente via TRM de la fila
+        totalUsd += c.totalUsd;
+        totalCop += c.totalUsd * (c.row.fijacion_cop ?? 0);
+      } else {
+        // fila en COP: total nativo COP, USD equivalente via TRM de la fila
+        totalCop += c.totalCop;
+        if (c.row.fijacion_cop && c.row.fijacion_cop > 0) {
+          totalUsd += c.totalCop / c.row.fijacion_cop;
+        }
+      }
+    }
+    return {
+      sacos: computed.reduce((s, c) => s + (c.row.sacos_fijados ?? 0), 0),
+      kg: computed.reduce((s, c) => s + (c.row.kg ?? 0), 0),
+      totalCop,
+      totalUsd,
+    };
+  }, [computed]);
+
+  // Commit row to Supabase (forzado, sin filtrar por _dirty: el debounce
+  // ya garantiza que solo se llama cuando hubo cambios).
+  const commitRow = useCallback(async (id: string) => {
+    const r = rowsRef.current.find((x) => x.id === id);
+    if (!r) return;
+    setRows((prev) => prev.map((x) => (x.id === id ? { ...x, _state: 'saving' } : x)));
+    try {
+      await updateCafeFijacion(id, {
+        sacos_fijados: r.sacos_fijados,
+        kg: r.kg,
+        fijacion_ny: r.fijacion_ny,
+        prima: r.prima,
+        fijacion_cop: r.fijacion_cop,
+        fecha_fijacion: r.fecha_fijacion,
+        moneda: r.moneda,
+      });
+      setRows((prev) => prev.map((x) => (x.id === id ? { ...x, _state: 'saved' } : x)));
+      setTimeout(() => {
+        setRows((prev) => prev.map((x) => (x.id === id && x._state === 'saved' ? { ...x, _state: 'idle' } : x)));
+      }, 1500);
+    } catch (e) {
+      setRows((prev) => prev.map((x) => (x.id === id ? { ...x, _state: 'error' } : x)));
+      toast.error((e as Error)?.message || 'Error guardando fila');
+    }
+  }, []);
+
+  // Auto-save con debounce: cualquier cambio reinicia el timer; al pasar
+  // 600ms sin tocar, persiste. Esto cubre el caso "el usuario refresca
+  // sin hacer blur" donde antes se perdian los cambios.
+  const scheduleSave = useCallback((id: string) => {
+    const existing = saveTimers.current.get(id);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      saveTimers.current.delete(id);
+      commitRow(id);
+    }, AUTOSAVE_MS);
+    saveTimers.current.set(id, timer);
+  }, [commitRow]);
+
+  // Patch row state locally + agenda auto-save
+  const patchRow = useCallback((id: string, patch: Partial<Row>) => {
+    setRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch, _state: 'dirty' } : r)));
+    scheduleSave(id);
+  }, [scheduleSave]);
+
+  // Flush pendiente (cuando el usuario hace blur, no esperamos el debounce)
+  const flushRow = useCallback((id: string) => {
+    const existing = saveTimers.current.get(id);
+    if (existing) {
+      clearTimeout(existing);
+      saveTimers.current.delete(id);
+      commitRow(id);
+    }
+  }, [commitRow]);
+
+  // Add new row
+  const handleAdd = useCallback(async () => {
+    try {
+      const newRow = await insertCafeFijacion(emptyRow(companyId));
+      setRows((prev) => [...prev, { ...newRow, _state: 'idle' }]);
+    } catch (e) {
+      toast.error((e as Error)?.message || 'Error agregando fila');
+    }
+  }, [companyId]);
+
+  // Delete row
+  const handleDelete = useCallback(async (id: string) => {
+    if (!confirm('¿Borrar esta fijacion?')) return;
+    try {
+      await deleteCafeFijacion(id);
+      setRows((prev) => prev.filter((r) => r.id !== id));
+    } catch (e) {
+      toast.error((e as Error)?.message || 'Error borrando fila');
+    }
+  }, []);
+
+  // Save factor on blur
+  const handleFactorBlur = useCallback(async () => {
+    setSavingFactor(true);
+    try {
+      await updateCafeFactorConversion(companyId, factor);
+      toast.success(`Factor de conversion guardado: ${fmtFactor(factor)}`);
+    } catch (e) {
+      toast.error((e as Error)?.message || 'Error guardando factor');
+    } finally {
+      setSavingFactor(false);
+    }
+  }, [companyId, factor]);
+
+  return (
+    <div className="mt-4 p-3" style={{ background: '#fefefe', border: '1px solid #e2e8f0', borderRadius: 6 }}>
+      <div className="d-flex align-items-center justify-content-between mb-3">
+        <h6 className="mb-0" style={{ color: '#7c3aed', fontWeight: 600 }}>
+          ☕ Blotter Fijaciones Cafe
+        </h6>
+        <div className="d-flex align-items-center gap-2">
+          <Form.Label className="mb-0 small text-muted">Factor de conversion:</Form.Label>
+          <Form.Control
+            type="number"
+            step="0.0001"
+            size="sm"
+            value={factor}
+            onChange={(e) => setFactor(Number(e.target.value) || 0)}
+            onBlur={handleFactorBlur}
+            style={{ width: 100 }}
+            disabled={savingFactor}
+          />
+          <span className="text-muted small" style={{ minWidth: 80 }}>
+            {savingFactor ? <Spinner size="sm" /> : '(lb/saco / 100)'}
+          </span>
+          <Button variant="outline-primary" size="sm" onClick={handleAdd}>
+            + Nueva fijacion
+          </Button>
+        </div>
+      </div>
+
+      {loading && (
+        <div className="text-center py-3">
+          <Spinner animation="border" size="sm" /> Cargando blotter...
+        </div>
+      )}
+
+      {!loading && rows.length === 0 && (
+        <div className="text-center text-muted py-4">
+          No hay fijaciones registradas. Haz clic en &ldquo;+ Nueva fijacion&rdquo; para comenzar.
+        </div>
+      )}
+
+      {!loading && rows.length > 0 && (
+        <div className="table-responsive">
+          <Table
+            size="sm"
+            striped
+            hover
+            className="align-middle small mb-0"
+            style={{
+              tableLayout: 'fixed',
+              fontVariantNumeric: 'tabular-nums',
+            }}
+          >
+            <colgroup>
+              <col style={{ width: 130 }} />{/* Fecha */}
+              <col style={{ width: 70 }} />{/* Moneda */}
+              <col style={{ width: 75 }} />{/* Sacos */}
+              <col style={{ width: 90 }} />{/* KG */}
+              <col style={{ width: 95 }} />{/* Fij NY */}
+              <col style={{ width: 85 }} />{/* Prima */}
+              <col style={{ width: 105 }} />{/* Precio Final */}
+              <col style={{ width: 100 }} />{/* TRM */}
+              <col style={{ width: 130 }} />{/* Precio/KG */}
+              <col style={{ width: 130 }} />{/* Precio/Saco */}
+              <col style={{ width: 150 }} />{/* Total */}
+              <col style={{ width: 70 }} />{/* Estado + X */}
+            </colgroup>
+            <thead style={{ background: '#f8fafc' }}>
+              <tr style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', color: '#475569' }}>
+                <th style={{ padding: '8px 10px' }}>Fecha</th>
+                <th className="text-center" style={{ padding: '8px 6px' }}>Moneda</th>
+                <th className="text-end" style={{ padding: '8px 10px' }}>Sacos</th>
+                <th className="text-end" style={{ padding: '8px 10px' }}>KG</th>
+                <th className="text-end" style={{ padding: '8px 10px' }}>Fij. NY <span style={{ textTransform: 'none', fontWeight: 400 }}>(¢/lb)</span></th>
+                <th className="text-end" style={{ padding: '8px 10px' }}>Prima <span style={{ textTransform: 'none', fontWeight: 400 }}>(¢/lb)</span></th>
+                <th className="text-end" style={{ padding: '8px 10px', background: '#f1f5f9' }}>P. Final <span style={{ textTransform: 'none', fontWeight: 400 }}>(¢/lb)</span></th>
+                <th className="text-end" style={{ padding: '8px 10px' }}>TRM</th>
+                <th className="text-end" style={{ padding: '8px 10px', background: '#f1f5f9' }}>Precio / KG</th>
+                <th className="text-end" style={{ padding: '8px 10px', background: '#f1f5f9' }}>Precio / Saco</th>
+                <th className="text-end" style={{ padding: '8px 10px', background: '#f1f5f9' }}>Total</th>
+                <th style={{ padding: '8px 4px' }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {computed.map((c) => {
+                const isUsd = c.row.moneda === 'USD';
+                const ppKg = isUsd ? c.precioUsdKg : c.precioCopKg;
+                const ppSaco = isUsd ? c.precioPorSacoUsd : c.precioPorSacoCop;
+                const total = isUsd ? c.totalUsd : c.totalCop;
+                const monedaPrefix = isUsd ? '$' : '$';      // ambos usan $; el badge dice cual
+                return (
+                <tr key={c.row.id}>
+                  <td style={{ padding: '4px 6px' }}>
+                    <Form.Control
+                      type="date"
+                      size="sm"
+                      value={c.row.fecha_fijacion}
+                      onChange={(e) => patchRow(c.row.id, { fecha_fijacion: e.target.value })}
+                      onBlur={() => flushRow(c.row.id)}
+                      className="w-100"
+                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                    />
+                  </td>
+                  <td style={{ padding: '4px 6px' }}>
+                    <Form.Select
+                      size="sm"
+                      value={c.row.moneda}
+                      onChange={(e) => {
+                        // patchRow agenda auto-save con debounce (600ms);
+                        // como el select no dispara blur, dejamos al timer.
+                        patchRow(c.row.id, { moneda: e.target.value as 'COP' | 'USD' });
+                      }}
+                      className="w-100"
+                      style={{
+                        fontWeight: 600,
+                        color: isUsd ? '#1d4ed8' : '#15803d',
+                        background: isUsd ? '#dbeafe' : '#dcfce7',
+                      }}
+                    >
+                      <option value="COP">COP</option>
+                      <option value="USD">USD</option>
+                    </Form.Select>
+                  </td>
+                  <td style={{ padding: '4px 6px' }}>
+                    <Form.Control
+                      type="number"
+                      size="sm"
+                      className="text-end w-100"
+                      value={c.row.sacos_fijados}
+                      onChange={(e) => patchRow(c.row.id, { sacos_fijados: Number(e.target.value) || 0 })}
+                      onBlur={() => flushRow(c.row.id)}
+                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                    />
+                  </td>
+                  <td style={{ padding: '4px 6px' }}>
+                    <Form.Control
+                      type="number"
+                      step="0.01"
+                      size="sm"
+                      className="text-end w-100"
+                      value={c.row.kg}
+                      onChange={(e) => patchRow(c.row.id, { kg: Number(e.target.value) || 0 })}
+                      onBlur={() => flushRow(c.row.id)}
+                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                    />
+                  </td>
+                  <td style={{ padding: '4px 6px' }}>
+                    <Form.Control
+                      type="number"
+                      step="0.01"
+                      size="sm"
+                      className="text-end w-100"
+                      value={c.row.fijacion_ny}
+                      onChange={(e) => patchRow(c.row.id, { fijacion_ny: Number(e.target.value) || 0 })}
+                      onBlur={() => flushRow(c.row.id)}
+                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                    />
+                  </td>
+                  <td style={{ padding: '4px 6px' }}>
+                    <Form.Control
+                      type="number"
+                      step="0.01"
+                      size="sm"
+                      className="text-end w-100"
+                      value={c.row.prima}
+                      onChange={(e) => patchRow(c.row.id, { prima: Number(e.target.value) || 0 })}
+                      onBlur={() => flushRow(c.row.id)}
+                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                    />
+                  </td>
+                  <td className="text-end" style={{ background: '#f1f5f9', padding: '4px 12px', fontVariantNumeric: 'tabular-nums' }}>
+                    {fmtCents(c.precioFinal)}
+                  </td>
+                  <td style={{ padding: '4px 6px' }}>
+                    <Form.Control
+                      type="number"
+                      step="0.01"
+                      size="sm"
+                      className="text-end w-100"
+                      value={c.row.fijacion_cop}
+                      onChange={(e) => patchRow(c.row.id, { fijacion_cop: Number(e.target.value) || 0 })}
+                      onBlur={() => flushRow(c.row.id)}
+                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                    />
+                  </td>
+                  <td className="text-end" style={{ background: '#f1f5f9', padding: '4px 12px', fontVariantNumeric: 'tabular-nums' }}>
+                    {monedaPrefix}{isUsd ? fmtUsd(ppKg) : fmtCop(ppKg)}
+                  </td>
+                  <td className="text-end" style={{ background: '#f1f5f9', padding: '4px 12px', fontVariantNumeric: 'tabular-nums' }}>
+                    {monedaPrefix}{isUsd ? fmtUsd(ppSaco) : fmtCop(ppSaco)}
+                  </td>
+                  <td className="text-end fw-bold" style={{ background: '#f1f5f9', color: isUsd ? '#1d4ed8' : '#15803d', padding: '4px 12px', fontVariantNumeric: 'tabular-nums' }}>
+                    {monedaPrefix}{isUsd ? fmtUsd(total) : fmtCop(total)}
+                  </td>
+                  <td style={{ padding: '4px 4px', textAlign: 'center', whiteSpace: 'nowrap' }}>
+                    <span
+                      style={{
+                        display: 'inline-block',
+                        width: 14,
+                        fontSize: '0.85rem',
+                        marginRight: 4,
+                        color:
+                          c.row._state === 'saved' ? '#15803d'
+                            : c.row._state === 'saving' ? '#0ea5e9'
+                              : c.row._state === 'dirty' ? '#d97706'
+                                : c.row._state === 'error' ? '#b91c1c'
+                                  : 'transparent',
+                      }}
+                      title={
+                        c.row._state === 'saved' ? 'Guardado'
+                          : c.row._state === 'saving' ? 'Guardando...'
+                            : c.row._state === 'dirty' ? 'Pendiente — guardando en 0.6s'
+                              : c.row._state === 'error' ? 'Error al guardar'
+                                : ''
+                      }
+                    >
+                      {c.row._state === 'saved' ? '✓'
+                        : c.row._state === 'saving' ? '⟳'
+                          : c.row._state === 'dirty' ? '●'
+                            : c.row._state === 'error' ? '!'
+                              : ''}
+                    </span>
+                    <Button
+                      variant="link"
+                      size="sm"
+                      onClick={() => handleDelete(c.row.id)}
+                      title="Borrar"
+                      className="p-0 text-danger"
+                      style={{ lineHeight: 1, fontSize: '1.1rem' }}
+                    >
+                      &times;
+                    </Button>
+                  </td>
+                </tr>
+                );
+              })}
+            </tbody>
+            <tfoot>
+              {/* 2 filas de totales: COP y USD, cada una expresando TODAS las
+                  fijaciones en esa moneda (las de otra moneda convertidas via
+                  TRM de cada fila). */}
+              <tr style={{ background: '#f1f5f9', fontWeight: 600, borderTop: '2px solid #cbd5e1' }}>
+                <td style={{ padding: '8px 10px', textTransform: 'uppercase', letterSpacing: '0.04em', fontSize: '0.72rem', color: '#475569' }}>Total <span style={{ color: '#15803d' }}>COP</span></td>
+                <td />
+                <td className="text-end" style={{ padding: '8px 12px', fontVariantNumeric: 'tabular-nums' }}>{fmtCop(totals.sacos)}</td>
+                <td className="text-end" style={{ padding: '8px 12px', fontVariantNumeric: 'tabular-nums' }}>{fmtCop(totals.kg)}</td>
+                <td colSpan={6} />
+                <td className="text-end" style={{ color: '#15803d', padding: '8px 12px', fontVariantNumeric: 'tabular-nums', fontSize: '0.95rem' }}>${fmtCop(totals.totalCop)}</td>
+                <td />
+              </tr>
+              <tr style={{ background: '#f8fafc', fontWeight: 600, borderTop: '1px solid #e2e8f0' }}>
+                <td style={{ padding: '8px 10px', textTransform: 'uppercase', letterSpacing: '0.04em', fontSize: '0.72rem', color: '#475569' }}>Total <span style={{ color: '#1d4ed8' }}>USD</span></td>
+                <td colSpan={9} />
+                <td className="text-end" style={{ color: '#1d4ed8', padding: '8px 12px', fontVariantNumeric: 'tabular-nums', fontSize: '0.95rem' }}>${fmtUsd(totals.totalUsd)}</td>
+                <td />
+              </tr>
+            </tfoot>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/risk/BlotterCompraCafe.tsx
+++ b/src/components/risk/BlotterCompraCafe.tsx
@@ -1,0 +1,508 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+/**
+ * Blotter de compras de cafe. Tabla CRUD que se renderiza dentro del
+ * tab Benchmark de /risk-management cuando la empresa tiene CAFE.
+ *
+ * Cada fila representa una compra: kg de cafe humedo + precio pagado por @.
+ * El cafe humedo se convierte a cafe verde (vendible) via factor_humedo,
+ * y solo el cafe verde se usa para el calculo de contratos y exposicion.
+ *
+ * Calculos derivados (en pantalla, no se almacenan):
+ *   kg_verde               = total_kg × factor_humedo            (default 0.1434)
+ *   total_at_compradas     = total_kg / kg_per_at                 (default 60)
+ *   total_valor_compra     = total_at_compradas × valor_compra_at (COP)
+ *   contratos_kc           = kg_verde × 2.2046 / lbs_por_contrato (default 37,500)
+ *   exposicion_usd         = contratos_kc × lbs_por_contrato × precio_kc_cents / 100
+ *
+ * Inputs globales (en risk_company_config, editables al top del blotter):
+ *   - kg_per_at             (default 60)      kg por @ de compra
+ *   - lbs_por_contrato_kc   (default 37,500)  lbs por contrato Coffee C
+ *   - factor_humedo         (default 0.1434)  conversion cafe humedo -> verde
+ *
+ * Precio KC actual: se trae del front contract en risk_prices (CAFE),
+ * actualizado por collectors.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Table, Form, Button, Spinner } from 'react-bootstrap';
+import { toast } from 'react-toastify';
+
+import {
+  fetchCafeCompras,
+  insertCafeCompra,
+  updateCafeCompra,
+  deleteCafeCompra,
+  fetchCafeCompraGlobals,
+  updateCafeCompraGlobals,
+  CafeCompraRow,
+} from 'src/lib/risk/supabaseRisk';
+
+const LB_PER_KG = 2.20462;
+
+type SaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
+
+interface Row extends CafeCompraRow {
+  _state?: SaveState;
+}
+
+const AUTOSAVE_MS = 600;
+
+interface Props {
+  companyId: string;
+  // Precio actual de CAFE (cents/lb) — viene de benchmarkFactors.factors.CAFE.price_end
+  // del page padre, que es el mismo dato ya cargado para la tabla Benchmark.
+  // Evita un fetch extra que puede estar bloqueado por RLS u otra cosa.
+  precioKcCents?: number | null;
+  precioKcDate?: string | null;
+}
+
+const fmtCop = (v: number): string =>
+  new Intl.NumberFormat('es-CO', { minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(Math.round(v));
+
+const fmtKg = (v: number): string =>
+  new Intl.NumberFormat('es-CO', { minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(Math.round(v));
+
+const fmtNum2 = (v: number): string => v.toFixed(2);
+const fmtNum4 = (v: number): string => v.toFixed(4);
+
+// Formato con signo explicito: +0.0718 (long) / -0.0718 (short).
+// Cero se muestra como 0 sin signo (para no contaminar visualmente).
+const fmtSignedNum4 = (v: number): string => {
+  if (v === 0) return '0.0000';
+  return (v > 0 ? '+' : '') + v.toFixed(4);
+};
+const fmtSignedCop = (v: number): string => {
+  if (v === 0) return '$0';
+  const abs = new Intl.NumberFormat('es-CO').format(Math.round(Math.abs(v)));
+  return (v > 0 ? '+$' : '−$') + abs;
+};
+
+function isoWeek(dateStr: string): number {
+  // ISO week number from YYYY-MM-DD
+  if (!dateStr) return 0;
+  const d = new Date(dateStr + 'T12:00:00');
+  const target = new Date(d.valueOf());
+  const dayNr = (d.getDay() + 6) % 7; // Mon=0
+  target.setDate(target.getDate() - dayNr + 3);
+  const firstThursday = target.valueOf();
+  target.setMonth(0, 1);
+  if (target.getDay() !== 4) {
+    target.setMonth(0, 1 + ((4 - target.getDay()) + 7) % 7);
+  }
+  return 1 + Math.ceil((firstThursday - target.valueOf()) / 604800000);
+}
+
+function emptyRow(companyId: string): Omit<Row, 'id' | 'created_at' | 'updated_at'> {
+  return {
+    company_id: companyId,
+    fecha_compra: new Date().toISOString().slice(0, 10),
+    total_kg: 0,
+    valor_compra_at: 0,
+    factor_humedo: 0.1431,
+  };
+}
+
+export default function BlotterCompraCafe({ companyId, precioKcCents, precioKcDate }: Props) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [kgPerAt, setKgPerAt] = useState<number>(60);
+  const [lbsPorContrato, setLbsPorContrato] = useState<number>(37500);
+  const [loading, setLoading] = useState(false);
+  const [savingGlobals, setSavingGlobals] = useState(false);
+
+  // Timers de auto-save por fila. Cuando el usuario edita un input, debounce
+  // 600ms y luego persiste. Si vuelve a editar antes, se reinicia el timer.
+  const saveTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  // Latest row snapshots para que el timer guarde el estado mas reciente sin
+  // depender de closures sobre `rows`.
+  const rowsRef = useRef<Row[]>([]);
+  useEffect(() => { rowsRef.current = rows; }, [rows]);
+
+  useEffect(() => () => {
+    // Cleanup: clear all pending timers on unmount
+    saveTimers.current.forEach((t) => clearTimeout(t));
+    saveTimers.current.clear();
+  }, []);
+
+  // Precio actual KC — viene como prop del page padre (que ya lo carga via
+  // benchmarkFactors). Si no esta, se muestra "no disponible".
+  const precioKc = useMemo(
+    () => (precioKcCents != null ? { price: precioKcCents, date: precioKcDate ?? '' } : null),
+    [precioKcCents, precioKcDate],
+  );
+
+  // Initial load (compras + globals). Las dos cargas son INDEPENDIENTES:
+  // si falla la de globals, la de compras debe seguir mostrandose.
+  // Antes usabamos Promise.all -> un error en cualquiera tumbaba ambas.
+  useEffect(() => {
+    if (!companyId) return;
+    setLoading(true);
+    let comprasErr: string | null = null;
+    let globalsErr: string | null = null;
+    (async () => {
+      try {
+        const compras = await fetchCafeCompras(companyId);
+        setRows(compras);
+      } catch (e) {
+        comprasErr = (e as Error)?.message || 'Error cargando compras';
+      }
+      try {
+        const globals = await fetchCafeCompraGlobals(companyId);
+        setKgPerAt(globals.kg_per_at);
+        setLbsPorContrato(globals.lbs_per_contrato_kc);
+      } catch (e) {
+        globalsErr = (e as Error)?.message || 'Error cargando globals';
+      }
+      if (comprasErr) toast.error(comprasErr);
+      if (globalsErr) toast.warning(`Globals: ${globalsErr} (usando defaults)`);
+      setLoading(false);
+    })();
+  }, [companyId]);
+
+  // Calc derived per row — factor_humedo ahora es per-fila
+  const computed = useMemo(() => rows.map((r) => {
+    const factor = r.factor_humedo ?? 0.1431;
+    const kgVerde = r.total_kg * factor;
+    const totalAtCompradas = kgPerAt > 0 ? r.total_kg / kgPerAt : 0;
+    const totalValorCompra = totalAtCompradas * r.valor_compra_at;
+    // Hedging se calcula con cafe VERDE (no total kg humedo)
+    const contratosKc = lbsPorContrato > 0 ? (kgVerde * LB_PER_KG) / lbsPorContrato : 0;
+    const exposicionUsd = precioKc?.price != null
+      ? contratosKc * lbsPorContrato * precioKc.price / 100
+      : 0;
+    return {
+      row: r,
+      semana: isoWeek(r.fecha_compra),
+      kgVerde,
+      totalAtCompradas,
+      totalValorCompra,
+      contratosKc,
+      exposicionUsd,
+    };
+  }), [rows, kgPerAt, lbsPorContrato, precioKc]);
+
+  // Totals
+  const totals = useMemo(() => ({
+    totalKg: rows.reduce((s, r) => s + (r.total_kg ?? 0), 0),
+    kgVerde: computed.reduce((s, c) => s + c.kgVerde, 0),
+    totalAtCompradas: computed.reduce((s, c) => s + c.totalAtCompradas, 0),
+    totalValorCompra: computed.reduce((s, c) => s + c.totalValorCompra, 0),
+    contratosKc: computed.reduce((s, c) => s + c.contratosKc, 0),
+    exposicionUsd: computed.reduce((s, c) => s + c.exposicionUsd, 0),
+  }), [rows, computed]);
+
+  const commitRow = useCallback(async (id: string) => {
+    const r = rowsRef.current.find((x) => x.id === id);
+    if (!r) return;
+    setRows((prev) => prev.map((x) => (x.id === id ? { ...x, _state: 'saving' } : x)));
+    try {
+      await updateCafeCompra(id, {
+        fecha_compra: r.fecha_compra,
+        total_kg: r.total_kg,
+        valor_compra_at: r.valor_compra_at,
+        factor_humedo: r.factor_humedo,
+      });
+      setRows((prev) => prev.map((x) => (x.id === id ? { ...x, _state: 'saved' } : x)));
+      // El badge "Guardado ✓" se oculta despues de 1.5s
+      setTimeout(() => {
+        setRows((prev) => prev.map((x) => (x.id === id && x._state === 'saved' ? { ...x, _state: 'idle' } : x)));
+      }, 1500);
+    } catch (e) {
+      setRows((prev) => prev.map((x) => (x.id === id ? { ...x, _state: 'error' } : x)));
+      toast.error((e as Error)?.message || 'Error guardando fila');
+    }
+  }, []);
+
+  // Auto-save con debounce. Cada cambio resetea el timer; al terminar de
+  // editar (600ms sin tocar), persiste a Supabase. Asi no se pierde nada
+  // aunque el usuario refresque sin hacer blur.
+  const scheduleSave = useCallback((id: string) => {
+    const existing = saveTimers.current.get(id);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      saveTimers.current.delete(id);
+      commitRow(id);
+    }, AUTOSAVE_MS);
+    saveTimers.current.set(id, timer);
+  }, [commitRow]);
+
+  const patchRow = useCallback((id: string, patch: Partial<Row>) => {
+    setRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch, _state: 'dirty' } : r)));
+    scheduleSave(id);
+  }, [scheduleSave]);
+
+  // Si hay save pendiente y el usuario hace blur, persiste inmediatamente
+  // (no espera el debounce). Asi sigue siendo robusto en el caso clasico.
+  const flushRow = useCallback((id: string) => {
+    const existing = saveTimers.current.get(id);
+    if (existing) {
+      clearTimeout(existing);
+      saveTimers.current.delete(id);
+      commitRow(id);
+    }
+  }, [commitRow]);
+
+  const handleAdd = useCallback(async () => {
+    try {
+      const newRow = await insertCafeCompra(emptyRow(companyId));
+      setRows((prev) => [...prev, { ...newRow, _state: 'idle' }]);
+    } catch (e) {
+      toast.error((e as Error)?.message || 'Error agregando fila');
+    }
+  }, [companyId]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    if (!confirm('¿Borrar esta compra?')) return;
+    try {
+      await deleteCafeCompra(id);
+      setRows((prev) => prev.filter((r) => r.id !== id));
+    } catch (e) {
+      toast.error((e as Error)?.message || 'Error borrando fila');
+    }
+  }, []);
+
+  const handleGlobalsBlur = useCallback(async () => {
+    setSavingGlobals(true);
+    try {
+      await updateCafeCompraGlobals(companyId, {
+        kg_per_at: kgPerAt,
+        lbs_per_contrato_kc: lbsPorContrato,
+      });
+    } catch (e) {
+      toast.error((e as Error)?.message || 'Error guardando parametros globales');
+    } finally {
+      setSavingGlobals(false);
+    }
+  }, [companyId, kgPerAt, lbsPorContrato]);
+
+  return (
+    <div className="mt-4 p-3" style={{ background: '#fefefe', border: '1px solid #e2e8f0', borderRadius: 6 }}>
+      <div className="d-flex flex-wrap align-items-center justify-content-between mb-3 gap-2">
+        <h6 className="mb-0" style={{ color: '#7c3aed', fontWeight: 600 }}>
+          ☕ Blotter Compras Café
+        </h6>
+        <div className="d-flex flex-wrap align-items-center gap-3">
+          <div className="d-flex align-items-center gap-2">
+            <Form.Label className="mb-0 small text-muted">Kg / @:</Form.Label>
+            <Form.Control
+              type="number"
+              step="0.1"
+              size="sm"
+              value={kgPerAt}
+              onChange={(e) => setKgPerAt(Number(e.target.value) || 0)}
+              onBlur={handleGlobalsBlur}
+              style={{ width: 70, fontVariantNumeric: 'tabular-nums' }}
+              disabled={savingGlobals}
+            />
+          </div>
+          <div className="d-flex align-items-center gap-2">
+            <Form.Label className="mb-0 small text-muted">Lbs / KC:</Form.Label>
+            <Form.Control
+              type="number"
+              step="100"
+              size="sm"
+              value={lbsPorContrato}
+              onChange={(e) => setLbsPorContrato(Number(e.target.value) || 0)}
+              onBlur={handleGlobalsBlur}
+              style={{ width: 85, fontVariantNumeric: 'tabular-nums' }}
+              disabled={savingGlobals}
+            />
+          </div>
+          <div className="text-muted small" style={{ minWidth: 150 }}>
+            {precioKc ? (
+              <>
+                Precio KC: <strong style={{ color: '#1e293b' }}>{fmtNum2(precioKc.price)}¢/lb</strong>{' '}
+                <span className="text-muted">({precioKc.date})</span>
+              </>
+            ) : (
+              <span className="text-warning">Precio KC no disponible</span>
+            )}
+          </div>
+          <Button variant="outline-primary" size="sm" onClick={handleAdd}>
+            + Nueva compra
+          </Button>
+        </div>
+      </div>
+
+      {loading && (
+        <div className="text-center py-3">
+          <Spinner animation="border" size="sm" /> Cargando blotter...
+        </div>
+      )}
+
+      {!loading && rows.length === 0 && (
+        <div className="text-center text-muted py-4">
+          No hay compras registradas. Haz clic en &ldquo;+ Nueva compra&rdquo; para comenzar.
+        </div>
+      )}
+
+      {!loading && rows.length > 0 && (
+        <div className="table-responsive">
+          <Table
+            size="sm"
+            striped
+            hover
+            className="align-middle small mb-0"
+            style={{ tableLayout: 'fixed', fontVariantNumeric: 'tabular-nums' }}
+          >
+            <colgroup>
+              <col style={{ width: 130 }} />{/* Fecha */}
+              <col style={{ width: 55 }} />{/* Sem */}
+              <col style={{ width: 110 }} />{/* Total Kg */}
+              <col style={{ width: 85 }} />{/* Factor */}
+              <col style={{ width: 110 }} />{/* Kg × Factor */}
+              <col style={{ width: 120 }} />{/* Valor @ */}
+              <col style={{ width: 95 }} />{/* @ Compradas */}
+              <col style={{ width: 150 }} />{/* Total Compra */}
+              <col style={{ width: 95 }} />{/* # Ctos KC */}
+              <col style={{ width: 150 }} />{/* Exp USD */}
+              <col style={{ width: 70 }} />{/* Estado + X */}
+            </colgroup>
+            <thead style={{ background: '#f8fafc' }}>
+              <tr style={{ fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.04em', color: '#475569' }}>
+                <th style={{ padding: '8px 8px' }}>Fecha</th>
+                <th className="text-end" style={{ padding: '8px 6px' }}>Sem</th>
+                <th className="text-end" style={{ padding: '8px 10px' }}>Total Kg <span style={{ textTransform: 'none', fontWeight: 400 }}>(húmedo)</span></th>
+                <th className="text-end" style={{ padding: '8px 10px' }} title="Factor de conversion humedo a verde (editable per fila)">Factor <span style={{ textTransform: 'none', fontWeight: 400 }}>conv.</span></th>
+                <th className="text-end" style={{ padding: '8px 10px', background: '#f1f5f9' }}>Kg × Factor <span style={{ textTransform: 'none', fontWeight: 400 }}>(verde)</span></th>
+                <th className="text-end" style={{ padding: '8px 10px' }}>Valor @ <span style={{ textTransform: 'none', fontWeight: 400 }}>(COP)</span></th>
+                <th className="text-end" style={{ padding: '8px 10px', background: '#f1f5f9' }}>@ Compradas</th>
+                <th className="text-end" style={{ padding: '8px 10px', background: '#dcfce7', color: '#15803d' }}>Total Compra <span style={{ textTransform: 'none', fontWeight: 400 }}>(COP)</span></th>
+                <th className="text-end" style={{ padding: '8px 10px', background: '#fef3c7', color: '#854d0e' }} title="+ = LONG café (compraste, tienes inventario)">
+                  # Ctos KC <span style={{ textTransform: 'none', fontWeight: 400 }}>(café)</span>
+                </th>
+                <th className="text-end" style={{ padding: '8px 10px', background: '#fef3c7', color: '#854d0e' }} title="+ = LONG USD (el inventario vale USD)">
+                  Exp. USD
+                </th>
+                <th style={{ padding: '8px 4px' }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {computed.map((c) => (
+                <tr key={c.row.id}>
+                  <td style={{ padding: '4px 6px' }}>
+                    <Form.Control
+                      type="date"
+                      size="sm"
+                      value={c.row.fecha_compra}
+                      onChange={(e) => patchRow(c.row.id, { fecha_compra: e.target.value })}
+                      onBlur={() => flushRow(c.row.id)}
+                      className="w-100"
+                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                    />
+                  </td>
+                  <td className="text-end text-muted" style={{ padding: '4px 6px' }}>{c.semana || '—'}</td>
+                  <td style={{ padding: '4px 6px' }}>
+                    <Form.Control
+                      type="number"
+                      step="1"
+                      size="sm"
+                      className="text-end w-100"
+                      value={c.row.total_kg}
+                      onChange={(e) => patchRow(c.row.id, { total_kg: Number(e.target.value) || 0 })}
+                      onBlur={() => flushRow(c.row.id)}
+                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                    />
+                  </td>
+                  <td style={{ padding: '4px 6px' }}>
+                    <Form.Control
+                      type="number"
+                      step="0.0001"
+                      min="0"
+                      max="1"
+                      size="sm"
+                      className="text-end w-100"
+                      value={c.row.factor_humedo ?? 0.1431}
+                      onChange={(e) => patchRow(c.row.id, { factor_humedo: Number(e.target.value) || 0 })}
+                      onBlur={() => flushRow(c.row.id)}
+                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                      title="Factor de conversion humedo a verde (default 0.1431)"
+                    />
+                  </td>
+                  <td className="text-end" style={{ background: '#f1f5f9', padding: '4px 12px' }}>
+                    {fmtKg(c.kgVerde)}
+                  </td>
+                  <td style={{ padding: '4px 6px' }}>
+                    <Form.Control
+                      type="number"
+                      step="100"
+                      size="sm"
+                      className="text-end w-100"
+                      value={c.row.valor_compra_at}
+                      onChange={(e) => patchRow(c.row.id, { valor_compra_at: Number(e.target.value) || 0 })}
+                      onBlur={() => flushRow(c.row.id)}
+                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                    />
+                  </td>
+                  <td className="text-end" style={{ background: '#f1f5f9', padding: '4px 12px' }}>
+                    {fmtNum2(c.totalAtCompradas)}
+                  </td>
+                  <td className="text-end fw-bold" style={{ background: '#dcfce7', color: '#15803d', padding: '4px 12px' }}>
+                    ${fmtCop(c.totalValorCompra)}
+                  </td>
+                  <td className="text-end fw-semibold" style={{ background: '#fef3c7', color: c.contratosKc >= 0 ? '#15803d' : '#b91c1c', padding: '4px 12px' }}>
+                    {fmtSignedNum4(c.contratosKc)}
+                  </td>
+                  <td className="text-end fw-semibold" style={{ background: '#fef3c7', color: c.exposicionUsd >= 0 ? '#15803d' : '#b91c1c', padding: '4px 12px' }}>
+                    {fmtSignedCop(c.exposicionUsd)}
+                  </td>
+                  <td style={{ padding: '4px 4px', textAlign: 'center', whiteSpace: 'nowrap' }}>
+                    <span
+                      style={{
+                        display: 'inline-block',
+                        width: 14,
+                        fontSize: '0.85rem',
+                        marginRight: 4,
+                        color:
+                          c.row._state === 'saved' ? '#15803d'
+                            : c.row._state === 'saving' ? '#0ea5e9'
+                              : c.row._state === 'dirty' ? '#d97706'
+                                : c.row._state === 'error' ? '#b91c1c'
+                                  : 'transparent',
+                      }}
+                      title={
+                        c.row._state === 'saved' ? 'Guardado'
+                          : c.row._state === 'saving' ? 'Guardando...'
+                            : c.row._state === 'dirty' ? 'Pendiente — guardando en 0.6s'
+                              : c.row._state === 'error' ? 'Error al guardar'
+                                : ''
+                      }
+                    >
+                      {c.row._state === 'saved' ? '✓'
+                        : c.row._state === 'saving' ? '⟳'
+                          : c.row._state === 'dirty' ? '●'
+                            : c.row._state === 'error' ? '!'
+                              : ''}
+                    </span>
+                    <Button
+                      variant="link"
+                      size="sm"
+                      onClick={() => handleDelete(c.row.id)}
+                      title="Borrar"
+                      className="p-0 text-danger"
+                      style={{ lineHeight: 1, fontSize: '1.1rem' }}
+                    >
+                      &times;
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr style={{ background: '#f1f5f9', fontWeight: 600, borderTop: '2px solid #cbd5e1' }}>
+                <td style={{ padding: '8px 8px', textTransform: 'uppercase', letterSpacing: '0.04em', fontSize: '0.7rem', color: '#475569' }} colSpan={2}>Total</td>
+                <td className="text-end" style={{ padding: '8px 10px' }}>{fmtKg(totals.totalKg)}</td>
+                <td />{/* Factor (no aplica suma) */}
+                <td className="text-end" style={{ padding: '8px 12px' }}>{fmtKg(totals.kgVerde)}</td>
+                <td />
+                <td className="text-end" style={{ padding: '8px 12px' }}>{fmtNum2(totals.totalAtCompradas)}</td>
+                <td className="text-end" style={{ color: '#15803d', padding: '8px 12px', fontSize: '0.95rem' }}>${fmtCop(totals.totalValorCompra)}</td>
+                <td className="text-end" style={{ color: totals.contratosKc >= 0 ? '#15803d' : '#b91c1c', padding: '8px 12px', fontSize: '0.95rem' }}>{fmtSignedNum4(totals.contratosKc)}</td>
+                <td className="text-end" style={{ color: totals.exposicionUsd >= 0 ? '#15803d' : '#b91c1c', padding: '8px 12px', fontSize: '0.95rem' }}>{fmtSignedCop(totals.exposicionUsd)}</td>
+                <td />
+              </tr>
+            </tfoot>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/risk/supabaseRisk.ts
+++ b/src/lib/risk/supabaseRisk.ts
@@ -352,3 +352,204 @@ export async function fetchCoffeePrices(
   if (error) throw new Error(`Failed to fetch coffee_prices: ${error.message}`);
   return (data ?? []) as CoffeePriceRow[];
 }
+
+// ── Cafe Fijaciones (blotter por empresa) ──
+
+export interface CafeFijacionRow {
+  id: string;
+  company_id: string;
+  sacos_fijados: number;
+  kg: number;
+  fijacion_ny: number;     // cents/lb del NY base
+  prima: number;            // cents/lb del premio
+  fijacion_cop: number;     // TRM al momento de fijar (siempre se guarda; en USD es informativa)
+  fecha_fijacion: string;   // YYYY-MM-DD
+  moneda: 'COP' | 'USD';    // moneda de la venta
+  created_at?: string;
+  updated_at?: string;
+}
+
+export async function fetchCafeFijaciones(companyId: string): Promise<CafeFijacionRow[]> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_fijaciones')
+    .select('*')
+    .eq('company_id', companyId)
+    .order('fecha_fijacion', { ascending: true });
+  if (error) throw new Error(`Failed to fetch cafe_fijaciones: ${error.message}`);
+  return (data ?? []) as CafeFijacionRow[];
+}
+
+export async function insertCafeFijacion(
+  row: Omit<CafeFijacionRow, 'id' | 'created_at' | 'updated_at'>,
+): Promise<CafeFijacionRow> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_fijaciones')
+    .insert(row)
+    .select()
+    .single();
+  if (error) throw new Error(`Failed to insert cafe_fijacion: ${error.message}`);
+  return data as CafeFijacionRow;
+}
+
+export async function updateCafeFijacion(
+  id: string,
+  updates: Partial<Omit<CafeFijacionRow, 'id' | 'company_id' | 'created_at' | 'updated_at'>>,
+): Promise<void> {
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_fijaciones')
+    .update(updates)
+    .eq('id', id);
+  if (error) throw new Error(`Failed to update cafe_fijacion: ${error.message}`);
+}
+
+export async function deleteCafeFijacion(id: string): Promise<void> {
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_fijaciones')
+    .delete()
+    .eq('id', id);
+  if (error) throw new Error(`Failed to delete cafe_fijacion: ${error.message}`);
+}
+
+// Factor de conversion (vive en risk_company_config.cafe_factor_conversion)
+
+export async function fetchCafeFactorConversion(companyId: string): Promise<number> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_company_config')
+    .select('cafe_factor_conversion')
+    .eq('company_id', companyId)
+    .maybeSingle();
+  if (error) throw new Error(`Failed to fetch cafe_factor_conversion: ${error.message}`);
+  return Number(data?.cafe_factor_conversion ?? 1.5432);
+}
+
+export async function updateCafeFactorConversion(
+  companyId: string,
+  factor: number,
+): Promise<void> {
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_company_config')
+    .update({ cafe_factor_conversion: factor })
+    .eq('company_id', companyId);
+  if (error) throw new Error(`Failed to update cafe_factor_conversion: ${error.message}`);
+}
+
+// ── Cafe Compras (blotter de compra) ──
+
+export interface CafeCompraRow {
+  id: string;
+  company_id: string;
+  fecha_compra: string;          // YYYY-MM-DD
+  total_kg: number;              // kg de cafe humedo comprado
+  valor_compra_at: number;       // COP por @
+  factor_humedo: number;         // conversion humedo -> verde (default 0.1431, editable per fila)
+  created_at?: string;
+  updated_at?: string;
+}
+
+export async function fetchCafeCompras(companyId: string): Promise<CafeCompraRow[]> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_compras')
+    .select('*')
+    .eq('company_id', companyId)
+    .order('fecha_compra', { ascending: true });
+  if (error) throw new Error(`Failed to fetch cafe_compras: ${error.message}`);
+  return (data ?? []) as CafeCompraRow[];
+}
+
+export async function insertCafeCompra(
+  row: Omit<CafeCompraRow, 'id' | 'created_at' | 'updated_at'>,
+): Promise<CafeCompraRow> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_compras')
+    .insert(row)
+    .select()
+    .single();
+  if (error) throw new Error(`Failed to insert cafe_compra: ${error.message}`);
+  return data as CafeCompraRow;
+}
+
+export async function updateCafeCompra(
+  id: string,
+  updates: Partial<Omit<CafeCompraRow, 'id' | 'company_id' | 'created_at' | 'updated_at'>>,
+): Promise<void> {
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_compras')
+    .update(updates)
+    .eq('id', id);
+  if (error) throw new Error(`Failed to update cafe_compra: ${error.message}`);
+}
+
+export async function deleteCafeCompra(id: string): Promise<void> {
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_compras')
+    .delete()
+    .eq('id', id);
+  if (error) throw new Error(`Failed to delete cafe_compra: ${error.message}`);
+}
+
+// Globals de compra (kg_per_at + lbs_por_contrato_kc)
+// Nota: factor_humedo ya NO es global. Vive per-fila en cafe_compras
+// porque el rendimiento puede mejorar con el tiempo y se ajusta manualmente.
+
+export interface CafeCompraGlobals {
+  kg_per_at: number;            // default 60
+  lbs_per_contrato_kc: number;  // default 37500
+}
+
+export async function fetchCafeCompraGlobals(companyId: string): Promise<CafeCompraGlobals> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_company_config')
+    .select('cafe_kg_per_at_compra, cafe_lbs_per_contrato_kc')
+    .eq('company_id', companyId)
+    .maybeSingle();
+  if (error) throw new Error(`Failed to fetch cafe compra globals: ${error.message}`);
+  return {
+    kg_per_at: Number(data?.cafe_kg_per_at_compra ?? 60),
+    lbs_per_contrato_kc: Number(data?.cafe_lbs_per_contrato_kc ?? 37500),
+  };
+}
+
+export async function updateCafeCompraGlobals(
+  companyId: string,
+  globals: Partial<CafeCompraGlobals>,
+): Promise<void> {
+  const payload: Record<string, number> = {};
+  if (globals.kg_per_at != null) payload.cafe_kg_per_at_compra = globals.kg_per_at;
+  if (globals.lbs_per_contrato_kc != null) payload.cafe_lbs_per_contrato_kc = globals.lbs_per_contrato_kc;
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_company_config')
+    .update(payload)
+    .eq('company_id', companyId);
+  if (error) throw new Error(`Failed to update cafe compra globals: ${error.message}`);
+}
+
+// Precio actual KC desde risk_prices (front contract de CAFE)
+export async function fetchLatestCafePriceCents(): Promise<{ price: number; date: string } | null> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('risk_prices')
+    .select('date, price')
+    .eq('asset', 'CAFE')
+    .order('date', { ascending: false })
+    .limit(1);
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.error('fetchLatestCafePriceCents error:', error);
+    throw new Error(`Failed to fetch latest CAFE price: ${error.message}`);
+  }
+  const row = data?.[0];
+  if (!row) return null;
+  return { price: Number(row.price), date: String(row.date) };
+}

--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -2,7 +2,7 @@
 
 import { CoreLayout } from '@layout';
 import { Row, Col, Form, Modal } from 'react-bootstrap';
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import Container from 'react-bootstrap/Container';
 import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import {
@@ -50,6 +50,8 @@ import RoleGuard from 'src/components/RoleGuard';
 import { fetchCompanyRiskConfig, getAssetsWithCurrency, getChartColors, saveCompanyRiskConfig, COMMODITY_TEMPLATES, DEFAULT_EXPOSURE_PARAMS } from 'src/lib/risk/companyConfig';
 import type { RiskCompanyConfig } from 'src/lib/risk/companyConfig';
 import { parseContractMaturity } from 'src/lib/risk/futuresCalculator';
+import BlotterCafe from 'src/components/risk/BlotterCafe';
+import BlotterCompraCafe from 'src/components/risk/BlotterCompraCafe';
 
 const PAGE_TITLE = 'Gestión de Riesgos';
 
@@ -844,6 +846,15 @@ function CommoditySetup({ companyId, onSaved }: { companyId: string; onSaved: (c
 
 function RiskManagement() {
   const { userProfile, isSuperAdmin, selectedCompanyId, setSelectedCompanyId } = useAppStore();
+  const companies = useAppStore((s) => s.companies);
+
+  // Nombre de la empresa activa, derivado del store. Cae a "Exp. Natural"
+  // como fallback si todavia no carga (evita parpadeo con "Super" hardcoded).
+  const activeCompanyName = useMemo(() => {
+    const id = selectedCompanyId || userProfile?.company_id;
+    if (!id) return 'Exp. Natural';
+    return companies.find((c) => c.id === id)?.name ?? 'Exp. Natural';
+  }, [selectedCompanyId, userProfile?.company_id, companies]);
 
   // Set default company to user's own company (if not already selected by global selector)
   useEffect(() => {
@@ -872,6 +883,11 @@ function RiskManagement() {
 
   // Check if this company has CAFE in its commodities (for conditional tabs)
   const hasCafe = companyConfig?.commodities?.some((c) => c.asset === 'CAFE') ?? false;
+
+  // Total $ COP del blotter cafe — alimenta Exposicion Natural de CAFE en Benchmark.
+  // Solo aplica si hasCafe es true. El componente BlotterCafe llama a setCafeBlotterTotal
+  // cada vez que cambian sus filas.
+  const [cafeBlotterTotal, setCafeBlotterTotal] = useState<number>(0);
 
   const [activeTab, setActiveTab] = useState('benchmark');
   // Build tabs dynamically: add "Precios Locales" if CAFE, + "Calculadora USDCOP" always
@@ -1279,6 +1295,12 @@ function RiskManagement() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [benchmarkMonth]);
 
+  // NOTA: anteriormente aqui habia un useEffect que tomaba el total del
+  // Blotter Fijaciones Cafe y lo metia en la fila CAFE Exp. Natural del
+  // Benchmark. Se elimino por decision del usuario (las fijaciones ahora
+  // pueden ser en COP o USD, asi que la integracion automatica no es
+  // trivial). El estado `cafeBlotterTotal` queda no usado (por ahora).
+
   // When exposure results change, update benchmark position_super
   useEffect(() => {
     if (!exposureResult) return;
@@ -1524,14 +1546,14 @@ function RiskManagement() {
                     <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px', color: '#1e40af' }}>Exp. Natural</th>
                     <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px', color: '#854d0e' }}>Portafolio GR</th>
                     <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px' }}>Total</th>
-                    <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px' }}>Super</th>
+                    <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px' }}>{activeCompanyName}</th>
                     <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px', color: '#854d0e' }}>GR</th>
                     <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px' }}>Total</th>
                     <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px' }}>Diario %</th>
                     <th className="text-center" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px' }}>Unidad</th>
                     <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px' }}>Inicio</th>
                     <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px' }}>Fin</th>
-                    <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px' }}>Super</th>
+                    <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px' }}>{activeCompanyName}</th>
                     <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px', color: '#854d0e' }}>GR</th>
                     <th className="text-end" style={{ borderBottom: '2px solid #e2e8f0', padding: '6px 4px' }}>Total</th>
                   </tr>
@@ -1609,6 +1631,24 @@ function RiskManagement() {
               </table>
             </div>
             </div>
+
+            {/* Blotters Cafe — solo visibles si la empresa tiene CAFE.
+                Orden: Compras primero, despues Fijaciones (ventas).
+                Razon: el flujo logico es comprar -> hedgear -> fijar venta.
+                El precio KC para Exp USD viene de benchmarkFactors (mismo
+                dato que ya muestra la tabla Benchmark en columna Fin). */}
+            {hasCafe && selectedCompanyId && (
+              <>
+                <BlotterCompraCafe
+                  companyId={selectedCompanyId}
+                  precioKcCents={benchmarkFactors?.factors?.CAFE?.price_end ?? null}
+                  precioKcDate={benchmarkFactors?.period?.end ?? null}
+                />
+                <BlotterCafe
+                  companyId={selectedCompanyId}
+                />
+              </>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
Closes #378

## Summary
- **BlotterCafe** (fijaciones de venta): tabla CRUD con auto-save (debounce 600ms), badge de estado per-fila y toggle COP/USD per-fila con dos totales en el footer.
- **BlotterCompraCafe** (compras): factor de conversion humedo->verde editable per-fila (default 0.1431), calculo automatico de # contratos KC y exposicion USD con signos +/- para distinguir long/short. Mismo auto-save.
- Ambos blotters se renderizan condicionalmente en el tab Benchmark cuando la empresa tiene CAFE en sus commodities (\`risk_company_config\`).
- Se elimina el feed automatico \`cafeBlotterTotal\` -> \`CAFE Exp.Natural\` del Benchmark (las fijaciones pueden ser COP o USD, agregacion automatica no aplica).
- Headers del Benchmark: reemplaza \"Super\" hardcoded por \`activeCompanyName\` derivado del store de empresas.

## SQL requerido (PR aparte en xerenity-backend)
- \`cafe_fijaciones.sql\` + \`cafe_fijaciones_rls_v2.sql\`
- \`cafe_compras.sql\`
- \`cafe_compras_disable_rls.sql\`
- \`cafe_compras_factor_humedo_per_row.sql\`

## Test plan
- [ ] Empresa CON CAFE: aparecen los dos blotters
- [ ] Empresa SIN CAFE: no aparecen
- [ ] Auto-save: editar, esperar 600ms, badge cambia a verde
- [ ] Auto-save: refrescar, los datos persisten
- [ ] Factor humedo: cambiar valor por fila recalcula kg verde
- [ ] Fijaciones: toggle COP/USD por fila, dos totales correctos