### PR TITLE
fix(risk): quitar hardcode USD TRM en Benchmark

### DIFF
--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -1326,15 +1326,9 @@ function RiskManagement() {
         if (row.asset === 'Total') return;
 
         // ── USD row: fed from OTC store (FX Delta + P&L MTD USD) ──
-        // TODO(hardcode-temporal): el row USD deberia leer dinamicamente del OTC
-        // store (pricedXccy + pricedNdf + summary + refPrices.mtd) anclados a
-        // benchmarkDateStr. Por ahora no se dispara la carga del OTC store en
-        // este page (eso quedo fuera del PR #372 hasta organizar arquitectura
-        // de fechas). Mientras tanto, se hardcodean los valores de Abril 2026
-        // copiados manualmente del tab Portafolio OTC al 2026-04-30:
-        //   FX Delta total (sum XCCY + NDF)  = -$8,800,000
-        //   P&L MTD USD (npv hoy - npv MTD)  = +$121,300
-        // Quitar este hardcode cuando se implemente el flujo dinamico.
+        // Si la empresa no tiene OTC positions cargadas, los stores vienen
+        // vacios y los valores quedan en 0. NO se hardcodea ningun valor;
+        // mas adelante se decide que mostrar como fallback per-empresa.
         if (row.asset === 'USD') {
           const fxDeltaTotal = (pricedXccyStore ?? []).reduce((s, p) => s + (p.fx_delta ?? 0), 0)
             + (pricedNdfStore ?? []).reduce((s, p) => s + (p.fx_delta ?? 0), 0);
@@ -1342,15 +1336,8 @@ function RiskManagement() {
           const pnlMtdUsd = (otcSummary && mtdRef)
             ? otcSummary.total_npv_usd - mtdRef.summary.total_npv_usd
             : 0;
-          // Si el store esta poblado, usar valores reales. Si no, fallback al
-          // hardcode de Abril 2026.
-          const useStore = fxDeltaTotal !== 0 || pnlMtdUsd !== 0;
-          next[i].position_gr = useStore
-            ? String(Math.round(fxDeltaTotal))
-            : '-8800000';
-          next[i].pnl_gr = useStore
-            ? String(Math.round(pnlMtdUsd))
-            : '121300';
+          next[i].position_gr = String(Math.round(fxDeltaTotal));
+          next[i].pnl_gr = String(Math.round(pnlMtdUsd));
           return;
         }
 


### PR DESCRIPTION
Closes #378

## Summary
La fila USD del Benchmark caia en un hardcode de Abril 2026 (\`-\$8,800,000\` / \`+\$121,300\`) cuando el OTC store estaba vacio. Esto hacia que para empresas sin posiciones OTC (e.g. El Embrujo) aparecieran valores que NO les correspondian.

## Fix
Ahora siempre se usa el valor del store (que es \`0\` cuando esta vacio). Mas adelante se decide que poner como fallback per-empresa.

\`\`\`diff
-          const useStore = fxDeltaTotal !== 0 || pnlMtdUsd !== 0;
-          next[i].position_gr = useStore
-            ? String(Math.round(fxDeltaTotal))
-            : '-8800000';
-          next[i].pnl_gr = useStore
-            ? String(Math.round(pnlMtdUsd))
-            : '121300';
+          next[i].position_gr = String(Math.round(fxDeltaTotal));
+          next[i].pnl_gr = String(Math.round(pnlMtdUsd));
\`\`\`

## Test plan
- [ ] El Embrujo (sin OTC): fila USD muestra \`0\` / \`0\`, no \`-\$8.8M\` / \`+\$121K\`
- [ ] Super de Alimentos (con OTC): fila USD sigue mostrando los valores dinamicos del store