### PR TITLE
feat(monitor): link Playbook (GitHub) from overview + detail page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Xerenity Frontend - Claude Agent Workflow
 
+## 📖 Playbook operacional de collectors
+
+Para entender los collectors que alimentan los datos del FE (y el sistema de monitoreo en `/admin/monitor`), leer [el playbook en xerenity-dm](https://github.com/avelezX/xerenity-dm/blob/main/docs/COLLECTORS_PLAYBOOK.md). Cubre el modelo de catálogo, anti-patterns, convenciones, y metodología de triage. El monitor del FE tiene un botón "📖 Playbook" que linkea directo a ese archivo.
+
 ## Qué es
 Frontend de la plataforma Xerenity. Aplicación web para visualización de datos financieros, series de tiempo, curvas de rendimiento, y dashboards de portafolio.
 

--- a/src/pages/admin/monitor/[name].tsx
+++ b/src/pages/admin/monitor/[name].tsx
@@ -17,6 +17,7 @@ import {
   faChevronRight,
   faGauge,
   faBookOpen,
+  faBook,
 } from '@fortawesome/free-solid-svg-icons';
 import styled from 'styled-components';
 import PageTitle from '@components/PageTitle';
@@ -76,6 +77,39 @@ const BackLink = styled(Link)`
   margin-bottom: 12px;
   text-decoration: none;
   &:hover { text-decoration: underline; }
+`;
+
+// Canonical link to the operations playbook. See xerenity-fe/CLAUDE.md
+// and xerenity-dm/docs/COLLECTORS_PLAYBOOK.md.
+const PLAYBOOK_URL =
+  'https://github.com/avelezX/xerenity-dm/blob/main/docs/COLLECTORS_PLAYBOOK.md';
+
+const PlaybookLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #302b63;
+  background: #f3f3f7;
+  border: 1px solid #d8d8e6;
+  padding: 4px 10px;
+  border-radius: 4px;
+  text-decoration: none !important;
+  margin-left: 12px;
+
+  &:hover {
+    background: #e9e9f0;
+    color: #1f1b3e;
+  }
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
 `;
 
 const TabBar = styled.div`
@@ -213,9 +247,20 @@ const CollectorDetailPage = () => {
         }
       >
         <PageWrap>
-          <BackLink href="/admin/monitor">
-            <Icon icon={faArrowLeft} /> Volver al overview
-          </BackLink>
+          <HeaderRow>
+            <BackLink href="/admin/monitor" style={{ marginBottom: 0 }}>
+              <Icon icon={faArrowLeft} /> Volver al overview
+            </BackLink>
+            <PlaybookLink
+              href={PLAYBOOK_URL}
+              target="_blank"
+              rel="noreferrer"
+              title="Manual operacional — markdown en xerenity-dm. Edición vía PR."
+            >
+              <Icon icon={faBook} /> Playbook
+              <Icon icon={faArrowUpRightFromSquare} style={{ fontSize: 9 }} />
+            </PlaybookLink>
+          </HeaderRow>
           <PageTitle>{name ?? 'Collector'}</PageTitle>
 
           <TabBar role="tablist" aria-label="Vistas del collector">

--- a/src/pages/admin/monitor/index.tsx
+++ b/src/pages/admin/monitor/index.tsx
@@ -10,6 +10,8 @@ import {
   faCheck,
   faEye,
   faRobot,
+  faBook,
+  faArrowUpRightFromSquare,
 } from '@fortawesome/free-solid-svg-icons';
 import { toast } from 'react-toastify';
 import styled from 'styled-components';
@@ -21,6 +23,42 @@ import MonitorTable from './_MonitorTable';
 
 const PageWrap = styled.div`
   padding: 16px 24px;
+`;
+
+// Canonical link to the operations playbook. Markdown is source of truth in
+// xerenity-dm, GitHub renders it nicely (TOC, code highlight, edit button).
+// Repo is private, so GitHub auth gates read access — no extra permission
+// logic needed in the FE beyond the super_admin gate that already protects
+// /admin/monitor.
+const PLAYBOOK_URL =
+  'https://github.com/avelezX/xerenity-dm/blob/main/docs/COLLECTORS_PLAYBOOK.md';
+
+const PlaybookLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #302b63;
+  background: #f3f3f7;
+  border: 1px solid #d8d8e6;
+  padding: 4px 10px;
+  border-radius: 4px;
+  text-decoration: none !important;
+  margin-left: 12px;
+  vertical-align: middle;
+
+  &:hover {
+    background: #e9e9f0;
+    color: #1f1b3e;
+  }
+`;
+
+const TitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
 `;
 
 const AlertsPanel = styled.div`
@@ -348,7 +386,18 @@ const MonitorPage = () => {
         }
       >
         <PageWrap>
-          <PageTitle>Monitor de Collectors</PageTitle>
+          <TitleRow>
+            <PageTitle>Monitor de Collectors</PageTitle>
+            <PlaybookLink
+              href={PLAYBOOK_URL}
+              target="_blank"
+              rel="noreferrer"
+              title="Manual operacional de collectors — markdown en xerenity-dm. Edición vía PR."
+            >
+              <Icon icon={faBook} /> Playbook
+              <Icon icon={faArrowUpRightFromSquare} style={{ fontSize: 9 }} />
+            </PlaybookLink>
+          </TitleRow>
           <div style={{ fontSize: 13, color: '#666', marginBottom: 6 }}>
             <strong>Collectors:</strong> {counts.ok}/{counts.total} OK · {counts.warning} en warning · {counts.critical} en critical
           </div>


### PR DESCRIPTION
Small button on /admin/monitor and /admin/monitor/<name> headers that opens the canonical COLLECTORS_PLAYBOOK.md on GitHub. Markdown source-of-truth in xerenity-dm; access gated by GitHub auth (repo private).