### PR TITLE
feat(agent): catalog introspection tools (Phase 3)

### DIFF
--- a/src/pages/api/chat/tool-executor.ts
+++ b/src/pages/api/chat/tool-executor.ts
@@ -437,6 +437,77 @@ async function executeReadRepoFile(
 }
 
 
+// ─────────────────────────────────────────────────────────────────
+// Catalog tools (Phase 3) — let the agent introspect what data exists
+// before writing query_database SQL or referencing tables by guess.
+// All three use the caller's session (userSupabase) so the existing
+// auth.uid() gates in the catalog RPCs work transparently.
+// ─────────────────────────────────────────────────────────────────
+
+async function executeListDataCatalog(
+  userSupabase?: AnySupabaseClient,
+): Promise<ToolResult> {
+  if (!userSupabase) {
+    return { success: false, error: 'Se requiere sesion de usuario para consultar el catalogo' };
+  }
+  try {
+    const { data, error } = await userSupabase
+      .schema('xerenity')
+      .rpc('list_data_catalog_overview');
+    if (error) return { success: false, error: `Catalog overview: ${error.message}` };
+    return { success: true, data: { tables: data ?? [] } };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Error desconocido';
+    return { success: false, error: `Catalog overview: ${msg}` };
+  }
+}
+
+async function executeDescribeTable(
+  input: Record<string, unknown>,
+  userSupabase?: AnySupabaseClient,
+): Promise<ToolResult> {
+  if (!userSupabase) {
+    return { success: false, error: 'Se requiere sesion de usuario para describir tabla' };
+  }
+  const tableName = ((input.table_name as string) || '').trim();
+  if (!tableName) {
+    return { success: false, error: 'table_name es requerido' };
+  }
+  try {
+    const { data, error } = await userSupabase
+      .schema('xerenity')
+      .rpc('describe_table', { p_table: tableName });
+    if (error) return { success: false, error: `Describe table: ${error.message}` };
+    return { success: true, data };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Error desconocido';
+    return { success: false, error: `Describe table: ${msg}` };
+  }
+}
+
+async function executeDescribeLineage(
+  input: Record<string, unknown>,
+  userSupabase?: AnySupabaseClient,
+): Promise<ToolResult> {
+  if (!userSupabase) {
+    return { success: false, error: 'Se requiere sesion de usuario para consultar lineage' };
+  }
+  const tableName = ((input.table_name as string) || '').trim();
+  if (!tableName) {
+    return { success: false, error: 'table_name es requerido' };
+  }
+  try {
+    const { data, error } = await userSupabase
+      .schema('xerenity')
+      .rpc('get_table_lineage', { p_table: tableName });
+    if (error) return { success: false, error: `Lineage: ${error.message}` };
+    return { success: true, data };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Error desconocido';
+    return { success: false, error: `Lineage: ${msg}` };
+  }
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export async function executeTool(
   toolName: string,
@@ -460,6 +531,12 @@ export async function executeTool(
       return executeControlChart(toolInput);
     case 'read_repo_file':
       return executeReadRepoFile(toolInput, userSupabase);
+    case 'list_data_catalog':
+      return executeListDataCatalog(userSupabase);
+    case 'describe_table':
+      return executeDescribeTable(toolInput, userSupabase);
+    case 'describe_lineage':
+      return executeDescribeLineage(toolInput, userSupabase);
     default:
       return { success: false, error: `Tool desconocido: ${toolName}` };
   }

--- a/src/pages/api/chat/tools.ts
+++ b/src/pages/api/chat/tools.ts
@@ -241,4 +241,56 @@ export const tools: Anthropic.Tool[] = [
       required: ['action'],
     },
   },
+  {
+    name: 'list_data_catalog',
+    description:
+      'Devuelve el inventario de TODAS las tablas de datos registradas en el catálogo de Xerenity. ' +
+      'Para cada tabla incluye: nombre, label, categoría, país, fuentes (collectors writing), ' +
+      'número de consumers que la leen, número de slice values documentados, descripción, y ' +
+      'flag is_critical. Usar este tool ANTES de query_database cuando el usuario pregunta sobre ' +
+      'qué datos tiene Xerenity, o para descubrir qué tabla contiene cierta serie.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'describe_table',
+    description:
+      'Devuelve la descripción completa de una tabla específica del catálogo de Xerenity: ' +
+      'meta (label, descripción, categoría, país, columna fecha, columna slice), columnas con ' +
+      'tipos + labels + units, y diccionario de valores de slice (qué significa cada valor único ' +
+      'del slice_column). Usar este tool DESPUÉS de list_data_catalog cuando ya identificaste la ' +
+      'tabla de interés y necesitas detalles para construir queries SQL acertadas.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        table_name: {
+          type: 'string',
+          description: 'Nombre exacto de la tabla en el schema xerenity. Ej: "currency", "tes_operation", "cb_rates".',
+        },
+      },
+      required: ['table_name'],
+    },
+  },
+  {
+    name: 'describe_lineage',
+    description:
+      'Devuelve el lineage (linaje) de una tabla: qué collectors la pueblan (writers) y qué ' +
+      'consumers la leen (readers, e.g. páginas del FE, agente IA, pysdk). Útil para responder ' +
+      '"¿de dónde viene esta data?" o "¿quién depende de esta tabla?". ' +
+      'Cada writer incluye: nombre, source_name, cron, expected_frequency, severity, enabled. ' +
+      'Cada reader incluye: nombre, consumer_type (fe_page/agent_tool/sdk/etc), path, label, enabled.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        table_name: {
+          type: 'string',
+          description: 'Nombre exacto de la tabla en el schema xerenity.',
+        },
+      },
+      required: ['table_name'],
+    },
+  },
 ];


### PR DESCRIPTION
Three new tools (list_data_catalog, describe_table, describe_lineage) let the chat agent introspect xerenity.data_tables_meta + columns + slice values before writing SQL. Uses user session — no service-role escalation. Powered by the Phase 2 RPCs already live. Docs in xerenity-dm playbook §10.