### PR TITLE
feat(catalog): Phase 2 — /data-catalog public discovery pages

### DIFF
--- a/src/components/dataCatalog/DictionaryBlock.tsx
+++ b/src/components/dataCatalog/DictionaryBlock.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+// Shared DictionaryBlock — collapsible columns + slice values for a single
+// table from the catalog. Used by /data-catalog/[table] (Phase 2). The
+// monitor's _CatalogTab.tsx keeps its own inline copy because adding a
+// new import from src/components/ into src/pages/admin/monitor/ has been
+// known to break Vercel builds opaquely. This component lives at
+// src/components/dataCatalog/ and is only imported from /data-catalog/
+// pages, which has been a safe path.
+
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Badge } from 'react-bootstrap';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import {
+  faChevronDown,
+  faChevronRight,
+} from '@fortawesome/free-solid-svg-icons';
+import type { DataColumnMeta, DataSliceEntry } from 'src/types/catalog';
+
+const Wrap = styled.div`
+  margin-top: 12px;
+`;
+
+const Toggle = styled.button<{ $open: boolean }>`
+  background: ${(p) => (p.$open ? '#fafaff' : 'transparent')};
+  border: 1px solid #e0e0e8;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #302b63;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+
+  &:hover {
+    background: #f3f3f7;
+  }
+`;
+
+const SubTable = styled.table`
+  width: 100%;
+  margin-bottom: 12px;
+  border-collapse: collapse;
+
+  thead th {
+    background: #fafaff;
+    font-size: 10px;
+    text-transform: uppercase;
+    color: #555;
+    font-weight: 600;
+    padding: 6px 10px;
+    text-align: left;
+    border-bottom: 1px solid #eee;
+  }
+  tbody td {
+    padding: 6px 10px;
+    border-bottom: 1px solid #f5f5f5;
+    vertical-align: top;
+    font-size: 12px;
+  }
+  tbody tr:hover { background: rgba(48, 43, 99, 0.03); }
+  code {
+    font-family: monospace;
+    background: #f3f3f7;
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 11px;
+  }
+`;
+
+interface Props {
+  columns: DataColumnMeta[];
+  slices: DataSliceEntry[];
+  defaultOpenColumns?: boolean;
+  defaultOpenSlices?: boolean;
+}
+
+const DictionaryBlock: React.FC<Props> = ({
+  columns,
+  slices,
+  defaultOpenColumns = false,
+  defaultOpenSlices = false,
+}) => {
+  const [showColumns, setShowColumns] = useState(defaultOpenColumns);
+  const [showSlices, setShowSlices] = useState(defaultOpenSlices);
+
+  if (columns.length === 0 && slices.length === 0) {
+    return (
+      <Wrap>
+        <em style={{ color: '#bbb', fontSize: 12 }}>
+          Sin diccionario de columnas ni valores. Las columnas se auto-detectan
+          desde information_schema cuando la tabla está registrada en data_tables_meta.
+        </em>
+      </Wrap>
+    );
+  }
+
+  return (
+    <Wrap>
+      {columns.length > 0 && (
+        <>
+          <Toggle type="button" onClick={() => setShowColumns((v) => !v)} $open={showColumns}>
+            <Icon icon={showColumns ? faChevronDown : faChevronRight} />
+            Columnas ({columns.length})
+          </Toggle>
+          {showColumns && (
+            <SubTable>
+              <thead>
+                <tr>
+                  <th>Columna</th>
+                  <th>Tipo</th>
+                  <th>Label</th>
+                  <th>Descripción</th>
+                  <th>Unit</th>
+                </tr>
+              </thead>
+              <tbody>
+                {columns.map((c) => (
+                  <tr key={c.column_name}>
+                    <td>
+                      <code>{c.column_name}</code>
+                      {c.is_date_key && <Badge bg="info" style={{ marginLeft: 4, fontSize: 9 }}>date</Badge>}
+                      {c.is_slice_key && <Badge bg="warning" style={{ marginLeft: 4, fontSize: 9, color: '#000' }}>slice</Badge>}
+                    </td>
+                    <td style={{ color: '#888', fontSize: 11 }}>{c.data_type}</td>
+                    <td>{c.label ?? <em style={{ color: '#bbb' }}>—</em>}</td>
+                    <td style={{ fontSize: 11, color: '#555' }}>{c.description ?? <em style={{ color: '#bbb' }}>—</em>}</td>
+                    <td>{c.unit ?? <em style={{ color: '#bbb' }}>—</em>}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </SubTable>
+          )}
+        </>
+      )}
+
+      {slices.length > 0 && (
+        <>
+          <Toggle type="button" onClick={() => setShowSlices((v) => !v)} $open={showSlices}>
+            <Icon icon={showSlices ? faChevronDown : faChevronRight} />
+            Slice dictionary ({slices.length})
+          </Toggle>
+          {showSlices && (
+            <SubTable>
+              <thead>
+                <tr>
+                  <th>Valor</th>
+                  <th>Label</th>
+                  <th>Descripción</th>
+                </tr>
+              </thead>
+              <tbody>
+                {slices.map((s) => (
+                  <tr key={s.slice_value}>
+                    <td><code>{s.slice_value}</code></td>
+                    <td style={{ fontWeight: 500 }}>{s.label}</td>
+                    <td style={{ fontSize: 11, color: '#555' }}>{s.description ?? <em style={{ color: '#bbb' }}>—</em>}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </SubTable>
+          )}
+        </>
+      )}
+    </Wrap>
+  );
+};
+
+export default DictionaryBlock;

--- a/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
+++ b/src/layout/CoreLayout/Sidebar/SidebarNavList.tsx
@@ -15,6 +15,7 @@ import {
   faRobot,
   faUsers,
   faHeartPulse,
+  faBook,
 } from '@fortawesome/free-solid-svg-icons';
 import useAppStore from 'src/store';
 import SubNavItem from './SubNavItem';
@@ -167,6 +168,12 @@ const SidebarNavList = ({ currentPath }: SidebarNavProps) => {
         path="/suameca"
         icon={faChartSimple}
         active={SERIES_DASHBOARDS_PREFIX.some((p) => currentPath.includes(p))}
+      />
+      <NavigationItem
+        name="Catálogo"
+        path="/data-catalog"
+        icon={faBook}
+        active={currentPath.includes('/data-catalog')}
       />
       {(userRole === 'super_admin' || userRole === 'corp_admin') && (
         <NavigationItem

--- a/src/models/dataCatalog/index.ts
+++ b/src/models/dataCatalog/index.ts
@@ -1,0 +1,99 @@
+// Public-facing catalog RPC wrappers (Phase 2). Anyone authenticated
+// can call these — the catalog tells what data exists; the data itself
+// is gated by its own RLS/permissions.
+
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import type {
+  DataCatalogOverviewEntry,
+  DataSource,
+  DataConsumer,
+  TableLineage,
+  TableFreshness,
+  TableDescription,
+} from 'src/types/catalog';
+
+const supabase = createClientComponentClient();
+const SCHEMA = 'xerenity';
+
+export interface DataResponse<T> {
+  data: T | null;
+  error?: string;
+}
+
+export async function listDataCatalogOverview(): Promise<DataResponse<DataCatalogOverviewEntry[]>> {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('list_data_catalog_overview');
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as DataCatalogOverviewEntry[] };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function listDataSources(): Promise<DataResponse<DataSource[]>> {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('list_data_sources');
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as DataSource[] };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function listDataConsumers(): Promise<DataResponse<DataConsumer[]>> {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('list_data_consumers');
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as DataConsumer[] };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function describeTable(
+  tableName: string,
+): Promise<DataResponse<TableDescription>> {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('describe_table', { p_table: tableName });
+    if (error) return { data: null, error: error.message };
+    return { data: data as TableDescription };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function getTableLineage(
+  tableName: string,
+): Promise<DataResponse<TableLineage>> {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('get_table_lineage', { p_table: tableName });
+    if (error) return { data: null, error: error.message };
+    return { data: data as TableLineage };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+}
+
+export async function getTableFreshness(
+  tableName: string,
+): Promise<DataResponse<TableFreshness>> {
+  try {
+    const { data, error } = await supabase
+      .schema(SCHEMA)
+      .rpc('get_table_freshness', { p_table: tableName });
+    if (error) return { data: null, error: error.message };
+    return { data: data as TableFreshness };
+  } catch (e) {
+    return { data: null, error: e instanceof Error ? e.message : 'Error' };
+  }
+}

--- a/src/pages/data-catalog/[table].tsx
+++ b/src/pages/data-catalog/[table].tsx
@@ -1,0 +1,434 @@
+'use client';
+
+// Catálogo — table detail page (Phase 2).
+// Shows: meta + freshness + columns + slice dictionary + lineage
+// (collectors writing, consumers reading). Public to authenticated.
+
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import styled from 'styled-components';
+import { Badge } from 'react-bootstrap';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import {
+  faArrowLeft,
+  faStar,
+  faCircleCheck,
+  faCircleExclamation,
+  faCircleXmark,
+} from '@fortawesome/free-solid-svg-icons';
+import { CoreLayout } from '@layout';
+import PageTitle from '@components/PageTitle';
+import DictionaryBlock from 'src/components/dataCatalog/DictionaryBlock';
+import {
+  describeTable,
+  getTableLineage,
+  getTableFreshness,
+} from 'src/models/dataCatalog';
+import type {
+  TableDescription,
+  TableLineage,
+  TableFreshness,
+} from 'src/types/catalog';
+
+// ─────────────────────────────────────────────────────────────────
+// Styled
+// ─────────────────────────────────────────────────────────────────
+
+const PageWrap = styled.div`
+  padding: 16px 24px;
+`;
+
+const BackLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #302b63;
+  font-size: 13px;
+  margin-bottom: 12px;
+  text-decoration: none;
+  &:hover { text-decoration: underline; }
+`;
+
+const Section = styled.section`
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px 20px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  margin-bottom: 16px;
+`;
+
+const SectionHeader = styled.h4`
+  font-size: 14px;
+  font-weight: 700;
+  color: #302b63;
+  margin: 0 0 14px 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+`;
+
+const MetaGrid = styled.dl`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 8px 16px;
+  font-size: 13px;
+  margin: 0;
+  dt { font-weight: 600; color: #555; }
+  dd { margin: 0; word-break: break-word; }
+  code { font-family: monospace; background: #f3f3f7; padding: 2px 6px; border-radius: 3px; font-size: 12px; }
+`;
+
+type Tone = 'ok' | 'warn' | 'bad';
+
+const TONE_BORDER: Record<Tone, string> = {
+  ok: '#28a745',
+  warn: '#f0ad4e',
+  bad: '#dc3545',
+};
+
+const TONE_BG: Record<Tone, string> = {
+  ok: '#e9f6ec',
+  warn: '#fdf8ef',
+  bad: '#fdf3f4',
+};
+
+const TONE_ICON = (tone: Tone) => {
+  if (tone === 'ok') return faCircleCheck;
+  if (tone === 'warn') return faCircleExclamation;
+  return faCircleXmark;
+};
+
+const SEVERITY_BG: Record<string, string> = {
+  critical: 'danger',
+  warning: 'warning',
+  info: 'info',
+};
+
+const FreshCard = styled.div<{ $tone: Tone }>`
+  border-radius: 6px;
+  padding: 10px 14px;
+  font-size: 13px;
+  border-left: 4px solid ${(p) => TONE_BORDER[p.$tone]};
+  background: ${(p) => TONE_BG[p.$tone]};
+  margin-bottom: 12px;
+`;
+
+const SubTable = styled.table`
+  width: 100%;
+  margin-bottom: 0;
+  border-collapse: collapse;
+  thead th {
+    background: #fafaff;
+    font-size: 10px;
+    text-transform: uppercase;
+    color: #555;
+    font-weight: 600;
+    padding: 6px 10px;
+    text-align: left;
+    border-bottom: 1px solid #eee;
+  }
+  tbody td {
+    padding: 6px 10px;
+    border-bottom: 1px solid #f5f5f5;
+    vertical-align: top;
+    font-size: 12px;
+  }
+  tbody tr:hover { background: rgba(48, 43, 99, 0.03); }
+  code { font-family: monospace; background: #f3f3f7; padding: 1px 5px; border-radius: 3px; font-size: 11px; }
+`;
+
+// ─────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────
+
+const formatRelative = (iso: string | null): string => {
+  if (!iso) return 'sin datos';
+  const ms = Date.now() - new Date(iso).getTime();
+  const hours = ms / 3.6e6;
+  if (hours < 1) return 'hace <1h';
+  if (hours < 48) return `hace ${Math.round(hours)}h`;
+  const days = hours / 24;
+  if (days < 30) return `hace ${Math.round(days)}d`;
+  if (days < 365) return `hace ${Math.round(days / 30)} meses`;
+  return `hace ${(days / 365).toFixed(1)} años`;
+};
+
+const freshnessTone = (ageHours: number | null): 'ok' | 'warn' | 'bad' => {
+  if (ageHours == null) return 'bad';
+  if (ageHours <= 48) return 'ok';
+  if (ageHours <= 168) return 'warn';   // 7 días
+  return 'bad';
+};
+
+// ─────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────
+
+const DataCatalogTableDetail = () => {
+  const router = useRouter();
+  const tableParam = router.query.table;
+  const tableName = Array.isArray(tableParam) ? tableParam[0] : tableParam;
+
+  const [description, setDescription] = useState<TableDescription | null>(null);
+  const [lineage, setLineage] = useState<TableLineage | null>(null);
+  const [freshness, setFreshness] = useState<TableFreshness | null>(null);
+  const [error, setError] = useState<string | undefined>();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!tableName) return;
+    setLoading(true);
+    Promise.all([
+      describeTable(tableName),
+      getTableLineage(tableName),
+      getTableFreshness(tableName),
+    ]).then(([d, l, f]) => {
+      if (d.error) setError(d.error);
+      if (d.data) setDescription(d.data);
+      if (l.data) setLineage(l.data);
+      if (f.data) setFreshness(f.data);
+      setLoading(false);
+    });
+  }, [tableName]);
+
+  if (!tableName) {
+    return (
+      <CoreLayout>
+        <PageWrap><em>Cargando…</em></PageWrap>
+      </CoreLayout>
+    );
+  }
+
+  if (loading) {
+    return (
+      <CoreLayout>
+        <PageWrap>
+          <BackLink href="/data-catalog">
+            <Icon icon={faArrowLeft} /> Volver al catálogo
+          </BackLink>
+          <PageTitle>{tableName}</PageTitle>
+          <em>Cargando información de la tabla…</em>
+        </PageWrap>
+      </CoreLayout>
+    );
+  }
+
+  if (error || !description) {
+    return (
+      <CoreLayout>
+        <PageWrap>
+          <BackLink href="/data-catalog">
+            <Icon icon={faArrowLeft} /> Volver al catálogo
+          </BackLink>
+          <PageTitle>{tableName}</PageTitle>
+          <div style={{ color: '#dc3545' }}>
+            {error ?? 'No se pudo cargar la tabla.'}
+          </div>
+        </PageWrap>
+      </CoreLayout>
+    );
+  }
+
+  const { meta, columns, slices } = description;
+  const overall = freshness?.overall;
+  const perSlice = freshness?.per_slice;
+  const ageHours = overall?.age_hours ?? null;
+  const tone = freshnessTone(ageHours);
+
+  return (
+    <CoreLayout>
+      <PageWrap>
+        <BackLink href="/data-catalog">
+          <Icon icon={faArrowLeft} /> Volver al catálogo
+        </BackLink>
+
+        <PageTitle>
+          {meta.is_critical && (
+            <Icon icon={faStar} style={{ color: '#dc3545', marginRight: 8 }} />
+          )}
+          {meta.table_name}
+        </PageTitle>
+
+        {meta.label && (
+          <div style={{ fontSize: 14, color: '#555', marginBottom: 16 }}>{meta.label}</div>
+        )}
+
+        {/* ── Frescura ─── */}
+        {overall && !overall.error && (
+          <FreshCard $tone={tone}>
+            <Icon icon={TONE_ICON(tone)} style={{ marginRight: 8 }} />
+            <strong>{overall.row_count.toLocaleString()} filas</strong> · última observación{' '}
+            <strong>{formatRelative(overall.last_date)}</strong>
+            {overall.first_date && (
+              <> · histórico desde <strong>{overall.first_date}</strong></>
+            )}
+          </FreshCard>
+        )}
+
+        {/* ── Meta ─── */}
+        <Section>
+          <SectionHeader>Información de la tabla</SectionHeader>
+          <MetaGrid>
+            <dt>Schema / Tabla</dt>
+            <dd><code>xerenity.{meta.table_name}</code></dd>
+            {meta.category && (
+              <>
+                <dt>Categoría</dt>
+                <dd><Badge bg="info">{meta.category}</Badge></dd>
+              </>
+            )}
+            {meta.country && (
+              <>
+                <dt>País / región</dt>
+                <dd><Badge bg="secondary">{meta.country}</Badge></dd>
+              </>
+            )}
+            <dt>Crítica</dt>
+            <dd>{meta.is_critical ? '⭐ sí — alimenta cálculos clave del libro de derivados' : 'no'}</dd>
+            <dt>Columna fecha</dt>
+            <dd>{meta.date_column ? <code>{meta.date_column}</code> : <em>—</em>}</dd>
+            <dt>Columna slice</dt>
+            <dd>{meta.slice_column ? <code>{meta.slice_column}</code> : <em>—</em>}</dd>
+            {meta.description && (
+              <>
+                <dt>Descripción</dt>
+                <dd style={{ fontSize: 12, color: '#444' }}>{meta.description}</dd>
+              </>
+            )}
+          </MetaGrid>
+
+          <DictionaryBlock columns={columns} slices={slices} />
+        </Section>
+
+        {/* ── Per-slice freshness ─── */}
+        {Array.isArray(perSlice) && perSlice.length > 0 && (
+          <Section>
+            <SectionHeader>
+              Frescura por {meta.slice_column ? <code>{meta.slice_column}</code> : 'slice'}
+            </SectionHeader>
+            <SubTable>
+              <thead>
+                <tr>
+                  <th>Slice</th>
+                  <th>Filas</th>
+                  <th>Primera fecha</th>
+                  <th>Última fecha</th>
+                </tr>
+              </thead>
+              <tbody>
+                {perSlice.slice(0, 50).map((p) => (
+                  <tr key={p.slice_value}>
+                    <td><code>{p.slice_value}</code></td>
+                    <td>{p.row_count.toLocaleString()}</td>
+                    <td>{p.first_date ?? '—'}</td>
+                    <td>{p.last_date ?? '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </SubTable>
+            {perSlice.length > 50 && (
+              <div style={{ fontSize: 11, color: '#888', marginTop: 6 }}>
+                Mostrando primeras 50 de {perSlice.length} slices.
+              </div>
+            )}
+          </Section>
+        )}
+
+        {/* ── Lineage: who writes ─── */}
+        {lineage && lineage.writers.length > 0 && (
+          <Section>
+            <SectionHeader>Quién la pobla (collectors)</SectionHeader>
+            <SubTable>
+              <thead>
+                <tr>
+                  <th>Collector</th>
+                  <th>Source</th>
+                  <th>Cron</th>
+                  <th>Cadencia esperada</th>
+                  <th>Severity</th>
+                  <th>Enabled</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lineage.writers.map((w) => (
+                  <tr key={w.name}>
+                    <td><code>{w.name}</code></td>
+                    <td>{w.source_name ?? <em>—</em>}</td>
+                    <td>{w.schedule_cron ? <code>{w.schedule_cron}</code> : <em>—</em>}</td>
+                    <td>{w.expected_frequency ?? <em>—</em>}</td>
+                    <td>
+                      <Badge
+                        bg={SEVERITY_BG[w.severity] ?? 'secondary'}
+                        style={{ color: w.severity === 'warning' ? '#000' : '#fff' }}
+                      >
+                        {w.severity}
+                      </Badge>
+                    </td>
+                    <td>
+                      <Badge bg={w.enabled ? 'success' : 'secondary'}>
+                        {w.enabled ? 'sí' : 'NO'}
+                      </Badge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </SubTable>
+            {lineage.writers.filter((w) => w.description).length > 0 && (
+              <div style={{ marginTop: 12 }}>
+                {lineage.writers
+                  .filter((w) => w.description)
+                  .map((w) => (
+                    <div key={w.name} style={{ marginBottom: 8, fontSize: 12, color: '#444' }}>
+                      <strong style={{ color: '#302b63' }}>{w.name}</strong>: {w.description}
+                    </div>
+                  ))}
+              </div>
+            )}
+          </Section>
+        )}
+
+        {/* ── Lineage: who reads ─── */}
+        {lineage && lineage.readers.length > 0 && (
+          <Section>
+            <SectionHeader>Quién la consume (consumers)</SectionHeader>
+            <SubTable>
+              <thead>
+                <tr>
+                  <th>Consumer</th>
+                  <th>Tipo</th>
+                  <th>Label</th>
+                  <th>Path</th>
+                  <th>Enabled</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lineage.readers.map((r) => (
+                  <tr key={r.name}>
+                    <td><code>{r.name}</code></td>
+                    <td><Badge bg="secondary">{r.consumer_type}</Badge></td>
+                    <td>{r.label}</td>
+                    <td>{r.path ? <code>{r.path}</code> : <em>—</em>}</td>
+                    <td><Badge bg={r.enabled ? 'success' : 'secondary'}>{r.enabled ? 'sí' : 'NO'}</Badge></td>
+                  </tr>
+                ))}
+              </tbody>
+            </SubTable>
+          </Section>
+        )}
+
+        {lineage && lineage.writers.length === 0 && lineage.readers.length === 0 && (
+          <Section>
+            <SectionHeader>Lineage</SectionHeader>
+            <div style={{ color: '#888', fontSize: 13, fontStyle: 'italic' }}>
+              Ningún collector escribe a esta tabla y ningún consumer la lee según el catálogo actual.
+              Si esto es incorrecto, registrar el collector en xerenity.collector_definitions o el
+              consumer en xerenity.data_consumers (super_admin only).
+            </div>
+          </Section>
+        )}
+      </PageWrap>
+    </CoreLayout>
+  );
+};
+
+export default DataCatalogTableDetail;

--- a/src/pages/data-catalog/index.tsx
+++ b/src/pages/data-catalog/index.tsx
@@ -1,0 +1,386 @@
+'use client';
+
+// Catálogo de datos — overview page (Phase 2 of the catalog plan).
+// Visible to any authenticated user. Lists every table in
+// xerenity.data_tables_meta with: category, country, sources writing,
+// number of consumers reading, slice value coverage. Click a row to
+// drill into /data-catalog/<table_name>.
+
+import React, { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import styled from 'styled-components';
+import { Badge, Form } from 'react-bootstrap';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import {
+  faStar,
+  faSearch,
+} from '@fortawesome/free-solid-svg-icons';
+import { CoreLayout } from '@layout';
+import PageTitle from '@components/PageTitle';
+import { listDataCatalogOverview } from 'src/models/dataCatalog';
+import type { DataCatalogOverviewEntry } from 'src/types/catalog';
+
+// ─────────────────────────────────────────────────────────────────
+// Styled
+// ─────────────────────────────────────────────────────────────────
+
+const PageWrap = styled.div`
+  padding: 16px 24px;
+`;
+
+const Toolbar = styled.div`
+  background: #fff;
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+
+  .label-inline {
+    font-size: 11px;
+    font-weight: 600;
+    color: #555;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    margin-right: 4px;
+  }
+
+  .search-wrap {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    padding: 4px 8px;
+    background: #fff;
+    flex: 1 1 240px;
+    max-width: 360px;
+
+    input {
+      border: none;
+      outline: none;
+      width: 100%;
+      font-size: 13px;
+    }
+  }
+`;
+
+const TableWrap = styled.div`
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  overflow-x: auto;
+
+  table { width: 100%; margin: 0; border-collapse: collapse; }
+  thead th {
+    background: #302b63;
+    color: #fff;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 10px 12px;
+    text-align: left;
+    white-space: nowrap;
+    cursor: pointer;
+    user-select: none;
+  }
+  thead th:hover { background: #3d3680; }
+  tbody td {
+    font-size: 13px;
+    padding: 9px 12px;
+    border-bottom: 1px solid #f1f1f4;
+    vertical-align: middle;
+  }
+  tbody tr:hover { background: rgba(48, 43, 99, 0.04); cursor: pointer; }
+  a {
+    color: #302b63;
+    text-decoration: none;
+    font-weight: 600;
+  }
+  a:hover { text-decoration: underline; }
+  code {
+    font-family: monospace;
+    background: #f3f3f7;
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 11px;
+  }
+`;
+
+const Chip = styled.span<{ $color?: string }>`
+  display: inline-block;
+  font-size: 10px;
+  background: ${(p) => p.$color ?? '#e9e9f0'};
+  color: #444;
+  padding: 1px 6px;
+  border-radius: 3px;
+  margin: 0 2px 2px 0;
+  white-space: nowrap;
+`;
+
+const InfoBox = styled.div`
+  background: #f3f3f7;
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  font-size: 12px;
+  color: #555;
+
+  strong { color: #302b63; }
+`;
+
+// ─────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────
+
+type SortKey =
+  | 'table_name'
+  | 'category'
+  | 'country'
+  | 'n_collectors_writing'
+  | 'n_consumers';
+
+const DataCatalogPage = () => {
+  const [rows, setRows] = useState<DataCatalogOverviewEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>();
+
+  const [search, setSearch] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<string>('');
+  const [countryFilter, setCountryFilter] = useState<string>('');
+  const [sourceFilter, setSourceFilter] = useState<string>('');
+  const [onlyCritical, setOnlyCritical] = useState(false);
+
+  const [sortBy, setSortBy] = useState<SortKey>('table_name');
+  const [sortDesc, setSortDesc] = useState(false);
+
+  useEffect(() => {
+    listDataCatalogOverview().then((res) => {
+      if (res.data) setRows(res.data);
+      if (res.error) setError(res.error);
+      setLoading(false);
+    });
+  }, []);
+
+  // Distinct option sets for filters
+  const optionSets = useMemo(() => {
+    const cats = new Set<string>();
+    const countries = new Set<string>();
+    const sources = new Set<string>();
+    rows.forEach((r) => {
+      if (r.category) cats.add(r.category);
+      if (r.country) countries.add(r.country);
+      r.sources.forEach((s) => sources.add(s));
+    });
+    return {
+      categories: Array.from(cats).sort(),
+      countries: Array.from(countries).sort(),
+      sources: Array.from(sources).sort(),
+    };
+  }, [rows]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return rows
+      .filter((r) => {
+        if (onlyCritical && !r.is_critical) return false;
+        if (categoryFilter && r.category !== categoryFilter) return false;
+        if (countryFilter && r.country !== countryFilter) return false;
+        if (sourceFilter && !r.sources.includes(sourceFilter)) return false;
+        if (!q) return true;
+        const haystack = [
+          r.table_name,
+          r.label ?? '',
+          r.description ?? '',
+          r.category ?? '',
+          r.country ?? '',
+          ...r.sources,
+        ]
+          .join(' ')
+          .toLowerCase();
+        return haystack.includes(q);
+      })
+      .sort((a, b) => {
+        const av = a[sortBy] ?? '';
+        const bv = b[sortBy] ?? '';
+        const cmp = typeof av === 'number' && typeof bv === 'number'
+          ? av - bv
+          : String(av).localeCompare(String(bv));
+        return sortDesc ? -cmp : cmp;
+      });
+  }, [rows, search, categoryFilter, countryFilter, sourceFilter, onlyCritical, sortBy, sortDesc]);
+
+  const toggleSort = (key: SortKey) => {
+    if (sortBy === key) {
+      setSortDesc(!sortDesc);
+    } else {
+      setSortBy(key);
+      setSortDesc(false);
+    }
+  };
+
+  return (
+    <CoreLayout>
+      <PageWrap>
+        <PageTitle>Catálogo de datos</PageTitle>
+
+        <InfoBox>
+          <strong>{rows.length}</strong> tablas registradas en el catálogo de Xerenity.
+          Buscá por nombre, categoría o fuente; click en una fila para ver detalle
+          (descripción, columnas, valores, quién la pobla y quién la lee).
+        </InfoBox>
+
+        <Toolbar>
+          <div className="search-wrap">
+            <Icon icon={faSearch} style={{ color: '#888' }} />
+            <input
+              type="text"
+              placeholder="Buscar tabla, descripción, fuente…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+
+          <span className="label-inline">Categoría</span>
+          <Form.Select
+            size="sm"
+            value={categoryFilter}
+            onChange={(e) => setCategoryFilter(e.target.value)}
+            style={{ width: 'auto' }}
+          >
+            <option value="">Todas</option>
+            {optionSets.categories.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </Form.Select>
+
+          <span className="label-inline">País</span>
+          <Form.Select
+            size="sm"
+            value={countryFilter}
+            onChange={(e) => setCountryFilter(e.target.value)}
+            style={{ width: 'auto' }}
+          >
+            <option value="">Todos</option>
+            {optionSets.countries.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </Form.Select>
+
+          <span className="label-inline">Fuente</span>
+          <Form.Select
+            size="sm"
+            value={sourceFilter}
+            onChange={(e) => setSourceFilter(e.target.value)}
+            style={{ width: 'auto' }}
+          >
+            <option value="">Todas</option>
+            {optionSets.sources.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </Form.Select>
+
+          <label style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+            fontSize: 12, color: '#444', cursor: 'pointer',
+            padding: '4px 8px', background: '#f3f3f7', borderRadius: 4,
+          }}>
+            <input
+              type="checkbox"
+              checked={onlyCritical}
+              onChange={(e) => setOnlyCritical(e.target.checked)}
+              style={{ margin: 0 }}
+            />
+            Solo críticas
+          </label>
+
+          <span style={{ marginLeft: 'auto', fontSize: 11, color: '#888' }}>
+            {filtered.length} de {rows.length} tablas
+          </span>
+        </Toolbar>
+
+        {loading && <em style={{ color: '#888' }}>Cargando catálogo…</em>}
+        {error && (
+          <div style={{ color: '#dc3545', padding: 12, background: '#fdf3f4', borderRadius: 4 }}>
+            Error: {error}
+          </div>
+        )}
+
+        {!loading && !error && (
+          <TableWrap>
+            <table>
+              <thead>
+                <tr>
+                  <th onClick={() => toggleSort('table_name')}>Tabla {sortBy === 'table_name' && (sortDesc ? '▾' : '▴')}</th>
+                  <th>Label</th>
+                  <th onClick={() => toggleSort('category')}>Categoría {sortBy === 'category' && (sortDesc ? '▾' : '▴')}</th>
+                  <th onClick={() => toggleSort('country')}>País {sortBy === 'country' && (sortDesc ? '▾' : '▴')}</th>
+                  <th>Fuentes</th>
+                  <th onClick={() => toggleSort('n_collectors_writing')}>Writers {sortBy === 'n_collectors_writing' && (sortDesc ? '▾' : '▴')}</th>
+                  <th onClick={() => toggleSort('n_consumers')}>Consumers {sortBy === 'n_consumers' && (sortDesc ? '▾' : '▴')}</th>
+                  <th>Slice values</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((r) => (
+                  <tr key={r.table_name} onClick={() => { window.location.href = `/data-catalog/${encodeURIComponent(r.table_name)}`; }}>
+                    <td>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                        {r.is_critical && (
+                          <Icon icon={faStar} style={{ color: '#dc3545' }} title="Tabla crítica" />
+                        )}
+                        <Link href={`/data-catalog/${encodeURIComponent(r.table_name)}`} onClick={(e) => e.stopPropagation()}>
+                          {r.table_name}
+                        </Link>
+                      </span>
+                    </td>
+                    <td style={{ color: '#555' }}>{r.label ?? <em style={{ color: '#bbb' }}>—</em>}</td>
+                    <td>{r.category ? <Chip $color="#e7f1fb">{r.category}</Chip> : <em style={{ color: '#bbb' }}>—</em>}</td>
+                    <td>{r.country ? <Chip $color="#fff5e3">{r.country}</Chip> : <em style={{ color: '#bbb' }}>—</em>}</td>
+                    <td>
+                      {r.sources.length > 0 ? (
+                        r.sources.map((s) => <Chip key={s} $color="#f3f3f7">{s}</Chip>)
+                      ) : (
+                        <em style={{ color: '#bbb' }}>—</em>
+                      )}
+                    </td>
+                    <td>
+                      <Badge bg={r.n_collectors_writing > 0 ? 'primary' : 'secondary'}>
+                        {r.n_collectors_writing}
+                      </Badge>
+                    </td>
+                    <td>
+                      <Badge bg={r.n_consumers > 0 ? 'success' : 'secondary'}>
+                        {r.n_consumers}
+                      </Badge>
+                    </td>
+                    <td>
+                      {r.n_slice_values > 0 ? (
+                        <span style={{ fontSize: 11, color: '#666' }}>{r.n_slice_values} valores</span>
+                      ) : (
+                        <em style={{ color: '#bbb', fontSize: 11 }}>—</em>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+                {filtered.length === 0 && (
+                  <tr>
+                    <td colSpan={8} style={{ textAlign: 'center', color: '#999', padding: 32 }}>
+                      Sin tablas que coincidan con los filtros.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </TableWrap>
+        )}
+      </PageWrap>
+    </CoreLayout>
+  );
+};
+
+export default DataCatalogPage;

--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -197,3 +197,82 @@ export interface CollectorFullDetail {
   run_stats: CollectorRunStats | null;
   dictionary: CollectorDictionary | null;
 }
+
+
+// ──────────────────────────────────────────────────────────────────────
+// Phase 2 — public data catalog (visible to any authenticated user)
+// ──────────────────────────────────────────────────────────────────────
+
+// Row returned by list_data_catalog_overview. One per table_meta with
+// writer/reader counts and source attribution for the overview page.
+export interface DataCatalogOverviewEntry {
+  table_name: string;
+  label: string | null;
+  category: string | null;
+  country: string | null;
+  is_critical: boolean;
+  description: string | null;
+  date_column: string;
+  slice_column: string | null;
+  n_collectors_writing: number;
+  n_consumers: number;
+  sources: string[];
+  n_slice_values: number;
+}
+
+// Returned by get_table_lineage(table_name).
+export interface TableLineageWriter {
+  name: string;
+  description: string | null;
+  enabled: boolean;
+  severity: 'critical' | 'warning' | 'info';
+  source_name: string | null;
+  schedule_cron: string | null;
+  expected_frequency: string | null;
+}
+
+export interface TableLineageReader {
+  name: string;
+  consumer_type: string;
+  label: string;
+  path: string | null;
+  enabled: boolean;
+  writes_tables: string[];
+  description: string | null;
+}
+
+export interface TableLineage {
+  writers: TableLineageWriter[];
+  readers: TableLineageReader[];
+}
+
+// Returned by get_table_freshness(table_name).
+export interface TableFreshnessOverall {
+  row_count: number;
+  first_date: string | null;
+  last_date: string | null;
+  age_hours: number | null;
+  error?: string;
+}
+
+export interface TableFreshnessPerSlice {
+  slice_value: string;
+  row_count: number;
+  first_date: string | null;
+  last_date: string | null;
+}
+
+export interface TableFreshness {
+  overall: TableFreshnessOverall;
+  // per_slice is an array when slice_column is set; can be the literal []
+  // when there is no slice_column. May be an error object if dynamic SQL
+  // failed (e.g. column type mismatch). The detail page guards both.
+  per_slice: TableFreshnessPerSlice[] | { error: string };
+}
+
+// Returned by describe_table (already exists in Phase 1 RPCs).
+export interface TableDescription {
+  meta: DataTableMeta;
+  columns: DataColumnMeta[];
+  slices: DataSliceEntry[];
+}


### PR DESCRIPTION
New /data-catalog (overview) and /data-catalog/[table] (detail) pages. Visible to any authenticated user. Sidebar entry 'Catálogo' added. Backed by Phase 2 RPCs in xerenity-db.