### PR TITLE
feat(risk): selector global de fecha + migracion a market_marks

### DIFF
--- a/src/components/risk/GlobalDateSelector.tsx
+++ b/src/components/risk/GlobalDateSelector.tsx
@@ -1,0 +1,313 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+/**
+ * Selector global de fecha del modulo de Riesgos.
+ *
+ * Diseño: "trading desk precision" — terminal-grade adaptado a tema claro.
+ *   - Tipografia monospace con tabular-nums para todas las cifras.
+ *   - Acento amber instrumental (#9a3412) solo en estados activos/hover.
+ *   - Sin radius >2px, sin transiciones >100ms, sin gradientes.
+ *   - El mes se muestra como "MAY · 2026" (abreviatura caps + interpunct + año).
+ *
+ * Lee/escribe globalEvaluationDate + dateSelectorMode del store
+ * (Zustand, persistido en localStorage). El consumidor (paginas) siempre
+ * lee un ISO string "YYYY-MM-DD" via activeEvaluationDate().
+ */
+import { ChangeEvent } from 'react';
+import useAppStore from 'src/store';
+import {
+  parseISOAsNoon,
+  formatISO,
+  lastBusinessDayOfMonth,
+  prevMonth,
+  nextMonth,
+  MONTH_NAMES_SHORT,
+} from 'src/lib/risk/dateHelpers';
+
+// ─────────────────────────────────────────────────────────────────
+// Design tokens (scoped a este componente)
+// ─────────────────────────────────────────────────────────────────
+const T = {
+  ink: '#0f172a',
+  inkSoft: '#1e293b',
+  muted: '#64748b',
+  mutedDim: '#94a3b8',
+  surface: '#ffffff',
+  surfaceAlt: '#f8fafc',
+  hairline: '#cbd5e1',
+  hairlineSoft: '#e2e8f0',
+  accent: '#9a3412',
+  accentSoft: '#fed7aa',
+};
+
+const MONO = "'IBM Plex Mono', 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace";
+
+// ─────────────────────────────────────────────────────────────────
+export default function GlobalDateSelector() {
+  const date = useAppStore((s) => s.globalEvaluationDate);
+  const mode = useAppStore((s) => s.dateSelectorMode);
+  const setDate = useAppStore((s) => s.setGlobalEvaluationDate);
+  const setMode = useAppStore((s) => s.setDateSelectorMode);
+
+  const currentDate = parseISOAsNoon(date);
+
+  const handleModeChange = (newMode: 'month' | 'day') => {
+    setMode(newMode);
+    if (newMode === 'month') {
+      setDate(formatISO(lastBusinessDayOfMonth(currentDate)));
+    }
+  };
+
+  const handlePrevMonth = () => setDate(formatISO(prevMonth(currentDate)));
+  const handleNextMonth = () => setDate(formatISO(nextMonth(currentDate)));
+
+  const handleDayChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) setDate(value);
+  };
+
+  const monthAbbr = MONTH_NAMES_SHORT[currentDate.getUTCMonth()].toUpperCase();
+  const year = currentDate.getUTCFullYear();
+  const day = String(currentDate.getUTCDate()).padStart(2, '0');
+  const monthSmall = MONTH_NAMES_SHORT[currentDate.getUTCMonth()].toLowerCase();
+
+  return (
+    <div className="gds-root">
+      {/* Toggle segmentado MES / DÍA */}
+      <div className="gds-toggle" role="group" aria-label="Modo de selección">
+        <button
+          type="button"
+          className={`gds-toggle-btn ${mode === 'month' ? 'is-active' : ''}`}
+          onClick={() => handleModeChange('month')}
+          aria-pressed={mode === 'month'}
+        >
+          MES
+        </button>
+        <button
+          type="button"
+          className={`gds-toggle-btn ${mode === 'day' ? 'is-active' : ''}`}
+          onClick={() => handleModeChange('day')}
+          aria-pressed={mode === 'day'}
+        >
+          DÍA
+        </button>
+      </div>
+
+      <span className="gds-divider" aria-hidden="true" />
+
+      {/* Control segun modo */}
+      {mode === 'month' ? (
+        <div className="gds-control">
+          <button
+            type="button"
+            className="gds-chevron"
+            onClick={handlePrevMonth}
+            aria-label="Mes anterior"
+          >
+            ‹
+          </button>
+
+          <div className="gds-display">
+            <div className="gds-display-primary">
+              <span className="gds-month">{monthAbbr}</span>
+              <span className="gds-interpunct">·</span>
+              <span className="gds-year">{year}</span>
+            </div>
+            <div className="gds-display-secondary">
+              {day} {monthSmall}
+            </div>
+          </div>
+
+          <button
+            type="button"
+            className="gds-chevron"
+            onClick={handleNextMonth}
+            aria-label="Mes siguiente"
+          >
+            ›
+          </button>
+        </div>
+      ) : (
+        <div className="gds-control">
+          <input
+            type="date"
+            className="gds-date-input"
+            value={date}
+            onChange={handleDayChange}
+            aria-label="Fecha de evaluación"
+          />
+          <div className="gds-day-caption">específico</div>
+        </div>
+      )}
+
+      <style jsx>{`
+        .gds-root {
+          display: inline-flex;
+          align-items: stretch;
+          gap: 10px;
+          padding: 4px 6px 4px 4px;
+          background: ${T.surface};
+          border: 1px solid ${T.hairline};
+          font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+        }
+
+        /* Toggle segmentado */
+        .gds-toggle {
+          display: inline-flex;
+          align-items: stretch;
+          border: 1px solid ${T.hairline};
+          background: ${T.surfaceAlt};
+        }
+        .gds-toggle-btn {
+          display: inline-flex;
+          align-items: center;
+          padding: 4px 10px;
+          font-size: 10px;
+          font-weight: 600;
+          letter-spacing: 0.12em;
+          color: ${T.muted};
+          background: transparent;
+          border: none;
+          cursor: pointer;
+          transition: color 80ms ease, background-color 80ms ease;
+          font-feature-settings: 'tnum';
+        }
+        .gds-toggle-btn:not(:last-child) {
+          border-right: 1px solid ${T.hairline};
+        }
+        .gds-toggle-btn:hover:not(.is-active) {
+          color: ${T.ink};
+          background: ${T.surface};
+        }
+        .gds-toggle-btn.is-active {
+          color: ${T.surface};
+          background: ${T.ink};
+        }
+        .gds-toggle-btn:focus-visible {
+          outline: 2px solid ${T.accent};
+          outline-offset: -2px;
+        }
+
+        /* Divider vertical hairline */
+        .gds-divider {
+          width: 1px;
+          background: ${T.hairlineSoft};
+          align-self: stretch;
+          margin: 0 2px;
+        }
+
+        /* Wrapper del control activo */
+        .gds-control {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+        }
+
+        /* Chevron buttons */
+        .gds-chevron {
+          width: 26px;
+          height: 26px;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          font-family: ${MONO};
+          font-size: 16px;
+          font-weight: 600;
+          line-height: 1;
+          color: ${T.inkSoft};
+          background: ${T.surfaceAlt};
+          border: 1px solid ${T.hairline};
+          cursor: pointer;
+          transition: color 80ms ease, background-color 80ms ease, border-color 80ms ease;
+        }
+        .gds-chevron:hover {
+          color: ${T.accent};
+          background: ${T.surface};
+          border-color: ${T.accent};
+        }
+        .gds-chevron:active {
+          background: ${T.accentSoft};
+        }
+        .gds-chevron:focus-visible {
+          outline: 2px solid ${T.accent};
+          outline-offset: 2px;
+        }
+
+        /* Display "MAY · 2026" + sub "15 may" */
+        .gds-display {
+          min-width: 110px;
+          text-align: center;
+          padding: 0 4px;
+        }
+        .gds-display-primary {
+          display: inline-flex;
+          align-items: baseline;
+          gap: 6px;
+          font-family: ${MONO};
+          line-height: 1;
+        }
+        .gds-month {
+          font-size: 13px;
+          font-weight: 700;
+          letter-spacing: 0.14em;
+          color: ${T.ink};
+        }
+        .gds-interpunct {
+          font-size: 13px;
+          font-weight: 500;
+          color: ${T.mutedDim};
+          transform: translateY(-1px);
+        }
+        .gds-year {
+          font-size: 13px;
+          font-weight: 500;
+          color: ${T.inkSoft};
+          font-variant-numeric: tabular-nums;
+          font-feature-settings: 'tnum';
+          letter-spacing: 0.02em;
+        }
+        .gds-display-secondary {
+          margin-top: 3px;
+          font-family: ${MONO};
+          font-size: 10px;
+          font-weight: 500;
+          letter-spacing: 0.08em;
+          color: ${T.muted};
+          font-variant-numeric: tabular-nums;
+          font-feature-settings: 'tnum';
+          text-transform: uppercase;
+        }
+
+        /* Input date para modo Dia */
+        .gds-date-input {
+          font-family: ${MONO};
+          font-size: 12px;
+          font-weight: 500;
+          letter-spacing: 0.04em;
+          color: ${T.ink};
+          padding: 4px 8px;
+          background: ${T.surface};
+          border: 1px solid ${T.hairline};
+          font-variant-numeric: tabular-nums;
+          font-feature-settings: 'tnum';
+          transition: border-color 80ms ease;
+        }
+        .gds-date-input:hover {
+          border-color: ${T.inkSoft};
+        }
+        .gds-date-input:focus {
+          outline: none;
+          border-color: ${T.accent};
+        }
+        .gds-day-caption {
+          font-size: 10px;
+          font-weight: 500;
+          letter-spacing: 0.1em;
+          color: ${T.muted};
+          text-transform: uppercase;
+          font-family: ${MONO};
+        }
+      `}
+      </style>
+    </div>
+  );
+}

