### PR TITLE
feat(risk): multi-lote de cafe (LoteSelector + filtrado de blotters)

### DIFF
--- a/src/components/risk/BlotterCafe.tsx
+++ b/src/components/risk/BlotterCafe.tsx
@@ -22,6 +22,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Table, Form, Button, Spinner } from 'react-bootstrap';
 import { toast } from 'react-toastify';
+import useAppStore from 'src/store';
 
 import {
   fetchCafeFijaciones,
@@ -97,9 +98,10 @@ const fmtSignedUsd = (v: number): string => {
   return `${v > 0 ? '+$' : '−$'}${abs}`;
 };
 
-function emptyRow(companyId: string): Omit<Row, 'id' | 'created_at' | 'updated_at'> {
+function emptyRow(companyId: string, loteId: string): Omit<Row, 'id' | 'created_at' | 'updated_at'> {
   return {
     company_id: companyId,
+    lote_id: loteId,
     sacos_fijados: 0,
     kg: 0,
     fijacion_ny: 0,
@@ -111,6 +113,7 @@ function emptyRow(companyId: string): Omit<Row, 'id' | 'created_at' | 'updated_a
 }
 
 export default function BlotterCafe({ companyId, precioKcCents, precioKcDate }: Props) {
+  const selectedLoteId = useAppStore((s) => s.selectedLoteId);
   const [rows, setRows] = useState<Row[]>([]);
   const [factor, setFactor] = useState<number>(1.5432);
   const [lbsPorContrato, setLbsPorContrato] = useState<number>(37500);
@@ -140,11 +143,15 @@ export default function BlotterCafe({ companyId, precioKcCents, precioKcDate }: 
   // compartirlo aqui en el calculo de # contratos).
   useEffect(() => {
     if (!companyId) return;
+    if (!selectedLoteId) {
+      setRows([]);  // sin lote seleccionado: blotter vacio
+      return;
+    }
     setLoading(true);
     (async () => {
       try {
         const [fijaciones, fct, globals] = await Promise.all([
-          fetchCafeFijaciones(companyId),
+          fetchCafeFijaciones(companyId, selectedLoteId),
           fetchCafeFactorConversion(companyId),
           fetchCafeCompraGlobals(companyId).catch(() => null),
         ]);
@@ -157,7 +164,7 @@ export default function BlotterCafe({ companyId, precioKcCents, precioKcDate }: 
         setLoading(false);
       }
     })();
-  }, [companyId]);
+  }, [companyId, selectedLoteId]);
 
   // Calc derived per row (soporta COP y USD)
   //
@@ -292,13 +299,17 @@ export default function BlotterCafe({ companyId, precioKcCents, precioKcDate }: 
 
   // Add new row
   const handleAdd = useCallback(async () => {
+    if (!selectedLoteId) {
+      toast.error('Selecciona o crea un lote antes de agregar una fijacion');
+      return;
+    }
     try {
-      const newRow = await insertCafeFijacion(emptyRow(companyId));
+      const newRow = await insertCafeFijacion(emptyRow(companyId, selectedLoteId));
       setRows((prev) => [...prev, { ...newRow, saveState: 'idle' }]);
     } catch (e) {
       toast.error((e as Error)?.message || 'Error agregando fila');
     }
-  }, [companyId]);
+  }, [companyId, selectedLoteId]);
 
   // Delete row
   const handleDelete = useCallback(async (id: string) => {

--- a/src/components/risk/BlotterCompraCafe.tsx
+++ b/src/components/risk/BlotterCompraCafe.tsx
@@ -25,6 +25,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Table, Form, Button, Spinner } from 'react-bootstrap';
 import { toast } from 'react-toastify';
+import useAppStore from 'src/store';
 
 import {
   fetchCafeCompras,
@@ -115,9 +116,10 @@ function isoWeek(dateStr: string): number {
   return 1 + Math.ceil((firstThursday - target.valueOf()) / 604800000);
 }
 
-function emptyRow(companyId: string): Omit<Row, 'id' | 'created_at' | 'updated_at'> {
+function emptyRow(companyId: string, loteId: string): Omit<Row, 'id' | 'created_at' | 'updated_at'> {
   return {
     company_id: companyId,
+    lote_id: loteId,
     fecha_compra: new Date().toISOString().slice(0, 10),
     total_kg: 0,
     valor_compra_at: 0,
@@ -126,6 +128,7 @@ function emptyRow(companyId: string): Omit<Row, 'id' | 'created_at' | 'updated_a
 }
 
 export default function BlotterCompraCafe({ companyId, precioKcCents, precioKcDate }: Props) {
+  const selectedLoteId = useAppStore((s) => s.selectedLoteId);
   const [rows, setRows] = useState<Row[]>([]);
   const [kgPerAt, setKgPerAt] = useState<number>(60);
   const [lbsPorContrato, setLbsPorContrato] = useState<number>(37500);
@@ -153,17 +156,21 @@ export default function BlotterCompraCafe({ companyId, precioKcCents, precioKcDa
     [precioKcCents, precioKcDate],
   );
 
-  // Initial load (compras + globals). Las dos cargas son INDEPENDIENTES:
-  // si falla la de globals, la de compras debe seguir mostrandose.
-  // Antes usabamos Promise.all -> un error en cualquiera tumbaba ambas.
+  // Initial load (compras filtradas por lote + globals).
+  // Re-fetch automatico cuando cambia el lote seleccionado.
+  // Si no hay lote, no fetcheamos — el usuario debe crear/seleccionar uno.
   useEffect(() => {
     if (!companyId) return;
+    if (!selectedLoteId) {
+      setRows([]);  // sin lote seleccionado: blotter vacio
+      return;
+    }
     setLoading(true);
     let comprasErr: string | null = null;
     let globalsErr: string | null = null;
     (async () => {
       try {
-        const compras = await fetchCafeCompras(companyId);
+        const compras = await fetchCafeCompras(companyId, selectedLoteId);
         setRows(compras);
       } catch (e) {
         comprasErr = (e as Error)?.message || 'Error cargando compras';
@@ -179,7 +186,7 @@ export default function BlotterCompraCafe({ companyId, precioKcCents, precioKcDa
       if (globalsErr) toast.warning(`Globals: ${globalsErr} (usando defaults)`);
       setLoading(false);
     })();
-  }, [companyId]);
+  }, [companyId, selectedLoteId]);
 
   // Calc derived per row — factor_humedo ahora es per-fila
   const computed = useMemo(() => rows.map((r) => {
@@ -265,13 +272,17 @@ export default function BlotterCompraCafe({ companyId, precioKcCents, precioKcDa
   }, [commitRow]);
 
   const handleAdd = useCallback(async () => {
+    if (!selectedLoteId) {
+      toast.error('Selecciona o crea un lote antes de agregar una compra');
+      return;
+    }
     try {
-      const newRow = await insertCafeCompra(emptyRow(companyId));
+      const newRow = await insertCafeCompra(emptyRow(companyId, selectedLoteId));
       setRows((prev) => [...prev, { ...newRow, saveState: 'idle' }]);
     } catch (e) {
       toast.error((e as Error)?.message || 'Error agregando fila');
     }
-  }, [companyId]);
+  }, [companyId, selectedLoteId]);
 
   const handleDelete = useCallback(async (id: string) => {
     // eslint-disable-next-line no-alert

--- a/src/components/risk/LoteSelector.tsx
+++ b/src/components/risk/LoteSelector.tsx
@@ -1,0 +1,273 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+/**
+ * Selector de Lote de Cafe.
+ *
+ * Vive dentro del tab Benchmark de /risk-management cuando la empresa
+ * tiene CAFE en sus commodities. Permite cambiar entre lotes y crear
+ * lotes nuevos. El lote seleccionado se persiste en localStorage via
+ * useAppStore.selectedLoteId.
+ *
+ * UI: dropdown nativo + boton "+ Nuevo lote" que abre modal.
+ * Modal de creacion: solo "nombre" es obligatorio.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { Modal, Form, Button } from 'react-bootstrap';
+import { toast } from 'react-toastify';
+import useAppStore from 'src/store';
+import {
+  fetchCafeLotes,
+  insertCafeLote,
+  CafeLoteRow,
+} from 'src/lib/risk/supabaseRisk';
+
+interface Props {
+  companyId: string;
+}
+
+export default function LoteSelector({ companyId }: Props) {
+  const [lotes, setLotes] = useState<CafeLoteRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [creating, setCreating] = useState(false);
+
+  // Form del modal
+  const [nombre, setNombre] = useState('');
+  const [descripcion, setDescripcion] = useState('');
+  const [origen, setOrigen] = useState('');
+  const [fechaApertura, setFechaApertura] = useState<string>(
+    new Date().toISOString().slice(0, 10),
+  );
+
+  const selectedLoteId = useAppStore((s) => s.selectedLoteId);
+  const setSelectedLoteId = useAppStore((s) => s.setSelectedLoteId);
+
+  // Carga de lotes al montar / cambiar empresa
+  const loadLotes = useCallback(async () => {
+    if (!companyId) return;
+    setLoading(true);
+    try {
+      const data = await fetchCafeLotes(companyId);
+      setLotes(data);
+      // Si no hay lote seleccionado o el seleccionado no esta en la lista,
+      // seleccionar el primero disponible.
+      if (data.length > 0 && (!selectedLoteId || !data.some((l) => l.id === selectedLoteId))) {
+        setSelectedLoteId(data[0].id);
+      } else if (data.length === 0 && selectedLoteId) {
+        // La empresa no tiene lotes — limpiar la seleccion.
+        setSelectedLoteId(undefined);
+      }
+    } catch (e) {
+      toast.error((e as Error)?.message || 'Error cargando lotes');
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [companyId]);
+
+  useEffect(() => {
+    loadLotes();
+  }, [loadLotes]);
+
+  const openModal = () => {
+    setNombre(`Lote ${lotes.length + 1}`); // sugerencia: siguiente numero
+    setDescripcion('');
+    setOrigen('');
+    setFechaApertura(new Date().toISOString().slice(0, 10));
+    setShowModal(true);
+  };
+
+  const handleCreate = async () => {
+    const nombreTrim = nombre.trim();
+    if (!nombreTrim) {
+      toast.error('El nombre del lote es obligatorio');
+      return;
+    }
+    setCreating(true);
+    try {
+      const newLote = await insertCafeLote({
+        company_id: companyId,
+        nombre: nombreTrim,
+        descripcion: descripcion.trim() || null,
+        origen: origen.trim() || null,
+        fecha_apertura: fechaApertura,
+      });
+      setLotes((prev) => [...prev, newLote].sort(
+        (a, b) => (a.fecha_apertura < b.fecha_apertura ? -1 : 1),
+      ));
+      setSelectedLoteId(newLote.id);
+      setShowModal(false);
+      toast.success(`Lote "${nombreTrim}" creado`);
+    } catch (e) {
+      const msg = (e as Error)?.message || 'Error creando lote';
+      // Caso comun: UNIQUE constraint violation (nombre duplicado per empresa)
+      if (msg.includes('cafe_lotes_company_id_nombre_key') || msg.includes('duplicate')) {
+        toast.error(`Ya existe un lote con el nombre "${nombreTrim}" para esta empresa`);
+      } else {
+        toast.error(msg);
+      }
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="lote-selector-root">
+      <div className="lote-selector-bar">
+        <span className="lote-selector-label">LOTE</span>
+        <select
+          className="lote-selector-select"
+          value={selectedLoteId ?? ''}
+          onChange={(e) => setSelectedLoteId(e.target.value || undefined)}
+          disabled={loading || lotes.length === 0}
+        >
+          {lotes.length === 0 && <option value="">— sin lotes —</option>}
+          {lotes.map((l) => (
+            <option key={l.id} value={l.id}>
+              {l.nombre}
+              {l.origen ? ` · ${l.origen}` : ''}
+              {' · '}
+              {l.fecha_apertura}
+            </option>
+          ))}
+        </select>
+
+        <button type="button" className="lote-selector-new-btn" onClick={openModal}>
+          + Nuevo lote
+        </button>
+      </div>
+
+      {/* Modal de creacion */}
+      <Modal show={showModal} onHide={() => setShowModal(false)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title style={{ fontSize: '1rem', fontWeight: 600 }}>Nuevo Lote de Café</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form.Group className="mb-3">
+            <Form.Label className="small fw-semibold">Nombre <span style={{ color: '#b91c1c' }}>*</span></Form.Label>
+            <Form.Control
+              type="text"
+              value={nombre}
+              onChange={(e) => setNombre(e.target.value)}
+              placeholder="e.g., Lote 2 - Cosecha Q2 2026"
+              autoFocus
+            />
+            <Form.Text className="text-muted small">
+              Debe ser único dentro de esta empresa.
+            </Form.Text>
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label className="small fw-semibold">Descripción <span className="text-muted small">(opcional)</span></Form.Label>
+            <Form.Control
+              as="textarea"
+              rows={2}
+              value={descripcion}
+              onChange={(e) => setDescripcion(e.target.value)}
+              placeholder="Notas operativas, cliente, calidad, etc."
+            />
+          </Form.Group>
+
+          <div className="row g-3">
+            <div className="col-md-6">
+              <Form.Group>
+                <Form.Label className="small fw-semibold">Origen <span className="text-muted small">(opcional)</span></Form.Label>
+                <Form.Control
+                  type="text"
+                  value={origen}
+                  onChange={(e) => setOrigen(e.target.value)}
+                  placeholder="e.g., Anserma, Huila"
+                />
+              </Form.Group>
+            </div>
+            <div className="col-md-6">
+              <Form.Group>
+                <Form.Label className="small fw-semibold">Fecha apertura</Form.Label>
+                <Form.Control
+                  type="date"
+                  value={fechaApertura}
+                  onChange={(e) => setFechaApertura(e.target.value)}
+                />
+              </Form.Group>
+            </div>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" size="sm" onClick={() => setShowModal(false)} disabled={creating}>
+            Cancelar
+          </Button>
+          <Button variant="primary" size="sm" onClick={handleCreate} disabled={creating || !nombre.trim()}>
+            {creating ? 'Creando...' : 'Crear lote'}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      <style jsx>{`
+        .lote-selector-root {
+          margin: 8px 0 12px;
+        }
+        .lote-selector-bar {
+          display: inline-flex;
+          align-items: stretch;
+          gap: 0;
+          background: #ffffff;
+          border: 1px solid #cbd5e1;
+        }
+        .lote-selector-label {
+          display: inline-flex;
+          align-items: center;
+          padding: 0 10px;
+          font-size: 10px;
+          font-weight: 600;
+          letter-spacing: 0.12em;
+          color: #64748b;
+          background: #f8fafc;
+          border-right: 1px solid #e2e8f0;
+          font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+        }
+        .lote-selector-select {
+          font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+          font-size: 12px;
+          font-weight: 500;
+          letter-spacing: 0.02em;
+          color: #0f172a;
+          background: #ffffff;
+          padding: 5px 28px 5px 10px;
+          min-width: 280px;
+          border: none;
+          outline: none;
+          appearance: none;
+          background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+          background-repeat: no-repeat;
+          background-position: right 8px center;
+          cursor: pointer;
+        }
+        .lote-selector-select:hover:not(:disabled) {
+          background-color: #f8fafc;
+        }
+        .lote-selector-select:disabled {
+          color: #94a3b8;
+          cursor: not-allowed;
+        }
+        .lote-selector-new-btn {
+          font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+          font-size: 11px;
+          font-weight: 600;
+          letter-spacing: 0.04em;
+          color: #1e293b;
+          background: #f8fafc;
+          border: none;
+          border-left: 1px solid #e2e8f0;
+          padding: 0 14px;
+          cursor: pointer;
+          transition: background-color 80ms ease, color 80ms ease;
+          white-space: nowrap;
+        }
+        .lote-selector-new-btn:hover {
+          background: #9a3412;
+          color: #ffffff;
+        }
+      `}
+      </style>
+    </div>
+  );
+}

--- a/src/lib/risk/supabaseRisk.ts
+++ b/src/lib/risk/supabaseRisk.ts
@@ -383,6 +383,7 @@ export async function fetchCoffeePrices(
 export interface CafeFijacionRow {
   id: string;
   company_id: string;
+  lote_id: string;          // FK a cafe_lotes — NOT NULL desde mayo 2026
   sacos_fijados: number;
   kg: number;
   fijacion_ny: number;     // cents/lb del NY base
@@ -394,13 +395,22 @@ export interface CafeFijacionRow {
   updated_at?: string;
 }
 
-export async function fetchCafeFijaciones(companyId: string): Promise<CafeFijacionRow[]> {
-  const { data, error } = await supabase
+/**
+ * Lee fijaciones de cafe.
+ * - Si se pasa `loteId`: filtra solo las de ese lote.
+ * - Si no: retorna TODAS las de la empresa (util para Resumen Empresa).
+ */
+export async function fetchCafeFijaciones(
+  companyId: string,
+  loteId?: string,
+): Promise<CafeFijacionRow[]> {
+  let query = supabase
     .schema(SCHEMA)
     .from('cafe_fijaciones')
     .select('*')
-    .eq('company_id', companyId)
-    .order('fecha_fijacion', { ascending: true });
+    .eq('company_id', companyId);
+  if (loteId) query = query.eq('lote_id', loteId);
+  const { data, error } = await query.order('fecha_fijacion', { ascending: true });
   if (error) throw new Error(`Failed to fetch cafe_fijaciones: ${error.message}`);
   return (data ?? []) as CafeFijacionRow[];
 }
@@ -469,6 +479,7 @@ export async function updateCafeFactorConversion(
 export interface CafeCompraRow {
   id: string;
   company_id: string;
+  lote_id: string;               // FK a cafe_lotes — NOT NULL desde mayo 2026
   fecha_compra: string;          // YYYY-MM-DD
   total_kg: number;              // kg de cafe humedo comprado
   valor_compra_at: number;       // COP por @
@@ -477,13 +488,22 @@ export interface CafeCompraRow {
   updated_at?: string;
 }
 
-export async function fetchCafeCompras(companyId: string): Promise<CafeCompraRow[]> {
-  const { data, error } = await supabase
+/**
+ * Lee compras de cafe.
+ * - Si se pasa `loteId`: filtra solo las de ese lote.
+ * - Si no: retorna TODAS las de la empresa (util para Resumen Empresa).
+ */
+export async function fetchCafeCompras(
+  companyId: string,
+  loteId?: string,
+): Promise<CafeCompraRow[]> {
+  let query = supabase
     .schema(SCHEMA)
     .from('cafe_compras')
     .select('*')
-    .eq('company_id', companyId)
-    .order('fecha_compra', { ascending: true });
+    .eq('company_id', companyId);
+  if (loteId) query = query.eq('lote_id', loteId);
+  const { data, error } = await query.order('fecha_compra', { ascending: true });
   if (error) throw new Error(`Failed to fetch cafe_compras: ${error.message}`);
   return (data ?? []) as CafeCompraRow[];
 }
@@ -577,4 +597,64 @@ export async function fetchLatestCafePriceCents(): Promise<{ price: number; date
   const row = data?.[0];
   if (!row) return null;
   return { price: Number(row.price), date: String(row.date) };
+}
+
+// ── Cafe Lotes (agrupador de compras + fijaciones) ──
+
+export interface CafeLoteRow {
+  id: string;
+  company_id: string;
+  nombre: string;
+  descripcion: string | null;
+  origen: string | null;
+  fecha_apertura: string;   // YYYY-MM-DD
+  created_at?: string;
+  updated_at?: string;
+}
+
+export async function fetchCafeLotes(companyId: string): Promise<CafeLoteRow[]> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_lotes')
+    .select('*')
+    .eq('company_id', companyId)
+    .order('fecha_apertura', { ascending: true });
+  if (error) throw new Error(`Failed to fetch cafe_lotes: ${error.message}`);
+  return (data ?? []) as CafeLoteRow[];
+}
+
+export async function insertCafeLote(
+  row: Omit<CafeLoteRow, 'id' | 'created_at' | 'updated_at'>,
+): Promise<CafeLoteRow> {
+  const { data, error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_lotes')
+    .insert(row)
+    .select()
+    .single();
+  if (error) throw new Error(`Failed to insert cafe_lote: ${error.message}`);
+  return data as CafeLoteRow;
+}
+
+export async function updateCafeLote(
+  id: string,
+  updates: Partial<Omit<CafeLoteRow, 'id' | 'company_id' | 'created_at' | 'updated_at'>>,
+): Promise<void> {
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_lotes')
+    .update(updates)
+    .eq('id', id);
+  if (error) throw new Error(`Failed to update cafe_lote: ${error.message}`);
+}
+
+export async function deleteCafeLote(id: string): Promise<void> {
+  // El FK ON DELETE RESTRICT impide borrar lotes con compras/fijaciones.
+  // El error de Supabase se propaga al caller que debe mostrar mensaje claro.
+  const { error } = await supabase
+    .schema(SCHEMA)
+    .from('cafe_lotes')
+    .delete()
+    .eq('id', id);
+  if (error) throw new Error(`Failed to delete cafe_lote: ${error.message}`);
 }

--- a/src/pages/risk-management/index.tsx
+++ b/src/pages/risk-management/index.tsx
@@ -51,6 +51,7 @@ import { parseContractMaturity } from 'src/lib/risk/futuresCalculator';
 import { lastBusinessDay, MONTH_NAMES } from 'src/lib/risk/dateHelpers';
 import BlotterCafe from 'src/components/risk/BlotterCafe';
 import BlotterCompraCafe from 'src/components/risk/BlotterCompraCafe';
+import LoteSelector from 'src/components/risk/LoteSelector';
 
 const PAGE_TITLE = 'Gestión de Riesgos';
 
@@ -1569,12 +1570,12 @@ function RiskManagement() {
             </div>
 
             {/* Blotters Cafe — solo visibles si la empresa tiene CAFE.
-                Orden: Compras primero, despues Fijaciones (ventas).
-                Razon: el flujo logico es comprar -> hedgear -> fijar venta.
-                El precio KC para Exp USD viene de benchmarkFactors (mismo
-                dato que ya muestra la tabla Benchmark en columna Fin). */}
+                Arriba: LoteSelector (dropdown para elegir lote actual).
+                Despues: Blotters de compras y fijaciones (filtrados por lote en PR C).
+                El precio KC viene de benchmarkFactors. */}
             {hasCafe && selectedCompanyId && (
               <>
+                <LoteSelector companyId={selectedCompanyId} />
                 <BlotterCompraCafe
                   companyId={selectedCompanyId}
                   precioKcCents={benchmarkFactors?.factors?.CAFE?.price_end ?? null}

--- a/src/store/user/index.ts
+++ b/src/store/user/index.ts
@@ -76,11 +76,18 @@ export interface UserSlice {
   setDateSelectorMode: (mode: 'month' | 'day') => void;
   /** Returns globalEvaluationDate (always defined; falls back to default). */
   activeEvaluationDate: () => string;
+
+  // Lote seleccionado del modulo cafe. Persistido en localStorage.
+  // Es un UUID de xerenity.cafe_lotes. undefined = "no hay lote elegido"
+  // (la UI muestra primer lote disponible o pide crear uno).
+  selectedLoteId: string | undefined;
+  setSelectedLoteId: (id: string | undefined) => void;
 }
 
 // localStorage keys (versioned para futuras migraciones de schema)
 const LS_DATE_KEY = 'xerenity.globalEvaluationDate.v1';
 const LS_MODE_KEY = 'xerenity.dateSelectorMode.v1';
+const LS_LOTE_KEY = 'xerenity.selectedLoteId.v1';
 
 function loadDateFromStorage(): string {
   if (typeof window === 'undefined') return formatISO(defaultEvaluationDate());
@@ -118,6 +125,30 @@ function saveModeToStorage(mode: 'month' | 'day'): void {
   if (typeof window === 'undefined') return;
   try {
     window.localStorage.setItem(LS_MODE_KEY, mode);
+  } catch {
+    // ignore
+  }
+}
+
+function loadLoteFromStorage(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    const stored = window.localStorage.getItem(LS_LOTE_KEY);
+    // Validacion basica: debe ser UUID v4-like
+    if (stored && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(stored)) {
+      return stored;
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+function saveLoteToStorage(id: string | undefined): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (id) window.localStorage.setItem(LS_LOTE_KEY, id);
+    else window.localStorage.removeItem(LS_LOTE_KEY);
   } catch {
     // ignore
   }
@@ -340,6 +371,12 @@ const createUserSlice: StateCreator<UserSlice> = (set, get) => ({
     set({ dateSelectorMode: mode });
   },
   activeEvaluationDate: () => get().globalEvaluationDate,
+
+  selectedLoteId: loadLoteFromStorage(),
+  setSelectedLoteId: (id) => {
+    saveLoteToStorage(id);
+    set({ selectedLoteId: id });
+  },
 });
 
 export default createUserSlice;


### PR DESCRIPTION
Closes #395

## Summary
Implementacion frontend del modelo multi-lote de cafe. Companion del SQL en avelezX/xerenity-backend#135.

Cada lote es una unidad economica independiente (N compras + M fijaciones + P&L + hedge propios). Permite negociar Lote 2, 3, etc. sin perder datos de lotes previos.

## Cambios
- \`src/components/risk/LoteSelector.tsx\` (NUEVO): dropdown con todos los lotes de la empresa + modal 'Nuevo lote' (solo nombre obligatorio)
- \`src/store/user/index.ts\`: extiende UserSlice con \`selectedLoteId\` + persistencia \`localStorage\`
- \`src/lib/risk/supabaseRisk.ts\`: tipos \`CafeLoteRow\` + CRUD (\`fetchCafeLotes\`, \`insertCafeLote\`, \`updateCafeLote\`, \`deleteCafeLote\`). \`fetchCafeCompras\` y \`fetchCafeFijaciones\` ahora aceptan \`loteId\` opcional.
- \`BlotterCompraCafe.tsx\` y \`BlotterCafe.tsx\`: cada blotter lee \`selectedLoteId\` del store, re-fetch automatico al cambiar de lote, blotter vacio si no hay lote seleccionado.
- \`risk-management/index.tsx\`: integra \`<LoteSelector>\` arriba de los blotters cuando \`hasCafe\`.

## Test plan
- [ ] Tab Benchmark de \`/risk-management\` muestra el dropdown de lotes arriba de los blotters
- [ ] Click '+ Nuevo lote' abre modal con campos (nombre obligatorio)
- [ ] Crear lote -> aparece en dropdown, se selecciona automaticamente, blotters quedan vacios
- [ ] Cambiar de lote -> blotters re-fetch con las filas correspondientes
- [ ] F5 -> mantiene el lote seleccionado (localStorage)
- [ ] '+ Nueva compra/fijacion' sin lote seleccionado -> toast de error