--- a/src/layout/CoreLayout/CoreLayout.tsx
+++ b/src/layout/CoreLayout/CoreLayout.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/router';
 import useAppStore from 'src/store';
 import type { Company } from 'src/types/user';
 import ChatContainer from '@components/chat/ChatContainer';
+import GlobalDateSelector from 'src/components/risk/GlobalDateSelector';
 import MobileWarning from './MobileWarning';
 
 const LOGIN_PATH = '/login';
@@ -36,18 +37,60 @@ function CompanySelector({ companies, selectedCompanyId, onSelect, onLoad }: {
   if (companies.length === 0) return null;
 
   return (
-    <div style={{ padding: '8px 16px', background: '#f1f5f9', borderBottom: '1px solid #e2e8f0', display: 'flex', alignItems: 'center', gap: 8 }}>
-      <span style={{ fontSize: '0.8rem', fontWeight: 600, color: '#64748b' }}>Empresa:</span>
+    <div className="company-selector-root">
+      <span className="company-selector-label">EMPRESA</span>
       <select
+        className="company-selector-select"
         value={selectedCompanyId || ''}
         onChange={(e) => onSelect(e.target.value || undefined)}
-        style={{ fontSize: '0.8rem', padding: '4px 8px', borderRadius: 4, border: '1px solid #cbd5e1', minWidth: 200 }}
       >
-        <option value="">Seleccionar empresa...</option>
+        <option value="">Seleccionar...</option>
         {companies.map((c) => (
           <option key={c.id} value={c.id}>{c.name}</option>
         ))}
       </select>
+      <style jsx>{`
+        .company-selector-root {
+          display: inline-flex;
+          align-items: stretch;
+          background: #ffffff;
+          border: 1px solid #cbd5e1;
+        }
+        .company-selector-label {
+          display: inline-flex;
+          align-items: center;
+          padding: 0 10px;
+          font-size: 10px;
+          font-weight: 600;
+          letter-spacing: 0.12em;
+          color: #64748b;
+          background: #f8fafc;
+          border-right: 1px solid #e2e8f0;
+        }
+        .company-selector-select {
+          font-size: 12px;
+          font-weight: 500;
+          letter-spacing: 0.02em;
+          color: #0f172a;
+          background: #ffffff;
+          padding: 5px 28px 5px 10px;
+          min-width: 200px;
+          border: none;
+          outline: none;
+          font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+          appearance: none;
+          background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+          background-repeat: no-repeat;
+          background-position: right 8px center;
+        }
+        .company-selector-select:hover {
+          background-color: #f8fafc;
+        }
+        .company-selector-select:focus-visible {
+          outline: 2px solid #9a3412;
+          outline-offset: -2px;
+        }
+      `}</style>
     </div>
   );
 }
@@ -132,14 +175,31 @@ export default function CoreLayout({ children }: PropsWithChildren) {
         <div className="layout-wrapper">
           <Sidebar />
           <div className="layout-content">
-            {isSuperAdmin() && isRiskSection(router.pathname) && (
-              <CompanySelector
-                companies={companies}
-                selectedCompanyId={selectedCompanyId}
-                onSelect={setSelectedCompanyId}
-                onLoad={loadCompanies}
-              />
+            {isRiskSection(router.pathname) && (
+              <div className="risk-context-bar">
+                {isSuperAdmin() ? (
+                  <CompanySelector
+                    companies={companies}
+                    selectedCompanyId={selectedCompanyId}
+                    onSelect={setSelectedCompanyId}
+                    onLoad={loadCompanies}
+                  />
+                ) : null}
+                <GlobalDateSelector />
+              </div>
             )}
+            <style jsx>{`
+              .risk-context-bar {
+                display: flex;
+                align-items: center;
+                gap: 24px;
+                padding: 10px 20px;
+                background: #f8fafc;
+                border-bottom: 1px solid #e2e8f0;
+                flex-wrap: wrap;
+                font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+              }
+            `}</style>
             <div>{children}</div>
           </div>
         </div>

--- a/src/lib/risk/dateHelpers.ts
+++ b/src/lib/risk/dateHelpers.ts
@@ -1,0 +1,162 @@
+/**
+ * Helpers centralizados de fechas para el módulo de Riesgos.
+ *
+ * Convenciones:
+ *   - El "wire format" es ISO string `"YYYY-MM-DD"` (sin hora, sin tz).
+ *   - Las funciones que reciben `Date` NUNCA lo mutan; siempre retornan un Date nuevo.
+ *   - `parseISOAsNoon` ancla la fecha al mediodía UTC para evitar bugs
+ *     de timezone shift cuando se construye un Date desde un string ISO.
+ *
+ * Este módulo reemplaza las copias dispersas de `lastBusinessDay`,
+ * `lastDayOfMonth`, `currentMonth`, etc. que vivían en risk-resumen,
+ * risk-management, futuresCalculator y riskApi.
+ */
+
+export const MONTH_NAMES = [
+  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+] as const;
+
+export const MONTH_NAMES_SHORT = [
+  'Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun',
+  'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic',
+] as const;
+
+// ─────────────────────────────────────────────────────────────────
+// Parse / format
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Convierte ISO string `"YYYY-MM-DD"` a Date anclado al mediodía UTC.
+ * Esto evita que `new Date("2026-03-15")` se interprete como medianoche
+ * UTC (puede dar día anterior en Colombia) o medianoche local (puede
+ * dar día siguiente en UTC).
+ */
+export function parseISOAsNoon(isoDate: string): Date {
+  return new Date(`${isoDate}T12:00:00Z`);
+}
+
+/**
+ * Date → ISO string `"YYYY-MM-DD"` (UTC-safe vía toISOString().slice).
+ * Siempre 10 chars exactos.
+ */
+export function formatISO(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * "Marzo 2026" — label legible para selectores y headers.
+ */
+export function formatMonthLabel(d: Date): string {
+  return `${MONTH_NAMES[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+}
+
+/**
+ * "Marzo 2026 (último día hábil: 31-mar)" — variante extendida.
+ */
+export function formatMonthLabelExtended(d: Date): string {
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const monthShort = MONTH_NAMES_SHORT[d.getUTCMonth()];
+  return `${formatMonthLabel(d)} (último día hábil: ${day}-${monthShort})`;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Calendario (sin festivos por ahora — solo fines de semana)
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Retorna el último día hábil <= la fecha dada. Inmutable.
+ * Si cae sábado/domingo, retrocede al viernes.
+ * NOTA: aún no respeta festivos colombianos — TODO.
+ */
+export function lastBusinessDay(d: Date): Date {
+  const result = new Date(d.getTime());
+  const day = result.getUTCDay();
+  if (day === 0) {          // domingo → viernes
+    result.setUTCDate(result.getUTCDate() - 2);
+  } else if (day === 6) {   // sábado → viernes
+    result.setUTCDate(result.getUTCDate() - 1);
+  }
+  return result;
+}
+
+/**
+ * Último día hábil del mes al que pertenece la fecha dada.
+ * Ej: lastBusinessDayOfMonth(2026-03-15) → 2026-03-31 (martes hábil).
+ */
+export function lastBusinessDayOfMonth(d: Date): Date {
+  // Primer día del mes siguiente, menos un día = último del mes actual
+  const eom = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0, 12, 0, 0));
+  return lastBusinessDay(eom);
+}
+
+/**
+ * Último día hábil del mes anterior al de la fecha dada.
+ * Ej: lastBusinessDayOfPrevMonth(2026-04-15) → 2026-03-31.
+ *
+ * Reemplaza las copias duplicadas en futuresCalculator.ts y riskApi.ts.
+ */
+export function lastBusinessDayOfPrevMonth(d: Date): Date {
+  // Día 0 del mes actual = último día del mes anterior
+  const eomPrev = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 0, 12, 0, 0));
+  return lastBusinessDay(eomPrev);
+}
+
+/**
+ * Primer día hábil del mes al que pertenece la fecha dada.
+ */
+export function firstBusinessDayOfMonth(d: Date): Date {
+  const result = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1, 12, 0, 0));
+  const day = result.getUTCDay();
+  if (day === 6) result.setUTCDate(result.getUTCDate() + 2);  // sábado → lunes
+  else if (day === 0) result.setUTCDate(result.getUTCDate() + 1); // domingo → lunes
+  return result;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// "Hoy" en Bogotá
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Hoy en zona horaria de Bogotá como Date anclado al mediodía UTC.
+ * Útil para inicializar selectores sin riesgo de off-by-one entre
+ * 19:00 y 00:00 hora Colombia (cuando UTC ya está en el día siguiente).
+ */
+export function todayBogota(): Date {
+  // Trick: usar Intl con timeZone Bogotá para extraer el día local,
+  // luego construir UTC noon de ese día.
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Bogota',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  });
+  const parts = fmt.format(new Date()); // "2026-05-15"
+  return parseISOAsNoon(parts);
+}
+
+/**
+ * Default razonable para `globalEvaluationDate`:
+ * último día hábil del mes corriente (Bogotá).
+ */
+export function defaultEvaluationDate(): Date {
+  return lastBusinessDayOfMonth(todayBogota());
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Navegación de meses (para selectores tipo `< Marzo 2026 >`)
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Mes anterior (preservando el último día hábil del mes).
+ */
+export function prevMonth(d: Date): Date {
+  const ref = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() - 1, 15, 12, 0, 0));
+  return lastBusinessDayOfMonth(ref);
+}
+
+/**
+ * Mes siguiente (preservando el último día hábil del mes).
+ */
+export function nextMonth(d: Date): Date {
+  const ref = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 15, 12, 0, 0));
+  return lastBusinessDayOfMonth(ref);
+}

--- a/src/lib/risk/futuresCalculator.ts
+++ b/src/lib/risk/futuresCalculator.ts
@@ -8,6 +8,7 @@
 import type { FuturesPosition } from 'src/types/risk';
 import type { FuturesPositionRow } from './supabaseRisk';
 import type { CommodityConfig } from './companyConfig';
+import { lastBusinessDayOfPrevMonth as lastBusinessDayOfPrevMonthHelper } from './dateHelpers';
 
 // ── Constants ──
 
@@ -68,15 +69,11 @@ export function parseContractMaturity(contract: string | null | undefined): stri
 
 /**
  * Last business day of the previous month (skip weekends).
+ * Re-exporta el helper inmutable centralizado para mantener la API pública
+ * de este modulo. Antes habia una copia local mutadora — ahora vive en
+ * dateHelpers.ts (single source of truth).
  */
-export function lastBusinessDayOfPrevMonth(refDate: Date): Date {
-  const firstOfMonth = new Date(refDate.getFullYear(), refDate.getMonth(), 1);
-  const lastCalDay = new Date(firstOfMonth.getTime() - 86400000); // day before = last of prev month
-  const wd = lastCalDay.getDay(); // 0=Sun, 6=Sat
-  if (wd === 0) lastCalDay.setDate(lastCalDay.getDate() - 2); // Sun → Fri
-  else if (wd === 6) lastCalDay.setDate(lastCalDay.getDate() - 1); // Sat → Fri
-  return lastCalDay;
-}
+export const lastBusinessDayOfPrevMonth = lastBusinessDayOfPrevMonthHelper;
 
 function toDateStr(d: Date): string {
   return d.toISOString().slice(0, 10);

--- a/src/lib/risk/marketMarks.ts
+++ b/src/lib/risk/marketMarks.ts
@@ -1,0 +1,135 @@
+/**
+ * Lecturas directas de `xerenity.market_marks` desde Supabase.
+ *
+ * `market_marks` es la fuente unica de verdad EOD para valoracion (FX spot,
+ * curvas IBR/SOFR/NDF). El backend Django ya lee esta tabla para OTC pricing
+ * (via /pricing/marks). Este modulo es el equivalente frontend-only para que
+ * el modulo de Riesgos pueda anclar sus calculos a la MISMA fuente que OTC,
+ * sin pasar por Django.
+ *
+ * Fallback policy: cuando no hay dato para una fecha exacta, retornamos el
+ * ultimo valor disponible <= esa fecha (carry-forward). Mismo comportamiento
+ * que `MarketDataLoader.fetch_usdcop_spot()` en pysdk.
+ */
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+
+const supabase = createClientComponentClient();
+const SCHEMA = 'xerenity';
+
+export interface MarketMarkRow {
+  fecha: string;             // ISO YYYY-MM-DD
+  status?: string | null;
+  fx_spot: number | null;
+  sofr_on?: number | null;
+  ibr?: Record<string, number> | null;
+  sofr?: Record<string, number> | null;
+  ndf?: Record<string, number> | null;
+}
+
+export interface FxSpotPoint {
+  fecha: string;
+  fx_spot: number;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// FX spot puntual (con carry-forward)
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Lee USD/COP spot EOD para una fecha especifica.
+ * Si no hay dato exacto, retorna el ultimo valor disponible <= fecha.
+ * Si no hay NADA en la tabla, retorna null (caller debe manejar).
+ */
+export async function fetchFxSpot(targetDate: string): Promise<number | null> {
+  // 1) Try exact date
+  const exactRes = await supabase
+    .schema(SCHEMA)
+    .from('market_marks')
+    .select('fx_spot')
+    .eq('fecha', targetDate)
+    .maybeSingle();
+  if (exactRes.error) throw new Error(`Failed to fetch market_marks: ${exactRes.error.message}`);
+  if (exactRes.data?.fx_spot != null) return Number(exactRes.data.fx_spot);
+
+  // 2) Carry-forward: ultimo dia con dato <= targetDate
+  const cfRes = await supabase
+    .schema(SCHEMA)
+    .from('market_marks')
+    .select('fx_spot, fecha')
+    .lte('fecha', targetDate)
+    .not('fx_spot', 'is', null)
+    .order('fecha', { ascending: false })
+    .limit(1);
+  if (cfRes.error) throw new Error(`Failed to fetch market_marks (carry-forward): ${cfRes.error.message}`);
+  const row = cfRes.data?.[0];
+  return row?.fx_spot != null ? Number(row.fx_spot) : null;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// FX spot serie historica (para Rolling VaR, vol calc, etc.)
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Lee serie de USD/COP spot EOD entre dos fechas inclusivas.
+ * Solo retorna dias con dato (sin carry-forward — el caller decide si rellena).
+ *
+ * Tipico uso: rolling VaR 180d, calculo de volatilidad, charts historicos.
+ */
+export async function fetchFxSpotSeries(
+  startDate: string,
+  endDate: string,
+): Promise<FxSpotPoint[]> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('market_marks')
+    .select('fecha, fx_spot')
+    .gte('fecha', startDate)
+    .lte('fecha', endDate)
+    .not('fx_spot', 'is', null)
+    .order('fecha', { ascending: true });
+  if (error) throw new Error(`Failed to fetch fx_spot series: ${error.message}`);
+  return (data ?? []).map((r) => ({
+    fecha: String(r.fecha),
+    fx_spot: Number(r.fx_spot),
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Mark completo (FX + IBR + SOFR + NDF JSONB)
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Lee la fila completa de market_marks para una fecha. Util si el caller
+ * necesita IBR/SOFR/NDF curves ademas del fx_spot.
+ *
+ * Sin carry-forward por defecto — el caller decide si quiere fallback al
+ * ultimo disponible (usar fetchLatestMarketMark).
+ */
+export async function fetchMarketMark(targetDate: string): Promise<MarketMarkRow | null> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('market_marks')
+    .select('*')
+    .eq('fecha', targetDate)
+    .maybeSingle();
+  if (error) throw new Error(`Failed to fetch market_marks row: ${error.message}`);
+  return (data as MarketMarkRow | null) ?? null;
+}
+
+/**
+ * Lee la fila mas reciente de market_marks <= targetDate.
+ * Util para anclar curvas al ultimo dia con dato cuando el target tiene gap.
+ */
+export async function fetchLatestMarketMark(
+  targetDate: string,
+): Promise<MarketMarkRow | null> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('market_marks')
+    .select('*')
+    .lte('fecha', targetDate)
+    .order('fecha', { ascending: false })
+    .limit(1);
+  if (error) throw new Error(`Failed to fetch latest market_marks: ${error.message}`);
+  return (data?.[0] as MarketMarkRow | undefined) ?? null;
+}

--- a/src/lib/risk/supabaseRisk.ts
+++ b/src/lib/risk/supabaseRisk.ts
@@ -4,6 +4,7 @@
  * Replaces Django backend calls — reads from xerenity schema tables.
  */
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { fetchFxSpotSeries } from 'src/lib/risk/marketMarks';
 
 const supabase = createClientComponentClient();
 const SCHEMA = 'xerenity';
@@ -21,16 +22,40 @@ export async function fetchRiskPrices(
   startDate: string,
   endDate: string,
 ): Promise<RiskPriceRow[]> {
-  const { data, error } = await supabase
+  // Commodities: precios EOD vienen de `risk_prices` (alimentada por collectors
+  // de IB para MAIZ/AZUCAR/CACAO/CAFE/etc.). Excluimos asset='USD' aqui.
+  // USD: viene de `market_marks.fx_spot` para ser consistente con OTC pricing
+  // y con la fuente unica de verdad del modulo. Si en `risk_prices` queda
+  // alguna fila vieja con asset='USD', se ignora.
+  const { data: commodityData, error: commodityErr } = await supabase
     .schema(SCHEMA)
     .from('risk_prices')
     .select('date, asset, price, contract')
     .gte('date', startDate)
     .lte('date', endDate)
+    .neq('asset', 'USD')
     .order('date', { ascending: true });
 
-  if (error) throw new Error(`Failed to fetch risk_prices: ${error.message}`);
-  return (data ?? []) as RiskPriceRow[];
+  if (commodityErr) throw new Error(`Failed to fetch risk_prices: ${commodityErr.message}`);
+  const commodityRows = (commodityData ?? []) as RiskPriceRow[];
+
+  // USD desde market_marks (single source of truth EOD para FX).
+  // Si falla, no rompemos los commodities — solo loggeamos.
+  let usdRows: RiskPriceRow[] = [];
+  try {
+    const fxSeries = await fetchFxSpotSeries(startDate, endDate);
+    usdRows = fxSeries.map((p) => ({
+      date: p.fecha,
+      asset: 'USD',
+      price: p.fx_spot,
+      contract: null,
+    }));
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('fetchRiskPrices: no se pudo cargar USD de market_marks:', e);
+  }
+
+  return [...commodityRows, ...usdRows].sort((a, b) => a.date.localeCompare(b.date));
 }
 
 /**

--- a/src/models/risk/riskApi.ts
+++ b/src/models/risk/riskApi.ts
@@ -23,6 +23,11 @@ import { calcularExposicionTotal } from 'src/lib/risk/exposureCalculator';
 import { calculateFuturesPortfolio, executeRoll } from 'src/lib/risk/futuresCalculator';
 import type { CommodityConfig, RiskCompanyConfig } from 'src/lib/risk/companyConfig';
 import { getUnits } from 'src/lib/risk/companyConfig';
+import {
+  parseISOAsNoon,
+  formatISO,
+  lastBusinessDayOfPrevMonth as lastBusinessDayOfPrevMonthDate,
+} from 'src/lib/risk/dateHelpers';
 
 // Fallback units (used when no company config)
 const DEFAULT_UNITS: Record<string, string> = {
@@ -37,14 +42,10 @@ function getStartDate(filterDate: string, daysBack: number): string {
   return d.toISOString().slice(0, 10);
 }
 
+/** Wrapper string -> string. Delegates a la implementacion inmutable de
+ *  dateHelpers.ts (single source of truth, libre de mutacion). */
 function lastBusinessDayOfPrevMonth(filterDate: string): string {
-  const d = new Date(filterDate + 'T12:00:00');
-  const first = new Date(d.getFullYear(), d.getMonth(), 1);
-  const last = new Date(first.getTime() - 86400000);
-  const wd = last.getDay();
-  if (wd === 0) last.setDate(last.getDate() - 2);
-  else if (wd === 6) last.setDate(last.getDate() - 1);
-  return last.toISOString().slice(0, 10);
+  return formatISO(lastBusinessDayOfPrevMonthDate(parseISOAsNoon(filterDate)));
 }
 
 // ── Benchmark Factors ──

--- a/src/models/risk/usdcopCalculator.ts
+++ b/src/models/risk/usdcopCalculator.ts
@@ -1,9 +1,18 @@
 /**
- * USDCOP Calculator — fetch TRM and volatility from pysdk backend.
- * Endpoint: GET /usdcop_calculator
+ * USDCOP Calculator — calcula TRM spot + vol rolling 180d desde `market_marks`.
+ *
+ * Antes: llamaba al endpoint Django `/usdcop_calculator` que leia de
+ * `banrep_series_value_v2`. Ahora calcula 100% en el frontend leyendo de
+ * `xerenity.market_marks.fx_spot` (misma fuente que OTC pricing).
+ *
+ * Esto garantiza consistencia con el resto del modulo de Riesgos y con
+ * el portafolio OTC — siempre el mismo TRM EOD.
  */
+import { fetchFxSpotSeries } from 'src/lib/risk/marketMarks';
 
-const BASE_URL = process.env.NEXT_PUBLIC_PYSDK_URL || 'https://pysdk.fly.dev';
+const TRADING_DAYS = 252;
+const VOL_WINDOW = 180;
+const FETCH_DAYS_BACK = 400; // ~13 meses de calendario para tener 180 dias habiles
 
 export interface UsdCopData {
   trm: number;
@@ -12,10 +21,53 @@ export interface UsdCopData {
   fecha: string;
 }
 
-export async function fetchUsdCopCalculator(): Promise<UsdCopData> {
-  const resp = await fetch(`${BASE_URL}/usdcop_calculator`);
-  if (!resp.ok) {
-    throw new Error(`Failed to fetch USDCOP calculator: HTTP ${resp.status}`);
+/**
+ * Calcula TRM y vol rolling 180d a partir de `market_marks.fx_spot`.
+ *
+ * @param asOfDate (opcional) fecha de referencia "YYYY-MM-DD". Si se omite
+ *   usa hoy. Util para que el calculador se sincronice con el selector
+ *   global de fecha del modulo de Riesgos.
+ */
+export async function fetchUsdCopCalculator(asOfDate?: string): Promise<UsdCopData> {
+  const end = asOfDate ?? new Date().toISOString().slice(0, 10);
+  const endDate = new Date(`${end}T12:00:00Z`);
+  const startDate = new Date(endDate);
+  startDate.setUTCDate(startDate.getUTCDate() - FETCH_DAYS_BACK);
+  const start = startDate.toISOString().slice(0, 10);
+
+  const series = await fetchFxSpotSeries(start, end);
+  if (series.length < 2) {
+    throw new Error('Datos insuficientes de market_marks.fx_spot para calcular retornos');
   }
-  return resp.json();
+
+  // Log returns: r_t = ln(p_t / p_{t-1})
+  const logReturns: number[] = [];
+  for (let i = 1; i < series.length; i += 1) {
+    const prev = series[i - 1].fx_spot;
+    const curr = series[i].fx_spot;
+    if (prev > 0 && curr > 0) {
+      logReturns.push(Math.log(curr / prev));
+    }
+  }
+
+  // Ventana rolling 180d (ultimos N returns)
+  const window = logReturns.slice(-VOL_WINDOW);
+  if (window.length < 30) {
+    throw new Error(`Datos insuficientes para vol rolling: ${window.length} retornos (min 30)`);
+  }
+
+  // Desviacion estandar muestral (n-1, mismo que pandas .std() default)
+  const mean = window.reduce((s, v) => s + v, 0) / window.length;
+  const variance = window.reduce((s, v) => s + (v - mean) ** 2, 0) / (window.length - 1);
+  const volDiaria = Math.sqrt(variance);
+  const volAnual = volDiaria * Math.sqrt(TRADING_DAYS);
+
+  const latest = series[series.length - 1];
+
+  return {
+    trm: latest.fx_spot,
+    vol_diaria: volDiaria,
+    vol_anual: volAnual,
+    fecha: latest.fecha,
+  };
 }

--- a/src/pages/portfolio/index.tsx
+++ b/src/pages/portfolio/index.tsx
@@ -66,37 +66,7 @@ import { MarksContent } from '../marks';
 
 const PAGE_TITLE = 'Portafolio de Derivados';
 
-// ── Mark date helpers ──
-/** Parse pysdk valuation_date string ("February 27th, 2026") → "2026-02-27" */
-function parseValuationDate(valDate: string | undefined): string | undefined {
-  if (!valDate) return undefined;
-  const d = new Date(valDate);
-  if (!Number.isNaN(d.getTime())) return d.toISOString().slice(0, 10);
-  return undefined;
-}
-
-function lastBusinessDay(d: Date): Date {
-  const day = d.getDay();
-  if (day === 0) d.setDate(d.getDate() - 2);
-  else if (day === 6) d.setDate(d.getDate() - 1);
-  return d;
-}
-function defaultMarkFecha(): string {
-  const d = new Date();
-  d.setDate(d.getDate() - 1);
-  return lastBusinessDay(d).toISOString().slice(0, 10);
-}
-function stepMarkDate(fecha: string, delta: number): string {
-  const d = new Date(`${fecha}T12:00:00`);
-  const step = delta > 0 ? 1 : -1;
-  let remaining = Math.abs(delta);
-  while (remaining > 0) {
-    d.setDate(d.getDate() + step);
-    const day = d.getDay();
-    if (day !== 0 && day !== 6) remaining -= 1;
-  }
-  return d.toISOString().slice(0, 10);
-}
+// Helpers de fecha locales removidos. La fecha viene del store global.
 
 // ── Mark Chip with dropdown ──
 function MarkChip({ label, ok, rows }: { label: string; ok: boolean; rows: [string, string][] }) {
@@ -148,12 +118,6 @@ const fmt = (v: number | null | undefined, decimals = 2) =>
       })
     : '\u2014';
 
-// ── Mark Date Bar ──
-const markNavBtn: React.CSSProperties = {
-  background: 'none', border: '1px solid #ced4da', borderRadius: 4,
-  padding: '2px 8px', cursor: 'pointer', fontSize: 12, color: '#495057',
-};
-
 const IBR_TENOR_KEYS: [string, string][] = [
   ['O/N', 'ibr_1d'], ['1M', 'ibr_1m'], ['3M', 'ibr_3m'], ['6M', 'ibr_6m'],
   ['1Y', 'ibr_12m'], ['2Y', 'ibr_2y'], ['5Y', 'ibr_5y'], ['10Y', 'ibr_10y'],
@@ -186,14 +150,10 @@ function ndfMarkRows(mark: HistoricalMark | null): [string, string][] {
 function MarkDateBar({
   repricing,
   fecha,
-  onFechaChange,
 }: {
   repricing: boolean;
   fecha: string;
-  onFechaChange: (f: string) => void;
 }) {
-  const today = new Date().toISOString().slice(0, 10);
-  const setFecha = onFechaChange;
   const [mark, setMark] = useState<HistoricalMark | null>(null);
   const [loadingMark, setLoadingMark] = useState(false);
 
@@ -211,22 +171,25 @@ function MarkDateBar({
 
   return (
     <div style={{
-      display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12,
+      display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12,
       fontSize: 12, flexWrap: 'wrap', background: '#f8f9fa',
       borderRadius: 6, padding: '6px 12px',
-    }}>
+    }}
+    >
       <span style={{ color: '#495057', fontWeight: 600 }}>Marca:</span>
-      <input
-        type="date"
-        value={fecha}
-        min="2026-01-01"
-        max={today}
-        onChange={(e) => e.target.value && setFecha(e.target.value)}
-        style={{ border: '1px solid #ced4da', borderRadius: 4, padding: '2px 6px', fontSize: 12, fontFamily: 'monospace' }}
-      />
-      <button type="button" onClick={() => setFecha(stepMarkDate(fecha, -1))} disabled={loadingMark} style={markNavBtn}>◀</button>
-      <button type="button" onClick={() => { const next = stepMarkDate(fecha, 1); if (next <= today) setFecha(next); }} disabled={loadingMark} style={markNavBtn}>▶</button>
-      <button type="button" onClick={() => setFecha(defaultMarkFecha())} disabled={loadingMark} style={{ ...markNavBtn, padding: '2px 10px' }}>Ayer</button>
+      <span style={{
+        fontFamily: 'ui-monospace, monospace',
+        fontWeight: 500,
+        color: '#0f172a',
+        padding: '2px 8px',
+        border: '1px solid #cbd5e1',
+        borderRadius: 4,
+        background: '#fff',
+        letterSpacing: '0.03em',
+      }}
+      >
+        {fecha}
+      </span>
       {loadingMark ? (
         <span style={{ color: '#6c757d' }}>…</span>
       ) : (
@@ -1937,7 +1900,12 @@ function CurvesPanel({ status }: { status: CurveStatus | null }) {
 function PortfolioPage() {
   const [loading, setLoading] = useState(false);
   const [markRepricing, setMarkRepricing] = useState(false);
-  const [markFecha, setMarkFecha] = useState<string>(defaultMarkFecha());
+  // Fecha global del modulo de Riesgos. El blotter OTC se anclla 100% a
+  // esta fecha — sin override local (mismo comportamiento que Resumen y
+  // Exposicion). Si el usuario quiere cambiar la fecha, lo hace desde el
+  // selector global de CoreLayout (con toggle Mes/Dia).
+  const markFecha = useAppStore((s) => s.globalEvaluationDate);
+  const setMarkFecha = useAppStore((s) => s.setGlobalEvaluationDate);
   const [curveStatus, setCurveStatus] = useState<CurveStatus | null>(null);
   const [addType, setAddType] = useState<string | null>(null); // 'xccy' | 'ndf' | 'ibr' | null
   // (#313 removed repriceTrigger — useRepricePortfolio's key includes position
@@ -2100,11 +2068,15 @@ function PortfolioPage() {
   }, [handleBuild, loadUserRole, loadMarketDataConfig, selectedCompanyId]);
 
 
-  // Sync markFecha to curveStatus valuation_date once it loads
-  useEffect(() => {
-    const parsed = parseValuationDate(curveStatus?.valuation_date);
-    if (parsed) setMarkFecha(parsed);
-  }, [curveStatus?.valuation_date]);
+  // NOTE: anteriormente habia un useEffect que sincronizaba markFecha al
+  // valuation_date que retornaba el backend (curveStatus). Esto creaba un
+  // tug-of-war con el selector global: el usuario cambiaba la fecha, el
+  // backend snapeaba a un dia habil, y este useEffect clobbereaba el valor
+  // local. Removido. Ahora `markFecha` solo cambia via:
+  //   1. globalEvaluationDate (selector global del CoreLayout)
+  //   2. Override manual en la MarkDateBar (input/◀/▶)
+  // Si el backend snapea, se muestra `curveStatus.valuation_date` por
+  // separado pero NO se reescribe `markFecha`.
 
   // Auto-reprice when positions loaded and curves are ready
   const curvesReady =
@@ -2256,7 +2228,6 @@ function PortfolioPage() {
         <MarkDateBar
           repricing={markRepricing}
           fecha={markFecha}
-          onFechaChange={setMarkFecha}
         />
 
         {/* Active market data sources */}

--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -10,8 +10,6 @@ import {
   faSyncAlt,
   faChartLine,
   faEdit,
-  faChevronLeft,
-  faChevronRight,
   faDollarSign,
   faBorderAll,
   faBookOpen,
@@ -50,6 +48,7 @@ import RoleGuard from 'src/components/RoleGuard';
 import { fetchCompanyRiskConfig, getAssetsWithCurrency, getChartColors, saveCompanyRiskConfig, COMMODITY_TEMPLATES, DEFAULT_EXPOSURE_PARAMS } from 'src/lib/risk/companyConfig';
 import type { RiskCompanyConfig } from 'src/lib/risk/companyConfig';
 import { parseContractMaturity } from 'src/lib/risk/futuresCalculator';
+import { lastBusinessDay, MONTH_NAMES } from 'src/lib/risk/dateHelpers';
 import BlotterCafe from 'src/components/risk/BlotterCafe';
 import BlotterCompraCafe from 'src/components/risk/BlotterCompraCafe';
 
@@ -169,39 +168,14 @@ const CHART_COLORS: Record<string, string> = {
   USD: '#3b82f6',
 };
 
-function lastBusinessDay(d: Date): Date {
-  const day = d.getDay();
-  if (day === 0) d.setDate(d.getDate() - 2);
-  else if (day === 6) d.setDate(d.getDate() - 1);
-  return d;
-}
+// Helpers de fecha (lastBusinessDay, lastBusinessDayOfMonth, MONTH_NAMES, etc.)
+// vienen de src/lib/risk/dateHelpers. La fecha global llega via useAppStore.
 
+/** Default para entry_date en los modales: ayer (ultimo dia habil). */
 function defaultDate(): string {
   const d = new Date();
   d.setDate(d.getDate() - 1);
   return lastBusinessDay(d).toISOString().slice(0, 10);
-}
-
-const MONTH_NAMES = [
-  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
-  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
-];
-
-/** Get the last day of a given month as YYYY-MM-DD */
-function lastDayOfMonth(year: number, month: number): string {
-  const d = new Date(year, month + 1, 0); // day 0 of next month = last day of this month
-  return lastBusinessDay(d).toISOString().slice(0, 10);
-}
-
-/** Format month key like "2026-01" */
-function monthKey(year: number, month: number): string {
-  return `${year}-${String(month + 1).padStart(2, '0')}`;
-}
-
-/** Current month/year */
-function currentMonth(): { year: number; month: number } {
-  const now = new Date();
-  return { year: now.getFullYear(), month: now.getMonth() };
 }
 
 
@@ -909,7 +883,12 @@ function RiskManagement() {
   const [usdcopLoading, setUsdcopLoading] = useState(false);
   const [usdcopDays, setUsdcopDays] = useState(30);
   const [usdcopSigma, setUsdcopSigma] = useState(2.0);
-  const [filterDate, setFilterDate] = useState(defaultDate());
+
+  // Fecha global del modulo de Riesgos. Viene del selector en CoreLayout
+  // (persistido en localStorage). Todas las pestañas de esta pagina y todas
+  // las paginas del modulo se sincronizan con esta unica fecha.
+  // Si el usuario quiere cambiar la fecha, lo hace desde el selector global.
+  const filterDate = useAppStore((s) => s.globalEvaluationDate);
 
   // OTC store handles — used by Benchmark USD row auto-fill
   const otcSummary = useAppStore((s) => s.summary) as { total_npv_cop: number; total_npv_usd: number } | undefined;
@@ -925,7 +904,13 @@ function RiskManagement() {
 
   // Benchmark state
   const [assets, setAssets] = useState<string[]>(dynamicAssets);
-  const [benchmarkMonth, setBenchmarkMonth] = useState(currentMonth());
+
+  // benchmarkMonth derivado de filterDate (global). Single source of truth.
+  // Antes: useState local que se desincronizaba con futuresMonth y con loans.
+  const benchmarkMonth = React.useMemo(() => {
+    const d = new Date(`${filterDate}T12:00:00Z`);
+    return { year: d.getUTCFullYear(), month: d.getUTCMonth() };
+  }, [filterDate]);
   const [benchmarkRows, setBenchmarkRows] = useState<BenchmarkRow[]>(emptyBenchmarkRows());
   const [benchmarkFactors, setBenchmarkFactors] = useState<BenchmarkFactorsResponse | null>(null);
   const [benchmarkLoading, setBenchmarkLoading] = useState(false);
@@ -976,7 +961,9 @@ function RiskManagement() {
   const [futuresShowClosed, setFuturesShowClosed] = useState(false);
   const [futuresShowAddForm, setFuturesShowAddForm] = useState(false);
   const [expandedSpreads, setExpandedSpreads] = useState<Set<string>>(new Set());
-  const [futuresMonth, setFuturesMonth] = useState(currentMonth());
+  // futuresMonth = benchmarkMonth (ya derivado de filterDate global).
+  // Antes existia una sync useEffect unidireccional que causaba bugs.
+  const futuresMonth = benchmarkMonth;
   const [newPosition, setNewPosition] = useState<NewFuturesPosition>({
     asset: 'MAIZ', contract: '', direction: 'SHORT', nominal: 1, entry_price: 0, entry_date: defaultDate(),
   });
@@ -1011,8 +998,10 @@ function RiskManagement() {
     }
   }, [filterDate, confidenceLevel, companyConfig]);
 
-  const benchmarkDateStr = lastDayOfMonth(benchmarkMonth.year, benchmarkMonth.month);
-  const benchmarkMonthKey = monthKey(benchmarkMonth.year, benchmarkMonth.month);
+  // filterDate ya es ISO "YYYY-MM-DD" (ultimo dia habil del mes en modo Mes,
+  // o dia especifico en modo Dia). Derivamos las cadenas auxiliares.
+  const benchmarkDateStr = filterDate;
+  const benchmarkMonthKey = filterDate.slice(0, 7);  // "YYYY-MM"
 
   const handleFetchBenchmarkFactors = useCallback(async () => {
     setBenchmarkLoading(true);
@@ -1070,29 +1059,14 @@ function RiskManagement() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [benchmarkDateStr, benchmarkMonthKey, confidenceLevel, companyConfig, dynamicAssets]);
 
-  // Save current rows to cache when they change
-  const saveBenchmarkToCache = useCallback(() => {
+  // Save current rows to cache when they change (auto, no manual trigger)
+  useEffect(() => {
     setMonthCache((prev) => ({ ...prev, [benchmarkMonthKey]: benchmarkRows }));
   }, [benchmarkMonthKey, benchmarkRows]);
 
-  // Navigate months
-  const goToPrevMonth = () => {
-    saveBenchmarkToCache();
-    setBenchmarkMonth((prev) => {
-      if (prev.month === 0) return { year: prev.year - 1, month: 11 };
-      return { year: prev.year, month: prev.month - 1 };
-    });
-    setBenchmarkFactors(null); // trigger reload
-  };
-
-  const goToNextMonth = () => {
-    saveBenchmarkToCache();
-    setBenchmarkMonth((prev) => {
-      if (prev.month === 11) return { year: prev.year + 1, month: 0 };
-      return { year: prev.year, month: prev.month + 1 };
-    });
-    setBenchmarkFactors(null); // trigger reload
-  };
+  // Navegacion de meses: ahora vive en el selector global (CoreLayout).
+  // Cuando el usuario cambia el mes alli, `filterDate` se actualiza y los
+  // useEffect de fetch reaccionan automaticamente.
 
   const handleFetchExposure = useCallback(async (overrideDate?: string) => {
     // Si la empresa no tiene parametros de proyeccion configurados, NO calculamos
@@ -1153,7 +1127,7 @@ function RiskManagement() {
   }, [companyConfig]);
 
   // ── Futures Portfolio handlers ──
-  const futuresFilterDate = lastDayOfMonth(futuresMonth.year, futuresMonth.month);
+  const futuresFilterDate = filterDate;
 
   const handleFetchFutures = useCallback(async () => {
     setFuturesLoading(true);
@@ -1261,14 +1235,16 @@ function RiskManagement() {
   const handleFetchUsdcop = useCallback(async () => {
     setUsdcopLoading(true);
     try {
-      const data = await fetchUsdCopCalculator();
+      // Anclar al selector global para que la TRM y la vol sean del mismo
+      // dia que el resto del modulo (Resumen, Benchmark, OTC).
+      const data = await fetchUsdCopCalculator(filterDate);
       setUsdcopData(data);
     } catch (e: unknown) {
       toast.error((e as Error)?.message || 'Error cargando calculadora USDCOP');
     } finally {
       setUsdcopLoading(false);
     }
-  }, []);
+  }, [filterDate]);
 
   useEffect(() => {
     if (!companyConfig) return; // guard: esperar a que config cargue
@@ -1280,15 +1256,16 @@ function RiskManagement() {
     }
     if (activeTab === 'futures') handleFetchFutures();
     if (activeTab === 'coffee') handleFetchCoffeePrices();
-    if (activeTab === 'usdcop' && !usdcopData) handleFetchUsdcop();
+    // USDCOP: refetch al cambiar tab O al cambiar filterDate (asi sigue
+    // al selector global para que TRM/vol siempre sean del mismo dia).
+    if (activeTab === 'usdcop') handleFetchUsdcop();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab, futuresMonth, benchmarkDateStr, companyConfig]);
 
-  // Sync futuresMonth with benchmarkMonth (both views show the same period)
-  useEffect(() => {
-    setFuturesMonth(benchmarkMonth);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [benchmarkMonth]);
+  // NOTE: anteriormente habia un useEffect que sincronizaba futuresMonth con
+  // benchmarkMonth de forma unidireccional (bug: cambiar mes en Portafolio GR
+  // no actualizaba Benchmark). Ahora ambos derivan de la misma `filterDate`
+  // global, asi que la sincronizacion es automatica y bidireccional.
 
   // NOTA: anteriormente aqui habia un useEffect que tomaba el total del
   // Blotter Fijaciones Cafe y lo metia en la fila CAFE Exp. Natural del
@@ -1433,31 +1410,8 @@ function RiskManagement() {
         {activeTab === 'benchmark' && (
           <div id="pdf-benchmark">
             <Row className="mb-3 align-items-center">
-              <Col xs="auto" className="d-flex align-items-center gap-2">
-                <Button
-                  variant="outline-secondary"
-                  size="sm"
-                  onClick={goToPrevMonth}
-                  disabled={benchmarkLoading}
-                  style={{ padding: '4px 10px' }}
-                >
-                  <Icon icon={faChevronLeft} />
-                </Button>
-                <div className="text-center" style={{ minWidth: 160 }}>
-                  <strong style={{ fontSize: '1.1rem', color: '#7c3aed' }}>
-                    {MONTH_NAMES[benchmarkMonth.month]} {benchmarkMonth.year}
-                  </strong>
-                </div>
-                <Button
-                  variant="outline-secondary"
-                  size="sm"
-                  onClick={goToNextMonth}
-                  disabled={benchmarkLoading}
-                  style={{ padding: '4px 10px' }}
-                >
-                  <Icon icon={faChevronRight} />
-                </Button>
-              </Col>
+              {/* El selector de mes vive en CoreLayout (barra superior).
+                  Aqui solo dejamos los controles especificos del Benchmark. */}
               <Col xs="auto">
                 <Button
                   variant="primary"
@@ -1651,17 +1605,6 @@ function RiskManagement() {
                     ))}
                     <option value="TODOS">Todos</option>
                   </Form.Select>
-                </Form.Group>
-              </Col>
-              <Col xs="auto">
-                <Form.Group>
-                  <Form.Label className="small text-muted">Fecha filtro</Form.Label>
-                  <Form.Control
-                    type="date"
-                    size="sm"
-                    value={filterDate}
-                    onChange={(e) => setFilterDate(e.target.value)}
-                  />
                 </Form.Group>
               </Col>
               <Col xs="auto">
@@ -1904,19 +1847,8 @@ function RiskManagement() {
           return (
             <>
               <Row className="mb-3 align-items-center">
+                {/* Fecha global vive en CoreLayout. */}
                 <Col xs="auto">
-                  <Form.Group>
-                    <Form.Label className="small text-muted mb-0">Fecha precios</Form.Label>
-                    <Form.Control
-                      type="date"
-                      size="sm"
-                      value={filterDate}
-                      onChange={(e) => setFilterDate(e.target.value)}
-                    />
-                  </Form.Group>
-                </Col>
-                <Col xs="auto">
-                  <Form.Label className="small text-muted mb-0">&nbsp;</Form.Label>
                   <div>
                     <Button variant="primary" size="sm" onClick={handleFetchExposure} disabled={exposureLoading}>
                       <Icon icon={faSyncAlt} spin={exposureLoading} className="me-1" />
@@ -2592,15 +2524,7 @@ function RiskManagement() {
           return (
             <div id="pdf-matrices">
               <Row className="align-items-end mb-3 g-2">
-                <Col md={3}>
-                  <Form.Label className="small mb-1">Fecha de referencia</Form.Label>
-                  <Form.Control
-                    type="date"
-                    size="sm"
-                    value={filterDate}
-                    onChange={(e) => setFilterDate(e.target.value)}
-                  />
-                </Col>
+                {/* Fecha global vive en CoreLayout. */}
                 <Col md="auto">
                   <Button
                     size="sm"
@@ -2684,26 +2608,10 @@ function RiskManagement() {
         {/* ── Portafolio GR (Futures) Tab ── */}
         {activeTab === 'futures' && (
           <div id="futures-tab">
-            {/* Month selector + controls */}
+            {/* El selector de mes vive en CoreLayout (barra superior global). */}
             <div className="d-flex align-items-center gap-2 mb-3 flex-wrap">
-              <button type="button" className="btn btn-sm btn-outline-secondary" onClick={() => {
-                const prev = futuresMonth.month === 0 ? { year: futuresMonth.year - 1, month: 11 } : { year: futuresMonth.year, month: futuresMonth.month - 1 };
-                setFuturesMonth(prev);
-              }}>
-                <Icon icon={faChevronLeft} />
-              </button>
-              <strong style={{ minWidth: 140, textAlign: 'center' }}>
-                {MONTH_NAMES[futuresMonth.month]} {futuresMonth.year}
-              </strong>
-              <button type="button" className="btn btn-sm btn-outline-secondary" onClick={() => {
-                const next = futuresMonth.month === 11 ? { year: futuresMonth.year + 1, month: 0 } : { year: futuresMonth.year, month: futuresMonth.month + 1 };
-                setFuturesMonth(next);
-              }}>
-                <Icon icon={faChevronRight} />
-              </button>
-
               <Button
-                className="btn-sm ms-3"
+                className="btn-sm"
                 onClick={handleFetchFutures}
                 disabled={futuresLoading}
               >

--- a/src/pages/risk-resumen/index.tsx
+++ b/src/pages/risk-resumen/index.tsx
@@ -8,8 +8,6 @@ import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import {
   faShieldAlt,
   faSyncAlt,
-  faChevronLeft,
-  faChevronRight,
   faChartPie,
   faBriefcase,
   faDollarSign,
@@ -34,29 +32,10 @@ import type { RiskCompanyConfig } from 'src/lib/risk/companyConfig';
 
 const PAGE_TITLE = 'Resumen — Gestión de Riesgos';
 
-const MONTH_NAMES = [
-  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
-  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
-];
-
 const DEFAULT_ASSETS = ['MAIZ', 'AZUCAR', 'CACAO', 'USD'];
 
-function lastBusinessDay(d: Date): Date {
-  const day = d.getDay();
-  if (day === 0) d.setDate(d.getDate() - 2);
-  else if (day === 6) d.setDate(d.getDate() - 1);
-  return d;
-}
-
-function lastDayOfMonth(year: number, month: number): string {
-  const d = new Date(year, month + 1, 0);
-  return lastBusinessDay(d).toISOString().slice(0, 10);
-}
-
-function currentMonth(): { year: number; month: number } {
-  const now = new Date();
-  return { year: now.getFullYear(), month: now.getMonth() };
-}
+// Helpers de fecha viven en src/lib/risk/dateHelpers. La fecha global
+// llega via useAppStore (selector global en CoreLayout).
 
 function fmtCompact(v: number | null | undefined): string {
   if (v == null) return '—';
@@ -223,25 +202,10 @@ function RiskResumenPage() {
     [companyConfig],
   );
 
-  // Month selector — same pattern as Benchmark
-  const [resumenMonth, setResumenMonth] = useState(currentMonth());
-  const filterDate = useMemo(
-    () => lastDayOfMonth(resumenMonth.year, resumenMonth.month),
-    [resumenMonth],
-  );
-
-  const goToPrevMonth = () => {
-    setResumenMonth((prev) => {
-      if (prev.month === 0) return { year: prev.year - 1, month: 11 };
-      return { year: prev.year, month: prev.month - 1 };
-    });
-  };
-  const goToNextMonth = () => {
-    setResumenMonth((prev) => {
-      if (prev.month === 11) return { year: prev.year + 1, month: 0 };
-      return { year: prev.year, month: prev.month + 1 };
-    });
-  };
+  // Fecha global del modulo de Riesgos. Viene del selector en CoreLayout
+  // (Zustand, persistido en localStorage). Esta pagina ya no tiene
+  // selector propio — todas las paginas de Riesgos comparten la misma fecha.
+  const filterDate = useAppStore((s) => s.globalEvaluationDate);
 
   // Resumen state
   const [resumenData, setResumenData] = useState<ResumenData | null>(null);
@@ -382,37 +346,9 @@ function RiskResumenPage() {
               </Button>
             </div>
 
-            {/* Month selector */}
-            <Row className="mb-3 align-items-center">
-              <Col xs="auto" className="d-flex align-items-center gap-2">
-                <Button
-                  variant="outline-secondary"
-                  size="sm"
-                  onClick={goToPrevMonth}
-                  disabled={loading || tradingLoading}
-                  style={{ padding: '4px 10px' }}
-                >
-                  <Icon icon={faChevronLeft} />
-                </Button>
-                <div className="text-center" style={{ minWidth: 160 }}>
-                  <strong style={{ fontSize: '1.1rem', color: '#7c3aed' }}>
-                    {MONTH_NAMES[resumenMonth.month]} {resumenMonth.year}
-                  </strong>
-                </div>
-                <Button
-                  variant="outline-secondary"
-                  size="sm"
-                  onClick={goToNextMonth}
-                  disabled={loading || tradingLoading}
-                  style={{ padding: '4px 10px' }}
-                >
-                  <Icon icon={faChevronRight} />
-                </Button>
-                <span className="text-muted ms-3" style={{ fontSize: '0.8rem' }}>
-                  Cierre: {filterDate}
-                </span>
-              </Col>
-            </Row>
+            {/* El selector de mes vive en CoreLayout (barra superior global).
+                Esta pagina lee `filterDate` del store y se actualiza
+                automaticamente. */}
 
             {(loading || tradingLoading) && <p className="text-muted">Cargando resumen...</p>}
 

--- a/src/store/user/index.ts
+++ b/src/store/user/index.ts
@@ -7,6 +7,7 @@ import {
   UserRole,
   ROLE_HIERARCHY,
 } from 'src/types/user';
+import { defaultEvaluationDate, formatISO } from 'src/lib/risk/dateHelpers';
 import {
   fetchUserProfile,
   listCompanyUsers,
@@ -64,6 +65,62 @@ export interface UserSlice {
   setSelectedCompanyId: (id: string | undefined) => void;
   /** Returns selectedCompanyId if set, otherwise userProfile.company_id */
   activeCompanyId: () => string | undefined;
+
+  // Global evaluation date (for risk module). Persisted in localStorage.
+  // Format: ISO string "YYYY-MM-DD". El consumidor SIEMPRE recibe un string ISO.
+  // El `mode` es solo UI: 'month' usa el ultimo dia habil del mes, 'day' usa
+  // el dia tal cual seleccionado.
+  globalEvaluationDate: string;
+  dateSelectorMode: 'month' | 'day';
+  setGlobalEvaluationDate: (date: string) => void;
+  setDateSelectorMode: (mode: 'month' | 'day') => void;
+  /** Returns globalEvaluationDate (always defined; falls back to default). */
+  activeEvaluationDate: () => string;
+}
+
+// localStorage keys (versioned para futuras migraciones de schema)
+const LS_DATE_KEY = 'xerenity.globalEvaluationDate.v1';
+const LS_MODE_KEY = 'xerenity.dateSelectorMode.v1';
+
+function loadDateFromStorage(): string {
+  if (typeof window === 'undefined') return formatISO(defaultEvaluationDate());
+  try {
+    const stored = window.localStorage.getItem(LS_DATE_KEY);
+    // Validacion basica: debe ser YYYY-MM-DD
+    if (stored && /^\d{4}-\d{2}-\d{2}$/.test(stored)) return stored;
+  } catch {
+    // localStorage puede fallar en modo privado / Safari ITP
+  }
+  return formatISO(defaultEvaluationDate());
+}
+
+function loadModeFromStorage(): 'month' | 'day' {
+  if (typeof window === 'undefined') return 'month';
+  try {
+    const stored = window.localStorage.getItem(LS_MODE_KEY);
+    if (stored === 'month' || stored === 'day') return stored;
+  } catch {
+    // ignore
+  }
+  return 'month';
+}
+
+function saveDateToStorage(date: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LS_DATE_KEY, date);
+  } catch {
+    // ignore (localStorage full, private mode, etc.)
+  }
+}
+
+function saveModeToStorage(mode: 'month' | 'day'): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LS_MODE_KEY, mode);
+  } catch {
+    // ignore
+  }
 }
 
 const initialUserState = {
@@ -271,6 +328,18 @@ const createUserSlice: StateCreator<UserSlice> = (set, get) => ({
     const { selectedCompanyId: selected, userProfile } = get();
     return selected || userProfile?.company_id || undefined;
   },
+
+  globalEvaluationDate: loadDateFromStorage(),
+  dateSelectorMode: loadModeFromStorage(),
+  setGlobalEvaluationDate: (date) => {
+    saveDateToStorage(date);
+    set({ globalEvaluationDate: date });
+  },
+  setDateSelectorMode: (mode) => {
+    saveModeToStorage(mode);
+    set({ dateSelectorMode: mode });
+  },
+  activeEvaluationDate: () => get().globalEvaluationDate,
 });
 
 export default createUserSlice;


### PR DESCRIPTION
Closes #391

## Summary
Consolida 6 selectores de fecha dispersos del modulo de Riesgos (\`/risk-resumen\`, \`/risk-management\` con 2 selectores de mes + 3 inputs date, \`/portfolio\`) en una sola fecha global que vive en la barra superior del \`CoreLayout\`, persistida en \`localStorage\`. UI estilo Bloomberg Terminal con toggle Mes/Dia.

Migra ademas todas las lecturas de TRM/FX del modulo a \`xerenity.market_marks.fx_spot\` (misma fuente unica de verdad que OTC pricing) — antes leian de \`risk_prices\` alimentado por BanRep TRM.

## Archivos nuevos
- \`src/lib/risk/dateHelpers.ts\` — helpers inmutables centralizados (\`lastBusinessDay\`, \`lastBusinessDayOfMonth\`, \`MONTH_NAMES\`, \`parseISOAsNoon\`, etc.)
- \`src/lib/risk/marketMarks.ts\` — lecturas directas a \`market_marks\` via Supabase (\`fetchFxSpot\`, \`fetchFxSpotSeries\`)
- \`src/components/risk/GlobalDateSelector.tsx\` — UI con toggle Mes/Dia

## Bugs cerrados
- **#1** \`lastBusinessDay\` mutaba su argumento → ahora inmutable
- **#2** Stale closure en CRUD Portafolio GR (\`filterDate\` local vs \`futuresFilterDate\`) → unificado en el store global
- **#4** \`lastBusinessDayOfPrevMonth\` duplicado en 2 archivos → consolidado
- **Tug-of-war** Benchmark<->Futures month sync → ambos derivan del global
- **Tug-of-war** \`curveStatus\` reescribiendo \`markFecha\` en OTC → removido
- **Divergencia FX** Risk (Banrep) vs OTC (set-icap EOD) → unificada en market_marks

## Companion PR
Backend (pysdk) archiva los endpoints Django ahora dead: avelezX/xerenity-backend#131

## Test plan
- [ ] Login y navegar a \`/risk-resumen\` → selector global visible arriba, datos cargan al mes/dia seleccionado
- [ ] Cambiar mes en selector → todas las paginas Risk (Resumen, Management, OTC) se actualizan
- [ ] F5 (recargar) → la fecha se conserva (localStorage)
- [ ] Toggle Mes/Dia → cambia entre chevrons y date input
- [ ] Calculadora USDCOP muestra TRM de market_marks (~3,784 hoy) no la TRM Banrep
- [ ] Portafolio OTC: cambiar fecha global → reprice automatico con la nueva fecha